### PR TITLE
Update CI/CD process for modules

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,18 +9,16 @@ on:
     paths:
       - "**/init/**"
       - "**/helm/**"
+      - "**/module.yaml"
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
   packages: write
 
 jobs:
-  build-images:
+  build-and-release:
     runs-on: ubuntu-latest
-    outputs:
-      images-built: ${{ steps.build.outputs.images-built }}
-      built-modules: ${{ steps.build.outputs.built-modules }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -30,23 +28,25 @@ jobs:
       - name: Install yq
         uses: mikefarah/yq@v4
 
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Login to GHCR
+      - name: Login to GHCR (Docker)
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Detect changes, build and push images
-        id: build
+      - name: Login to GHCR (Helm)
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io --username "${{ github.actor }}" --password-stdin
+
+      - name: Build images and release charts
         run: |
-          SHORT_SHA=$(git rev-parse --short HEAD)
           REPO_OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
-          UPDATED=false
-          BUILT_MODULES=""
 
           # Determine changed files
           if git rev-parse HEAD~1 >/dev/null 2>&1; then
@@ -55,169 +55,64 @@ jobs:
             CHANGED_FILES=$(git ls-files)
           fi
 
-          for dir in */; do
-            module="${dir%/}"
-
-            # Skip if no changes in this module's init/ directory (unless manually triggered)
-            if [ "${{ github.event_name }}" != "workflow_dispatch" ]; then
-              if ! echo "$CHANGED_FILES" | grep -q "^${module}/init/"; then
-                continue
-              fi
-            fi
-
-            # Skip if no module.yaml exists
-            if [ ! -f "${module}/module.yaml" ]; then
-              echo "No module.yaml found for ${module}, skipping"
-              continue
-            fi
-
-            image_count=$(yq '.images | length' "${module}/module.yaml")
-            if [ "$image_count" = "0" ] || [ "$image_count" = "null" ]; then
-              continue
-            fi
-
-            for i in $(seq 0 $((image_count - 1))); do
-              image_name=$(yq ".images[${i}].name" "${module}/module.yaml")
-              context=$(yq ".images[${i}].context" "${module}/module.yaml")
-              dockerfile=$(yq ".images[${i}].dockerfile" "${module}/module.yaml")
-              values_repo_path=$(yq ".images[${i}].valuesYaml.repositoryPath" "${module}/module.yaml")
-
-              FULL_IMAGE="ghcr.io/${REPO_OWNER}/${image_name}"
-
-              echo "::group::Building and pushing ${FULL_IMAGE}:${SHORT_SHA}"
-              docker buildx build \
-                --push \
-                -t "${FULL_IMAGE}:${SHORT_SHA}" \
-                -t "${FULL_IMAGE}:latest" \
-                -f "${module}/${dockerfile}" \
-                "${module}/${context}"
-              echo "::endgroup::"
-
-              # Update image repository in values.yaml
-              yq -i "${values_repo_path} = \"${FULL_IMAGE}\"" "${module}/helm/values.yaml"
-
-              # Update appVersion in Chart.yaml (used as default image tag)
-              yq -i ".appVersion = \"${SHORT_SHA}\"" "${module}/helm/Chart.yaml"
-              UPDATED=true
-
-              # Track which modules had images built
-              if [ -z "$BUILT_MODULES" ]; then
-                BUILT_MODULES="${module}"
-              else
-                BUILT_MODULES="${BUILT_MODULES},${module}"
-              fi
-            done
-          done
-
-          if [ "$UPDATED" = true ]; then
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
-            git add '*/helm/Chart.yaml' '*/helm/values.yaml'
-            git diff --cached --quiet || git commit -m "ci: update image tags to ${SHORT_SHA} [skip ci]"
-            git push
-          fi
-
-          echo "images-built=${UPDATED}" >> "$GITHUB_OUTPUT"
-          echo "built-modules=${BUILT_MODULES}" >> "$GITHUB_OUTPUT"
-
-  release-charts:
-    needs: build-images
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          # Pull the latest commit (may include the appVersion update from build-images)
-          # fetch-depth: 3 ensures HEAD~2 exists for diffing when build-images pushed a commit
-          ref: ${{ github.ref }}
-          fetch-depth: 3
-
-      - name: Pull latest changes
-        run: git pull --ff-only origin ${{ github.ref_name }}
-
-      - name: Install Helm
-        uses: azure/setup-helm@v4
-
-      - name: Install yq
-        uses: mikefarah/yq@v4
-
-      - name: Login to GHCR
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io --username "${{ github.actor }}" --password-stdin
-
-      - name: Detect charts with version changes and publish
-        env:
-          BUILT_MODULES: ${{ needs.build-images.outputs.built-modules }}
-        run: |
-          REPO_OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
-
-          # Determine changed files in the original commit (before any bot commits)
-          # If build-images pushed a commit, we need to look 2 commits back
-          if [ "${{ needs.build-images.outputs.images-built }}" = "true" ]; then
-            # HEAD is the bot commit, HEAD~1 is the user commit, HEAD~2 is the previous state
-            CHANGED_FILES=$(git diff --name-only HEAD~2 HEAD~1)
-          elif git rev-parse HEAD~1 >/dev/null 2>&1; then
-            CHANGED_FILES=$(git diff --name-only HEAD~1 HEAD)
-          else
-            CHANGED_FILES=$(git ls-files)
-          fi
-
-          PUBLISHED=false
+          echo "Changed files:"
+          echo "$CHANGED_FILES"
+          echo ""
 
           for module_dir in */; do
             module="${module_dir%/}"
             chart_dir="${module}/helm"
 
+            # Skip directories without a helm chart
             if [ ! -f "${chart_dir}/Chart.yaml" ]; then
               continue
             fi
 
-            SHOULD_PUBLISH=false
+            # Determine if this module's chart version was bumped
+            CHART_VERSION=$(yq '.version' "${chart_dir}/Chart.yaml")
+            OLD_CHART_VERSION=$(git show HEAD~1:"${chart_dir}/Chart.yaml" 2>/dev/null | yq '.version' 2>/dev/null || echo "")
+            VERSION_BUMPED=false
 
-            # Check if Chart.yaml version field was changed in this module
-            if echo "$CHANGED_FILES" | grep -q "^${module}/helm/Chart.yaml"; then
-              # Verify the 'version' field actually changed (not just appVersion)
-              if [ "${{ needs.build-images.outputs.images-built }}" = "true" ]; then
-                OLD_VERSION=$(git show HEAD~2:"${chart_dir}/Chart.yaml" 2>/dev/null | yq '.version' || echo "")
-                NEW_VERSION=$(git show HEAD~1:"${chart_dir}/Chart.yaml" 2>/dev/null | yq '.version' || echo "")
-              else
-                OLD_VERSION=$(git show HEAD~1:"${chart_dir}/Chart.yaml" 2>/dev/null | yq '.version' || echo "")
-                NEW_VERSION=$(yq '.version' "${chart_dir}/Chart.yaml")
-              fi
-
-              if [ "$OLD_VERSION" != "$NEW_VERSION" ] && [ -n "$NEW_VERSION" ]; then
-                echo "Chart version changed for ${module}: ${OLD_VERSION} -> ${NEW_VERSION}"
-                SHOULD_PUBLISH=true
-              fi
+            if [ "$OLD_CHART_VERSION" != "$CHART_VERSION" ]; then
+              VERSION_BUMPED=true
             fi
 
-            # For modules without images, publish if any helm files changed
-            if [ "$SHOULD_PUBLISH" != "true" ]; then
-              image_count="0"
-              if [ -f "${module}/module.yaml" ]; then
-                image_count=$(yq '.images | length' "${module}/module.yaml")
-              fi
-              if [ "$image_count" = "0" ] || [ "$image_count" = "null" ]; then
-                if echo "$CHANGED_FILES" | grep -q "^${module}/helm/"; then
-                  echo "Helm files changed for image-less module ${module}, publishing chart"
-                  SHOULD_PUBLISH=true
-                fi
-              fi
-            fi
-
-            # For workflow_dispatch, publish all charts
+            # For workflow_dispatch, always publish
             if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-              SHOULD_PUBLISH=true
+              VERSION_BUMPED=true
             fi
 
-            if [ "$SHOULD_PUBLISH" != "true" ]; then
-              echo "Skipping ${module}: no chart version change detected"
+            if [ "$VERSION_BUMPED" != "true" ]; then
+              echo "Skipping ${module}: chart version unchanged (${CHART_VERSION})"
               continue
             fi
 
-            chart_name=$(yq '.name' "${chart_dir}/Chart.yaml")
-            chart_version=$(yq '.version' "${chart_dir}/Chart.yaml")
+            echo "::group::${module} v${CHART_VERSION}"
 
-            echo "::group::${chart_name} v${chart_version}"
+            # ── Build container images if this module has any ──
+            if [ -f "${module}/module.yaml" ]; then
+              image_count=$(yq '.images | length' "${module}/module.yaml")
+              if [ "$image_count" != "0" ] && [ "$image_count" != "null" ]; then
+                for i in $(seq 0 $((image_count - 1))); do
+                  image_name=$(yq ".images[${i}].name" "${module}/module.yaml")
+                  context=$(yq ".images[${i}].context" "${module}/module.yaml")
+                  dockerfile=$(yq ".images[${i}].dockerfile" "${module}/module.yaml")
+
+                  FULL_IMAGE="ghcr.io/${REPO_OWNER}/${image_name}"
+
+                  echo "Building and pushing ${FULL_IMAGE}:${CHART_VERSION}"
+                  docker buildx build \
+                    --push \
+                    -t "${FULL_IMAGE}:${CHART_VERSION}" \
+                    -t "${FULL_IMAGE}:latest" \
+                    -f "${module}/${dockerfile}" \
+                    "${module}/${context}"
+                done
+              fi
+            fi
+
+            # ── Package and publish the Helm chart ──
+            chart_name=$(yq '.name' "${chart_dir}/Chart.yaml")
 
             # Add dependency repos and build
             dep_count=$(yq '.dependencies | length' "${chart_dir}/Chart.yaml")
@@ -234,13 +129,8 @@ jobs:
 
             helm package "${chart_dir}" -d .packages
 
-            echo "Pushing ${chart_name}:${chart_version} to ghcr.io/${REPO_OWNER}/charts..."
-            helm push ".packages/${chart_name}-${chart_version}.tgz" "oci://ghcr.io/${REPO_OWNER}/charts"
+            echo "Pushing ${chart_name}:${CHART_VERSION} to ghcr.io/${REPO_OWNER}/charts..."
+            helm push ".packages/${chart_name}-${CHART_VERSION}.tgz" "oci://ghcr.io/${REPO_OWNER}/charts"
 
-            PUBLISHED=true
             echo "::endgroup::"
           done
-
-          if [ "$PUBLISHED" != "true" ]; then
-            echo "No charts required publishing"
-          fi

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 2
+          fetch-depth: 0
 
       - name: Install yq
         uses: mikefarah/yq@v4
@@ -48,9 +48,11 @@ jobs:
         run: |
           REPO_OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
 
+          BEFORE_SHA="${{ github.event.before }}"
+
           # Determine changed files
-          if git rev-parse HEAD~1 >/dev/null 2>&1; then
-            CHANGED_FILES=$(git diff --name-only HEAD~1 HEAD)
+          if [ -n "$BEFORE_SHA" ] && [ "$BEFORE_SHA" != "0000000000000000000000000000000000000000" ]; then
+            CHANGED_FILES=$(git diff --name-only "$BEFORE_SHA" HEAD)
           else
             CHANGED_FILES=$(git ls-files)
           fi
@@ -70,7 +72,7 @@ jobs:
 
             # Determine if this module's chart version was bumped
             CHART_VERSION=$(yq '.version' "${chart_dir}/Chart.yaml")
-            OLD_CHART_VERSION=$(git show HEAD~1:"${chart_dir}/Chart.yaml" 2>/dev/null | yq '.version' 2>/dev/null || echo "")
+            OLD_CHART_VERSION=$(git show "${BEFORE_SHA}:${chart_dir}/Chart.yaml" 2>/dev/null | yq '.version' 2>/dev/null || echo "")
             VERSION_BUMPED=false
 
             if [ "$OLD_CHART_VERSION" != "$CHART_VERSION" ]; then

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,0 +1,79 @@
+# Copyright 2026 The OpenChoreo Authors
+# SPDX-License-Identifier: Apache-2.0
+
+name: Validate PR
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "**/init/**"
+      - "**/helm/**"
+      - "**/module.yaml"
+
+permissions:
+  contents: read
+
+jobs:
+  check-version-bump:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install yq
+        uses: mikefarah/yq@v4
+
+      - name: Ensure chart version is bumped for changed modules
+        run: |
+          # Get the list of changed files compared to the base branch
+          CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
+
+          echo "Changed files:"
+          echo "$CHANGED_FILES"
+          echo ""
+
+          FAILED=false
+
+          for module_dir in */; do
+            module="${module_dir%/}"
+            chart_dir="${module}/helm"
+
+            # Skip if this module has no helm chart
+            if [ ! -f "${chart_dir}/Chart.yaml" ]; then
+              continue
+            fi
+
+            # Check if any files in this module were changed (init/ or helm/)
+            if ! echo "$CHANGED_FILES" | grep -q "^${module}/"; then
+              continue
+            fi
+
+            # Skip if only non-helm, non-init files changed (e.g., README.md)
+            if ! echo "$CHANGED_FILES" | grep -qE "^${module}/(init/|helm/|module\.yaml)"; then
+              continue
+            fi
+
+            # Check if version was bumped
+            OLD_VERSION=$(git show origin/${{ github.base_ref }}:"${chart_dir}/Chart.yaml" 2>/dev/null | yq '.version' 2>/dev/null || echo "")
+            NEW_VERSION=$(yq '.version' "${chart_dir}/Chart.yaml")
+
+            if [ "$OLD_VERSION" = "$NEW_VERSION" ]; then
+              echo "::error::Module '${module}' has changes but Chart.yaml version was not bumped (still ${OLD_VERSION}). Please bump the version in ${chart_dir}/Chart.yaml."
+              FAILED=true
+            else
+              echo "✓ ${module}: version bumped ${OLD_VERSION} → ${NEW_VERSION}"
+            fi
+          done
+
+          if [ "$FAILED" = "true" ]; then
+            echo ""
+            echo "One or more modules have changes without a version bump."
+            echo "Please update the 'version' field in the relevant Chart.yaml file(s)."
+            exit 1
+          fi
+
+          echo ""
+          echo "All changed modules have version bumps. ✓"

--- a/observability-logs-opensearch/README.md
+++ b/observability-logs-opensearch/README.md
@@ -12,5 +12,6 @@ This module collects logs using Fluent Bit and stores them in OpenSearch.
 helm install observability-logs-opensearch \
   oci://ghcr.io/openchoreo/charts/observability-logs-opensearch \
   --create-namespace \
-  --namespace openchoreo-observability-plane
+  --namespace openchoreo-observability-plane \
+  --version 0.2.0
 ```

--- a/observability-logs-opensearch/helm/Chart.yaml
+++ b/observability-logs-opensearch/helm/Chart.yaml
@@ -5,8 +5,8 @@ apiVersion: v2
 name: observability-logs-opensearch
 description: A Helm chart for OpenChoreo Observability Logs module with Fluent Bit and OpenSearch
 type: application
-version: 0.1.0
-appVersion: "1.0"
+version: 0.2.0
+appVersion: "0.2.0"
 keywords:
   - opensearch
   - observability

--- a/observability-logs-opensearch/helm/templates/opensearch-setup-logs/job.yaml
+++ b/observability-logs-opensearch/helm/templates/opensearch-setup-logs/job.yaml
@@ -31,7 +31,7 @@ spec:
           value: "{{ .Values.openSearchSetup.dataRetentionTime.containerLogs }}"
         - name: RCA_REPORTS_MIN_INDEX_AGE
           value: "{{ .Values.openSearchSetup.dataRetentionTime.rcaReports }}"
-        image: "{{ .Values.openSearchSetup.image.repository }}:{{ .Values.openSearchSetup.image.tag | default .Chart.AppVersion }}"
+        image: "{{ .Values.openSearchSetup.image.repository }}:{{ .Values.openSearchSetup.image.tag | default .Chart.Version }}"
         imagePullPolicy: {{ .Values.openSearchSetup.image.pullPolicy | default "IfNotPresent" }}
         resources:
           requests:

--- a/observability-logs-opensearch/module.yaml
+++ b/observability-logs-opensearch/module.yaml
@@ -9,5 +9,3 @@ images:
   - name: observability-logs-opensearch-setup
     context: init
     dockerfile: init/Dockerfile
-    valuesYaml:
-      repositoryPath: ".openSearchSetup.image.repository"

--- a/observability-metrics-prometheus/README.md
+++ b/observability-metrics-prometheus/README.md
@@ -15,5 +15,5 @@ helm install observability-metrics-prometheus \
   oci://ghcr.io/openchoreo/charts/observability-metrics-prometheus \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.1.0
+  --version 0.2.0
 ```

--- a/observability-metrics-prometheus/helm/Chart.yaml
+++ b/observability-metrics-prometheus/helm/Chart.yaml
@@ -5,8 +5,8 @@ apiVersion: v2
 name: observability-metrics-prometheus
 description: A Helm chart for OpenChoreo Observability Metrics module based on Prometheus
 type: application
-version: 0.1.0
-appVersion: "1.0"
+version: 0.2.0
+appVersion: "0.2.0"
 keywords:
   - prometheus
   - observability

--- a/observability-tracing-opensearch/README.md
+++ b/observability-tracing-opensearch/README.md
@@ -13,7 +13,7 @@ helm install observability-tracing-opensearch \
   oci://ghcr.io/openchoreo/charts/observability-tracing-opensearch \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.1.0
+  --version 0.2.0
 ```
 
 > **Note:** If OpenSearch is already installed by another module (e.g., `observability-logs-opensearch`), disable it to avoid conflicts:
@@ -23,6 +23,6 @@ helm install observability-tracing-opensearch \
 >   oci://ghcr.io/openchoreo/charts/observability-tracing-opensearch \
 >   --create-namespace \
 >   --namespace openchoreo-observability-plane \
->   --version 0.1.0 \
+>   --version 0.2.0 \
 >   --set openSearch.enabled=false
 > ```

--- a/observability-tracing-opensearch/helm/Chart.yaml
+++ b/observability-tracing-opensearch/helm/Chart.yaml
@@ -5,8 +5,8 @@ apiVersion: v2
 name: observability-tracing-opensearch
 description: A Helm chart for OpenChoreo Observability Tracing module with OpenTelemetry Collector and OpenSearch
 type: application
-version: 0.1.0
-appVersion: "1.0"
+version: 0.2.0
+appVersion: "0.2.0"
 keywords:
   - opensearch
   - observability

--- a/observability-tracing-opensearch/helm/templates/opensearch-setup/job.yaml
+++ b/observability-tracing-opensearch/helm/templates/opensearch-setup/job.yaml
@@ -27,7 +27,7 @@ spec:
               key: password
         - name: OTEL_TRACES_MIN_INDEX_AGE
           value: "{{ .Values.openSearchSetup.dataRetentionTime.traces }}"
-        image: "{{ .Values.openSearchSetup.image.repository }}:{{ .Values.openSearchSetup.image.tag | default .Chart.AppVersion }}"
+        image: "{{ .Values.openSearchSetup.image.repository }}:{{ .Values.openSearchSetup.image.tag | default .Chart.Version }}"
         imagePullPolicy: {{ .Values.openSearchSetup.image.pullPolicy | default "IfNotPresent" }}
         resources:
           requests:

--- a/observability-tracing-opensearch/helm/values.yaml
+++ b/observability-tracing-opensearch/helm/values.yaml
@@ -64,8 +64,7 @@ opentelemetry-collector:
 ## -----------------------------------------------------------
 openSearchSetup:
   image:
-    repository: "oc-module-opensearch-init"
-    tag: "latest"
+    repository: "ghcr.io/openchoreo/observability-tracing-opensearch-setup"
 
   openSearchUsername: "admin"
   openSearchPassword: "ThisIsTheOpenSearchPassword1"

--- a/observability-tracing-opensearch/module.yaml
+++ b/observability-tracing-opensearch/module.yaml
@@ -9,5 +9,3 @@ images:
   - name: observability-tracing-opensearch-setup
     context: init
     dockerfile: init/Dockerfile
-    valuesYaml:
-      repositoryPath: ".openSearchSetup.image.repository"


### PR DESCRIPTION
## Purpose
Unify and simplify the CI/CD process for modules

## Goals
1. Use the Helm chart version as the single source of truth for both image and chart releases.
2. Eliminate in-repo file rewrites and git pushes from CI.
3. Ensure every chart and image is published with a clear, matching version.

## Approach
1. CI builds and tags images with the chart version, and publishes Helm charts only when the version is bumped.
2. Helm templates reference .Chart.Version for image tags, so what’s in the repo matches what’s deployed.
3. Added PR validation to enforce version bumps when module code changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PR validation to enforce Helm chart version bumps.
  * Unified CI build-and-release flow with Helm-based chart packaging and per-module publish.

* **Bug Fixes / Improvements**
  * Only publish charts/images when chart versions change; improved change detection and messaging.
  * Switched tracing setup image to a registry-hosted repository and standardized tagging to chart version.

* **Chores**
  * Bumped multiple charts to v0.2.0 and updated install docs.
  * Removed obsolete image-to-valuesPath mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->