### PR TITLE
fix: build and publish multi arch Docker images

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,6 +31,9 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -104,6 +107,7 @@ jobs:
 
                   echo "Building and pushing ${FULL_IMAGE}:${CHART_VERSION}"
                   docker buildx build \
+                    --platform linux/amd64,linux/arm64 \
                     --push \
                     -t "${FULL_IMAGE}:${CHART_VERSION}" \
                     -t "${FULL_IMAGE}:latest" \

--- a/observability-logs-opensearch/README.md
+++ b/observability-logs-opensearch/README.md
@@ -13,5 +13,16 @@ helm install observability-logs-opensearch \
   oci://ghcr.io/openchoreo/charts/observability-logs-opensearch \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.2.0
+  --version 0.2.1
 ```
+
+> **Note:** If OpenSearch is already installed by another module (e.g., `observability-tracing-opensearch`), disable it to avoid conflicts:
+>
+> ```bash
+> helm install observability-logs-opensearch \
+>   oci://ghcr.io/openchoreo/charts/observability-logs-opensearch \
+>   --create-namespace \
+>   --namespace openchoreo-observability-plane \
+>   --version 0.2.1 \
+>   --set openSearch.enabled=false
+> ```

--- a/observability-logs-opensearch/helm/Chart.yaml
+++ b/observability-logs-opensearch/helm/Chart.yaml
@@ -5,8 +5,8 @@ apiVersion: v2
 name: observability-logs-opensearch
 description: A Helm chart for OpenChoreo Observability Logs module with Fluent Bit and OpenSearch
 type: application
-version: 0.2.0
-appVersion: "0.2.0"
+version: 0.2.1
+appVersion: "0.2.1"
 keywords:
   - opensearch
   - observability

--- a/observability-logs-opensearch/helm/templates/opensearch/backend-config-policy.yaml
+++ b/observability-logs-opensearch/helm/templates/opensearch/backend-config-policy.yaml
@@ -1,6 +1,8 @@
 # Copyright 2026 The OpenChoreo Authors
 # SPDX-License-Identifier: Apache-2.0
 
+{{- if .Values.openSearch.enabled }}
+
 apiVersion: gateway.kgateway.dev/v1alpha1
 kind: BackendConfigPolicy
 metadata:
@@ -14,3 +16,4 @@ spec:
   tls:
     sni: "opensearch"
     insecureSkipVerify: true
+{{- end }}

--- a/observability-tracing-opensearch/README.md
+++ b/observability-tracing-opensearch/README.md
@@ -13,7 +13,7 @@ helm install observability-tracing-opensearch \
   oci://ghcr.io/openchoreo/charts/observability-tracing-opensearch \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.2.0
+  --version 0.2.1
 ```
 
 > **Note:** If OpenSearch is already installed by another module (e.g., `observability-logs-opensearch`), disable it to avoid conflicts:
@@ -23,6 +23,6 @@ helm install observability-tracing-opensearch \
 >   oci://ghcr.io/openchoreo/charts/observability-tracing-opensearch \
 >   --create-namespace \
 >   --namespace openchoreo-observability-plane \
->   --version 0.2.0 \
+>   --version 0.2.1 \
 >   --set openSearch.enabled=false
 > ```

--- a/observability-tracing-opensearch/helm/Chart.yaml
+++ b/observability-tracing-opensearch/helm/Chart.yaml
@@ -5,8 +5,8 @@ apiVersion: v2
 name: observability-tracing-opensearch
 description: A Helm chart for OpenChoreo Observability Tracing module with OpenTelemetry Collector and OpenSearch
 type: application
-version: 0.2.0
-appVersion: "0.2.0"
+version: 0.2.1
+appVersion: "0.2.1"
 keywords:
   - opensearch
   - observability

--- a/observability-tracing-opensearch/helm/templates/opensearch/backend-config-policy.yaml
+++ b/observability-tracing-opensearch/helm/templates/opensearch/backend-config-policy.yaml
@@ -1,6 +1,8 @@
 # Copyright 2026 The OpenChoreo Authors
 # SPDX-License-Identifier: Apache-2.0
 
+{{- if .Values.openSearch.enabled }}
+
 apiVersion: gateway.kgateway.dev/v1alpha1
 kind: BackendConfigPolicy
 metadata:
@@ -14,3 +16,5 @@ spec:
   tls:
     sni: "opensearch"
     insecureSkipVerify: true
+    
+{{- end }}


### PR DESCRIPTION
## Purpose
linux/arm64 Docker images were not being published earlier and was causing containers to not start on some architectures. This includes a fix for it

## Goals
Build and publish Docker images for both linux/amd64 and linux/arm64 architectures

## Approach
Updated the buildx command and provided both architectures through the --platform flag


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added multi-architecture Docker image support (linux/amd64, linux/arm64).
  * Backend config resource now only appears when OpenSearch is enabled.

* **Documentation**
  * Updated install examples and added guidance to disable conflicting OpenSearch installations.

* **Chores**
  * Bumped observability module versions to 0.2.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->