### PR TITLE
fix: add replace_dots to Fluent Bit and set opensearch-operator version to 2.8.0 in README

### DIFF
--- a/observability-logs-opensearch/README.md
+++ b/observability-logs-opensearch/README.md
@@ -40,7 +40,10 @@ EOF
 ```bash
 helm repo add opensearch-operator https://opensearch-project.github.io/opensearch-k8s-operator/
 helm repo update
-helm install opensearch-operator opensearch-operator/opensearch-operator --namespace openchoreo-observability-plane
+helm install opensearch-operator opensearch-operator/opensearch-operator \
+  --create-namespace \
+  --namespace openchoreo-observability-plane \
+  --version 2.8.0
 ```
 
 ## Deploy Helm chart
@@ -48,22 +51,36 @@ helm install opensearch-operator opensearch-operator/opensearch-operator --names
 > **Note:** If you wish to use the Kubernetes operator-based OpenSearch version, add `--set openSearch.enabled=false --set openSearchCluster.enabled=true` flags when installing the Helm chart
 
 ```bash
-helm install observability-logs-opensearch \
+helm upgrade --install observability-logs-opensearch \
   oci://ghcr.io/openchoreo/charts/observability-logs-opensearch \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.3.0 \
+  --version 0.3.1 \
   --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials"
 ```
 
 > **Note:** If OpenSearch is already installed by another module (e.g., `observability-tracing-opensearch`), disable it to avoid conflicts:
 >
 > ```bash
-> helm install observability-logs-opensearch \
+> helm upgrade --install observability-logs-opensearch \
 >   oci://ghcr.io/openchoreo/charts/observability-logs-opensearch \
 >   --create-namespace \
 >   --namespace openchoreo-observability-plane \
->   --version 0.3.0 \
+>   --version 0.3.1 \
 >   --set openSearch.enabled=false \
 >   --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials"
 > ```
+
+## Enable log collection
+
+Enable Fluent Bit to start collecting logs from the cluster and publish to OpenSearch
+
+```bash
+helm upgrade observability-logs-opensearch \
+  oci://ghcr.io/openchoreo/charts/observability-logs-opensearch \
+  --create-namespace \
+  --namespace openchoreo-observability-plane \
+  --version 0.3.1 \
+  --reuse-values \
+  --set fluent-bit.enabled=true
+```

--- a/observability-logs-opensearch/helm/Chart.yaml
+++ b/observability-logs-opensearch/helm/Chart.yaml
@@ -5,8 +5,8 @@ apiVersion: v2
 name: observability-logs-opensearch
 description: A Helm chart for OpenChoreo Observability Logs module with Fluent Bit and OpenSearch
 type: application
-version: 0.3.0
-appVersion: "0.3.0"
+version: 0.3.1
+appVersion: "0.3.1"
 keywords:
   - opensearch
   - observability

--- a/observability-logs-opensearch/helm/values.yaml
+++ b/observability-logs-opensearch/helm/values.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 fluent-bit:
-  enabled: true
+  enabled: false
 
   config:
     customParsers: |
@@ -53,6 +53,7 @@ fluent-bit:
           Logstash_Prefix container-logs
           Match kube.*
           Port 9200
+          Replace_Dots On
           Suppress_Type_Name On
           tls On
           tls.verify Off

--- a/observability-tracing-opensearch/README.md
+++ b/observability-tracing-opensearch/README.md
@@ -40,7 +40,10 @@ EOF
 ```bash
 helm repo add opensearch-operator https://opensearch-project.github.io/opensearch-k8s-operator/
 helm repo update
-helm install opensearch-operator opensearch-operator/opensearch-operator --namespace openchoreo-observability-plane
+helm install opensearch-operator opensearch-operator/opensearch-operator \
+  --create-namespace \
+  --namespace openchoreo-observability-plane \
+  --version 2.8.0
 ```
 
 ### Deploy Helm chart
@@ -48,7 +51,7 @@ helm install opensearch-operator opensearch-operator/opensearch-operator --names
 > **Note:** If you wish to use the Kubernetes operator-based OpenSearch version, add `--set openSearch.enabled=false --set openSearchCluster.enabled=true` flags when installing the Helm chart
 
 ```bash
-helm install observability-tracing-opensearch \
+helm upgrade --install observability-tracing-opensearch \
   oci://ghcr.io/openchoreo/charts/observability-tracing-opensearch \
   --create-namespace \
   --namespace openchoreo-observability-plane \
@@ -59,7 +62,7 @@ helm install observability-tracing-opensearch \
 > **Note:** If OpenSearch is already installed by another module (e.g., `observability-logs-opensearch`), disable it to avoid conflicts:
 >
 > ```bash
-> helm install observability-tracing-opensearch \
+> helm upgrade --install observability-tracing-opensearch \
 >   oci://ghcr.io/openchoreo/charts/observability-tracing-opensearch \
 >   --create-namespace \
 >   --namespace openchoreo-observability-plane \


### PR DESCRIPTION
## Purpose
https://github.com/openchoreo/openchoreo/issues/1958

## Goals
Update Fluent Bit config to support dot replacement
Update OpenSearch guide to install operator v2.8.0
Add steps on how to enable log collection from Fluent Bit

## Approach
1. Updated README in observability-*-opensearch modules
2. Added `Replace_Dots On` to the Fluent Bit output config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added option to control handling of dots in log field names.

* **Documentation**
  * Installation docs updated to pin OpenSearch operator to v2.8.0 and show upgrade/install usage.
  * Added troubleshooting note for environments where OpenSearch is managed elsewhere.
  * Added guidance for enabling log collection (Fluent Bit) with a reuse-values upgrade command.

* **Chores**
  * Chart and app versions bumped to 0.3.1; Fluent Bit disabled by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->