### PR TITLE
fix: set service type to LoadBalancer in prometheus and otel-collector

### DIFF
--- a/observability-metrics-prometheus/helm/Chart.yaml
+++ b/observability-metrics-prometheus/helm/Chart.yaml
@@ -5,8 +5,8 @@ apiVersion: v2
 name: observability-metrics-prometheus
 description: A Helm chart for OpenChoreo Observability Metrics module based on Prometheus
 type: application
-version: 0.2.0
-appVersion: "0.2.0"
+version: 0.2.1
+appVersion: "0.2.1"
 keywords:
   - prometheus
   - observability

--- a/observability-metrics-prometheus/helm/values.yaml
+++ b/observability-metrics-prometheus/helm/values.yaml
@@ -26,6 +26,7 @@ kube-prometheus-stack:
   prometheus:
     enabled: true
     prometheusSpec:
+      enableRemoteWriteReceiver: true
       serviceMonitorNamespaceSelector: {}
       serviceMonitorSelector: {}
       serviceMonitorSelectorNilUsesHelmValues: false
@@ -35,6 +36,7 @@ kube-prometheus-stack:
     service:
       port: 9091
       reloaderWebPort: 8081
+      type: LoadBalancer
 
   alertmanager:
     enabled: true

--- a/observability-tracing-opensearch/helm/Chart.yaml
+++ b/observability-tracing-opensearch/helm/Chart.yaml
@@ -5,8 +5,8 @@ apiVersion: v2
 name: observability-tracing-opensearch
 description: A Helm chart for OpenChoreo Observability Tracing module with OpenTelemetry Collector and OpenSearch
 type: application
-version: 0.3.0
-appVersion: "0.3.0"
+version: 0.3.1
+appVersion: "0.3.1"
 keywords:
   - opensearch
   - observability

--- a/observability-tracing-opensearch/helm/values.yaml
+++ b/observability-tracing-opensearch/helm/values.yaml
@@ -57,6 +57,9 @@ opentelemetry-collector:
     requests:
       cpu: 50m
       memory: 100Mi
+  
+  service:
+    type: LoadBalancer
 
 
 ## -----------------------------------------------------------


### PR DESCRIPTION
## Purpose
Update service type of Prometheus and Otel-collector services

## Goals
Allow requests to Prometheus and Otel-collector in multi cluster deployments

## Approach
Updated helm values


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Prometheus monitoring chart to v0.2.1
  * Updated OpenTelemetry tracing chart to v0.3.1

* **New Features**
  * Enabled Prometheus remote write receiver
  * Exposed Prometheus service via LoadBalancer
  * Exposed OpenTelemetry Collector service via LoadBalancer

<!-- end of auto-generated comment: release notes by coderabbit.ai -->