### PR TITLE
fix: extract value property from opensearch secrets#346

### DIFF
--- a/observability-logs-opensearch/README.md
+++ b/observability-logs-opensearch/README.md
@@ -30,9 +30,11 @@ spec:
   - secretKey: username
     remoteRef:
       key: opensearch-username
+      property: value
   - secretKey: password
     remoteRef:
       key: opensearch-password
+      property: value
 EOF
 ```
 

--- a/observability-tracing-opensearch/README.md
+++ b/observability-tracing-opensearch/README.md
@@ -30,9 +30,11 @@ spec:
   - secretKey: username
     remoteRef:
       key: opensearch-username
+      property: value
   - secretKey: password
     remoteRef:
       key: opensearch-password
+      property: value
 EOF
 ```
 


### PR DESCRIPTION
## Purpose
Extract only the value property from ESO secrets used for OpenSearch

## Goals
fix secret creation issue for ESO based secret

## Approach
Added `property: value` for secret remoteRefs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated OpenSearch configuration documentation to include explicit property field specifications for username and password credentials in secret references across observability logging and tracing modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->