### PR TITLE
fix: update helm chart versions in helm install commands in READMEs

### DIFF
--- a/observability-logs-openobserve/README.md
+++ b/observability-logs-openobserve/README.md
@@ -26,7 +26,7 @@ helm upgrade --install observability-logs-openobserve \
   oci://ghcr.io/openchoreo/charts/observability-logs-openobserve \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.1.0
+  --version 0.2.0
 ```
 
 ## Enable log collection
@@ -37,7 +37,7 @@ Enable Fluent Bit to start collecting logs from the cluster and publish to OpenO
 helm upgrade observability-logs-openobserve \
   oci://ghcr.io/openchoreo/charts/observability-logs-openobserve \
   --namespace openchoreo-observability-plane \
-  --version 0.1.0 \
+  --version 0.2.0 \
   --reuse-values \
   --set fluent-bit.enabled=true
 ```

--- a/observability-logs-opensearch/README.md
+++ b/observability-logs-opensearch/README.md
@@ -57,7 +57,7 @@ helm upgrade --install observability-logs-opensearch \
   oci://ghcr.io/openchoreo/charts/observability-logs-opensearch \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.3.1 \
+  --version 0.3.2 \
   --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials"
 ```
 
@@ -68,7 +68,7 @@ helm upgrade --install observability-logs-opensearch \
 >   oci://ghcr.io/openchoreo/charts/observability-logs-opensearch \
 >   --create-namespace \
 >   --namespace openchoreo-observability-plane \
->   --version 0.3.1 \
+>   --version 0.3.2 \
 >   --set openSearch.enabled=false \
 >   --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials"
 > ```
@@ -82,7 +82,7 @@ helm upgrade observability-logs-opensearch \
   oci://ghcr.io/openchoreo/charts/observability-logs-opensearch \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.3.1 \
+  --version 0.3.2 \
   --reuse-values \
   --set fluent-bit.enabled=true
 ```

--- a/observability-tracing-opensearch/README.md
+++ b/observability-tracing-opensearch/README.md
@@ -57,7 +57,7 @@ helm upgrade --install observability-tracing-opensearch \
   oci://ghcr.io/openchoreo/charts/observability-tracing-opensearch \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.3.0 \
+  --version 0.3.2 \
   --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials"
 ```
 
@@ -68,7 +68,7 @@ helm upgrade --install observability-tracing-opensearch \
 >   oci://ghcr.io/openchoreo/charts/observability-tracing-opensearch \
 >   --create-namespace \
 >   --namespace openchoreo-observability-plane \
->   --version 0.3.0 \
+>   --version 0.3.2 \
 >   --set openSearch.enabled=false \
 >   --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials"
 > ```


### PR DESCRIPTION
## Purpose
The helm chart version had not been updated in the READMEs of some Observability modules. This PR fixes that

## Goals
Ensure that the correct helm chart version is specified in the `helm install` commands in the README

## Approach
Updated the `--version` flag value in READMEs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Helm chart version references in installation documentation across observability modules to reflect latest releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->