### PR TITLE
fix: collect all pod labels through otel collector's k8sattributes processor

### DIFF
--- a/observability-tracing-opensearch/README.md
+++ b/observability-tracing-opensearch/README.md
@@ -57,7 +57,7 @@ helm upgrade --install observability-tracing-opensearch \
   oci://ghcr.io/openchoreo/charts/observability-tracing-opensearch \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.3.2 \
+  --version 0.3.3 \
   --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials"
 ```
 
@@ -68,7 +68,7 @@ helm upgrade --install observability-tracing-opensearch \
 >   oci://ghcr.io/openchoreo/charts/observability-tracing-opensearch \
 >   --create-namespace \
 >   --namespace openchoreo-observability-plane \
->   --version 0.3.2 \
+>   --version 0.3.3 \
 >   --set openSearch.enabled=false \
 >   --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials"
 > ```

--- a/observability-tracing-opensearch/helm/Chart.yaml
+++ b/observability-tracing-opensearch/helm/Chart.yaml
@@ -5,8 +5,8 @@ apiVersion: v2
 name: observability-tracing-opensearch
 description: A Helm chart for OpenChoreo Observability Tracing module with OpenTelemetry Collector and OpenSearch
 type: application
-version: 0.3.2
-appVersion: "0.3.2"
+version: 0.3.3
+appVersion: "0.3.3"
 keywords:
   - opensearch
   - observability

--- a/observability-tracing-opensearch/helm/templates/opentelemetry-collector/configMap.yaml
+++ b/observability-tracing-opensearch/helm/templates/opentelemetry-collector/configMap.yaml
@@ -47,12 +47,9 @@ data:
 
         extract:
           labels:
-            - key: openchoreo.dev/component-uid
-              tag_name: openchoreo.dev/component-uid
-            - key: openchoreo.dev/environment-uid
-              tag_name: openchoreo.dev/environment-uid
-            - key: openchoreo.dev/project-uid
-              tag_name: openchoreo.dev/project-uid
+            - tag_name: $$1
+              key_regex: (.*)
+              from: pod
             
           metadata:
             - k8s.pod.name


### PR DESCRIPTION
## Purpose
In trace data that was returned from OpenSearch, openchoreo names (project, component etc..) were missing. This was caused by those labels not being collected through otel collector's k8sattributes processor. This PR enables the collection of all labels

## Goals
Collect all pod labels from pods that publish traces

## Approach
Added a regex to the label extraction configuration in otel collector


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced Kubernetes label extraction with regex-based mapping, enabling more flexible and broader capture of pod labels in the OpenTelemetry collector.

* **Chores**
  * Version bumped to 0.3.3.
  * Updated deployment documentation to reflect new chart version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->