### PR TITLE
Adding Moesif logs module

### DIFF
--- a/observability-logs-moesif/README.md
+++ b/observability-logs-moesif/README.md
@@ -1,0 +1,93 @@
+# Observability Logs Module for Moesif
+
+This module collects container logs using Fluent Bit and exports them to Moesif via OpenTelemetry Collector.
+
+## Prerequisites
+
+- [OpenChoreo](https://github.com/openchoreo/openchoreo) must be installed with the **observability plane** enabled for this module to work.
+- A Moesif account and Application ID from [Moesif](https://www.moesif.com/)
+
+## Installation
+
+Install this module in your OpenChoreo cluster using:
+
+```bash
+helm upgrade --install observability-logs-moesif \
+  oci://ghcr.io/openchoreo/charts/observability-logs-moesif \
+  --create-namespace \
+  --namespace openchoreo-observability-plane \
+  --version 0.1.0 \
+  --set moesif.apps[0].env-name=default \
+  --set moesif.apps[0].collector-application-id=YOUR_MOESIF_APPLICATION_ID
+```
+
+> **Note:** Replace `YOUR_MOESIF_APPLICATION_ID` with your actual Moesif Application ID. Alternatively, you can use `api-key` instead of `collector-application-id`.
+
+### Configuration Options
+
+You can configure multiple environments with different Moesif applications:
+
+```bash
+helm upgrade --install observability-logs-moesif \
+  oci://ghcr.io/openchoreo/charts/observability-logs-moesif \
+  --create-namespace \
+  --namespace openchoreo-observability-plane \
+  --version 0.1.0 \
+  --set moesif.apps[0].env-name=development \
+  --set moesif.apps[0].collector-application-id=YOUR_DEV_APP_ID \
+  --set moesif.apps[1].env-name=production \
+  --set moesif.apps[1].collector-application-id=YOUR_PROD_APP_ID
+```
+
+> **Important:** If multiple environments need to send logs to the same Moesif application, you must still define separate entries in `moesif.apps` for each environment, using the same `collector-application-id` or `api-key`:
+>
+> ```bash
+> --set moesif.apps[0].env-name=development \
+> --set moesif.apps[0].collector-application-id=YOUR_MOESIF_APP_ID \
+> --set moesif.apps[1].env-name=staging \
+> --set moesif.apps[1].collector-application-id=YOUR_MOESIF_APP_ID \
+> --set moesif.apps[2].env-name=production \
+> --set moesif.apps[2].collector-application-id=YOUR_MOESIF_APP_ID
+> ```
+
+### Using a values.yaml file
+
+For easier configuration management, create a `moesif-values.yaml` file:
+
+```yaml
+# moesif-values.yaml
+# Configuration for Moesif log collection
+
+moesif:
+  apps:
+    # First Moesif application (e.g., development environment)
+    - env-name: development                              # Environment name that matches openchoreo.dev/environment label
+      collector-application-id: "YOUR_DEV_APP_ID"        # Moesif Application ID (use either this OR api-key)
+      # api-key: "YOUR_DEV_API_KEY"                      # Alternative: Moesif API Key (use either this OR collector-application-id)
+    
+    # Second Moesif application (e.g., production environment)
+    - env-name: production
+      collector-application-id: "YOUR_PROD_APP_ID"
+      # api-key: "YOUR_PROD_API_KEY"
+
+    # Example: Multiple environments using the same Moesif application
+    # Even if using the same Moesif app, you must define separate entries for each environment
+    # - env-name: staging
+    #   collector-application-id: "YOUR_DEV_APP_ID"      # Same as development
+```
+
+> **Note:** 
+> - The `env-name` field should match the `openchoreo.dev/environment` label on your resources
+> - Use either `collector-application-id` OR `api-key` (not both) - collector-application-id can be found in your Moesif `Apps and Team` settings
+> - If multiple environments send logs to the same Moesif application, define separate entries for each environment with the same credentials
+
+Then install with:
+
+```bash
+helm upgrade --install observability-logs-moesif \
+  oci://ghcr.io/openchoreo/charts/observability-logs-moesif \
+  --create-namespace \
+  --namespace openchoreo-observability-plane \
+  --version 0.1.0 \
+  -f moesif-values.yaml
+```

--- a/observability-logs-moesif/README.md
+++ b/observability-logs-moesif/README.md
@@ -9,48 +9,38 @@ This module collects container logs using Fluent Bit and exports them to Moesif 
 
 ## Installation
 
-Install this module in your OpenChoreo cluster using:
+### Create a Kubernetes Secret (Optional)
+
+If you want to store your Moesif Application IDs in a Kubernetes Secret, create one with your credentials for each environment:
+
+```bash
+kubectl create secret generic moesif-app-secret \
+  --from-literal=development="YOUR_DEV_APP_ID" \
+  --from-literal=production="YOUR_PROD_APP_ID" \
+  --namespace openchoreo-observability-plane
+```
+
+> **Note:** 
+> - Create separate keys for each environment (e.g., `development`, `production`)
+> - For environment names with hyphens (e.g., "my-env"), replace hyphens with underscores in the secret key name (e.g., "my_env")
+
+### Install the Helm Chart
+
+Install this module in your OpenChoreo cluster:
 
 ```bash
 helm upgrade --install observability-logs-moesif \
   oci://ghcr.io/openchoreo/charts/observability-logs-moesif \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.1.0 \
-  --set moesif.apps[0].env-name=default \
-  --set moesif.apps[0].collector-application-id=YOUR_MOESIF_APPLICATION_ID
+  --version 0.1.0
 ```
-
-> **Note:** Replace `YOUR_MOESIF_APPLICATION_ID` with your actual Moesif Application ID. Alternatively, you can use `api-key` instead of `collector-application-id`.
 
 ### Configuration Options
 
-You can configure multiple environments with different Moesif applications:
+You can configure multiple environments and customize the Moesif endpoint:
 
-```bash
-helm upgrade --install observability-logs-moesif \
-  oci://ghcr.io/openchoreo/charts/observability-logs-moesif \
-  --create-namespace \
-  --namespace openchoreo-observability-plane \
-  --version 0.1.0 \
-  --set moesif.apps[0].env-name=development \
-  --set moesif.apps[0].collector-application-id=YOUR_DEV_APP_ID \
-  --set moesif.apps[1].env-name=production \
-  --set moesif.apps[1].collector-application-id=YOUR_PROD_APP_ID
-```
-
-> **Important:** If multiple environments need to send logs to the same Moesif application, you must still define separate entries in `moesif.apps` for each environment, using the same `collector-application-id` or `api-key`:
->
-> ```bash
-> --set moesif.apps[0].env-name=development \
-> --set moesif.apps[0].collector-application-id=YOUR_MOESIF_APP_ID \
-> --set moesif.apps[1].env-name=staging \
-> --set moesif.apps[1].collector-application-id=YOUR_MOESIF_APP_ID \
-> --set moesif.apps[2].env-name=production \
-> --set moesif.apps[2].collector-application-id=YOUR_MOESIF_APP_ID
-> ```
-
-### Using a values.yaml file
+#### Using a values.yaml file
 
 For easier configuration management, create a `moesif-values.yaml` file:
 
@@ -59,27 +49,24 @@ For easier configuration management, create a `moesif-values.yaml` file:
 # Configuration for Moesif log collection
 
 moesif:
-  apps:
-    # First Moesif application (e.g., development environment)
-    - env-name: development                              # Environment name that matches openchoreo.dev/environment label
-      collector-application-id: "YOUR_DEV_APP_ID"        # Moesif Application ID (use either this OR api-key)
-      # api-key: "YOUR_DEV_API_KEY"                      # Alternative: Moesif API Key (use either this OR collector-application-id)
-    
-    # Second Moesif application (e.g., production environment)
-    - env-name: production
-      collector-application-id: "YOUR_PROD_APP_ID"
-      # api-key: "YOUR_PROD_API_KEY"
+  # List of environment names to collect logs from
+  # These must match the openchoreo.dev/environment label on your resources
+  environments:
+    - development
+    - production
+    - staging
+  
+  # (Optional) Moesif API endpoint
+  # Uncomment to override the default endpoint
+  # endpoint: "https://api.moesif.net"
 
-    # Example: Multiple environments using the same Moesif application
-    # Even if using the same Moesif app, you must define separate entries for each environment
-    # - env-name: staging
-    #   collector-application-id: "YOUR_DEV_APP_ID"      # Same as development
+# (Optional) Reference a pre-existing secret containing Moesif Application IDs
+# Uncomment if you created the moesif-app-secret
+# opentelemetry-collector:
+#   extraEnvsFrom:
+#     - secretRef:
+#         name: moesif-app-secret
 ```
-
-> **Note:** 
-> - The `env-name` field should match the `openchoreo.dev/environment` label on your resources
-> - Use either `collector-application-id` OR `api-key` (not both) - collector-application-id can be found in your Moesif `Apps and Team` settings
-> - If multiple environments send logs to the same Moesif application, define separate entries for each environment with the same credentials
 
 Then install with:
 
@@ -90,4 +77,56 @@ helm upgrade --install observability-logs-moesif \
   --namespace openchoreo-observability-plane \
   --version 0.1.0 \
   -f moesif-values.yaml
+```
+
+#### Configuration Parameters
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `moesif.environments` | List of environment names to collect logs from | `[]` |
+| `moesif.endpoint` | (Optional) Moesif API endpoint URL | `https://api.moesif.net` |
+
+## How It Works
+
+This module deploys two main components:
+
+1. **Fluent Bit**: Collects logs from all containers in the cluster
+2. **OpenTelemetry Collector**: Receives logs from Fluent Bit, processes them, and routes them to the appropriate Moesif application based on environment labels
+
+The module uses the `openchoreo.dev/environment` label on your resources to route logs to the correct Moesif application.
+
+## Troubleshooting
+
+### Check OpenTelemetry Collector logs
+
+```bash
+kubectl -n openchoreo-observability-plane logs -f deploy/opentelemetry-collector
+```
+
+### Check Fluent Bit logs
+
+```bash
+kubectl -n openchoreo-observability-plane logs -f ds/fluent-bit
+```
+
+### Verify Secret Configuration
+
+```bash
+kubectl -n openchoreo-observability-plane get secret moesif-app-secret -o yaml
+```
+
+## Uninstalling
+
+To remove this module:
+
+```bash
+helm uninstall observability-logs-moesif \
+  --namespace openchoreo-observability-plane
+```
+
+To also remove the secret:
+
+```bash
+kubectl delete secret moesif-app-secret \
+  --namespace openchoreo-observability-plane
 ```

--- a/observability-logs-moesif/helm/.helmignore
+++ b/observability-logs-moesif/helm/.helmignore
@@ -1,0 +1,26 @@
+# Copyright 2026 The OpenChoreo Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/observability-logs-moesif/helm/Chart.lock
+++ b/observability-logs-moesif/helm/Chart.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: opentelemetry-collector
+  repository: https://open-telemetry.github.io/opentelemetry-helm-charts
+  version: 0.140.0
+- name: fluent-bit
+  repository: https://fluent.github.io/helm-charts
+  version: 0.54.0
+digest: sha256:a12824fd08c2113f4943b19b8976d42df52e19c6da4c769e8cae4eba4a88bdbb
+generated: "2026-03-06T09:32:55.660873+05:30"

--- a/observability-logs-moesif/helm/Chart.yaml
+++ b/observability-logs-moesif/helm/Chart.yaml
@@ -1,0 +1,25 @@
+# Copyright 2026 The OpenChoreo Authors
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v2
+name: observability-logs-moesif
+description: A Helm chart for OpenChoreo Moesif Logs module
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+keywords:
+  - moesif
+  - observability
+  - logs
+home: https://github.com/openchoreo/community-modules
+maintainers:
+  - name: Moesif Team
+dependencies:
+  - name: opentelemetry-collector
+    repository: https://open-telemetry.github.io/opentelemetry-helm-charts
+    version: 0.140.0
+    condition: opentelemetry-collector.enabled
+  - name: fluent-bit
+    repository: https://fluent.github.io/helm-charts
+    version: 0.54.0
+    condition: fluent-bit.enabled

--- a/observability-logs-moesif/helm/templates/opentelemetry-collector/configMap.yaml
+++ b/observability-logs-moesif/helm/templates/opentelemetry-collector/configMap.yaml
@@ -1,0 +1,64 @@
+# Copyright 2026 The OpenChoreo Authors
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: opentelemetry-collector-config
+  namespace: {{ .Release.Namespace }}
+data:
+  relay: |
+    extensions:
+      health_check:
+        endpoint: ${env:MY_POD_IP}:13133
+
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:4317
+          http:
+            endpoint: 0.0.0.0:4318
+
+    exporters:
+      {{- range .Values.moesif.apps }}
+      otlphttp/{{ index . "env-name" }}:
+        endpoint: {{ .endpoint | default "https://api.moesif.net" | quote }}
+        headers:
+          {{- if (index . "api-key") }}
+          X-Api-Token: {{ (index . "api-key") | quote }}
+          {{- end }}
+          {{- if (index . "collector-application-id") }}
+          X-Moesif-Application-Id: {{ (index . "collector-application-id") | quote }}
+          {{- end }}
+      {{- end }}
+
+    connectors:
+      routing:
+        table:
+          {{- range .Values.moesif.apps }}
+          - context: resource
+            statement: route() where resource.attributes["openchoreo.dev/environment"] == {{ index . "env-name" | quote }}
+            pipelines: [ logs/{{ index . "env-name" }} ]
+          {{- end }}
+
+    processors:
+      transform:
+        log_statements:
+          - context: resource
+            statements:
+              - set(attributes["service.name"], attributes["openchoreo.dev/component"])
+
+    service:
+      extensions: [health_check]
+      pipelines:
+        logs/in:
+          receivers: [ otlp ]
+          processors: [ transform ]
+          exporters: [ routing ]
+
+        {{- range .Values.moesif.apps }}
+        logs/{{ index . "env-name" }}:
+          receivers: [ routing ]
+          exporters: [ otlphttp/{{ index . "env-name" }} ]
+        {{- end }}

--- a/observability-logs-moesif/helm/templates/opentelemetry-collector/configMap.yaml
+++ b/observability-logs-moesif/helm/templates/opentelemetry-collector/configMap.yaml
@@ -21,25 +21,24 @@ data:
             endpoint: 0.0.0.0:4318
 
     exporters:
-      {{- range .Values.moesif.apps }}
-      otlphttp/{{ index . "env-name" }}:
-        endpoint: {{ .endpoint | default "https://api.moesif.net" | quote }}
+      {{- range .Values.moesif.environments }}
+      otlphttp/{{ . }}:
+        endpoint: {{ $.Values.moesif.endpoint | default "https://api.moesif.net" | quote }}
         headers:
-          {{- if (index . "api-key") }}
-          X-Api-Token: {{ (index . "api-key") | quote }}
-          {{- end }}
-          {{- if (index . "collector-application-id") }}
-          X-Moesif-Application-Id: {{ (index . "collector-application-id") | quote }}
+          {{- if eq $.Values.moesif.auth_mode "api-key" }}
+          X-Api-Token: ${env:api_key}
+          {{- else }}
+          X-Moesif-Application-Id: ${env:{{ . | replace "-" "_" }}}
           {{- end }}
       {{- end }}
 
     connectors:
       routing:
         table:
-          {{- range .Values.moesif.apps }}
+          {{- range .Values.moesif.environments }}
           - context: resource
-            statement: route() where resource.attributes["openchoreo.dev/environment"] == {{ index . "env-name" | quote }}
-            pipelines: [ logs/{{ index . "env-name" }} ]
+            statement: route() where resource.attributes["openchoreo.dev/environment"] == {{ . | quote }}
+            pipelines: [ logs/{{ . }} ]
           {{- end }}
 
     processors:
@@ -57,8 +56,8 @@ data:
           processors: [ transform ]
           exporters: [ routing ]
 
-        {{- range .Values.moesif.apps }}
-        logs/{{ index . "env-name" }}:
+        {{- range .Values.moesif.environments }}
+        logs/{{ . }}:
           receivers: [ routing ]
-          exporters: [ otlphttp/{{ index . "env-name" }} ]
+          exporters: [ otlphttp/{{ . }} ]
         {{- end }}

--- a/observability-logs-moesif/helm/values.yaml
+++ b/observability-logs-moesif/helm/values.yaml
@@ -22,7 +22,7 @@ fluent-bit:
           Skip_Long_Lines     On
           Buffer_Chunk_Size   32KB
           Buffer_Max_Size     2MB
-          Mem_Buf_Limit       256MB
+          Mem_Buf_Limit       128MB
           Inotify_Watcher     false
 
     filters: |
@@ -133,14 +133,7 @@ opentelemetry-collector:
   enabled: true
 
   clusterRole:
-    create: true
-    rules:
-      - apiGroups: [""]
-        resources: ["pods"]
-        verbs: ["list", "watch"]
-      - apiGroups: ["apps"]
-        resources: ["replicasets"]
-        verbs: ["list", "watch"]
+    create: false
 
   configMap:
     create: false
@@ -166,4 +159,4 @@ opentelemetry-collector:
       memory: 100Mi
 
   service:
-    type: LoadBalancer
+    type: ClusterIP

--- a/observability-logs-moesif/helm/values.yaml
+++ b/observability-logs-moesif/helm/values.yaml
@@ -153,6 +153,10 @@ opentelemetry-collector:
 
   mode: deployment
 
+  extraEnvsFrom:
+    - secretRef:
+        name: moesif-app-secret
+
   resources:
     limits:
       cpu: 100m

--- a/observability-logs-moesif/helm/values.yaml
+++ b/observability-logs-moesif/helm/values.yaml
@@ -1,0 +1,165 @@
+# Copyright 2026 The OpenChoreo Authors
+# SPDX-License-Identifier: Apache-2.0
+
+
+## -----------------------------------------------------------
+## Values for fluent-bit configuration
+## -----------------------------------------------------------
+fluent-bit:
+  enabled: true
+
+  config:
+    inputs: |
+      [INPUT]
+          Name                tail
+          Tag                 kube.*
+          Path                /var/log/containers/*.log
+          Exclude_Path        /var/log/containers/fluent-bit-*.log
+          DB                  /var/lib/fluent-bit/db/tail-container-logs.db
+          multiline.parser    docker, cri
+          Read_from_Head      On
+          Refresh_Interval    5
+          Skip_Long_Lines     On
+          Buffer_Chunk_Size   32KB
+          Buffer_Max_Size     2MB
+          Mem_Buf_Limit       256MB
+          Inotify_Watcher     false
+
+    filters: |
+      [FILTER]
+          Name                kubernetes
+          Match               kube.*
+          Kube_Tag_Prefix     kube.var.log.containers.
+          Merge_Log           On
+          Keep_Log            Off
+          Labels              On
+          Annotations         Off
+      
+      [FILTER]
+          Name                nest
+          Match               kube.*
+          Operation           lift
+          Nested_under        kubernetes
+          Add_prefix          k8s_
+      
+      [FILTER]
+          Name                modify
+          Match               kube.*
+          RENAME              k8s_labels attributes
+      
+      [FILTER]
+          Name                nest
+          Match               kube.*
+          Operation           nest
+          Wildcard            attributes
+          Nest_under          resource
+
+    outputs: |
+      [OUTPUT]
+          Name                           opentelemetry
+          Match                          kube.*
+          Host                           opentelemetry-collector
+          Port                           4318
+          TLS                            Off
+          TLS.Verify                     Off
+          logs_uri                       /v1/logs
+          Log_response_payload           True
+          logs_resource_metadata_key     resource
+
+  dnsPolicy: ClusterFirstWithHostNet
+  fullnameOverride: "fluent-bit"
+  hostNetwork: true
+
+  extraVolumeMounts:
+    - name: db
+      mountPath: "/var/lib/fluent-bit/db"
+      readOnly: false
+
+  extraVolumes:
+    - name: db
+      hostPath:
+        path: /var/lib/fluent-bit/db
+        type: DirectoryOrCreate
+
+  rbac:
+    nodeAccess: true
+
+  resources:
+    limits:
+      cpu: 200m
+      memory: 256Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    runAsUser: 10000
+
+  testFramework:
+    enabled: false
+
+  initContainers:
+    - name: set-volume-ownership
+      image: busybox
+      command: ["sh", "-c", "chown -R 10000:10000 /var/lib/fluent-bit/db"]
+      resources:
+        limits:
+          cpu: 15m
+          memory: "32Mi"
+        requests:
+          cpu: 10m
+          memory: "24Mi"
+      securityContext:
+        capabilities:
+          drop:
+            - ALL
+        privileged: true
+        readOnlyRootFilesystem: true
+        runAsUser: 0
+      volumeMounts:
+        - name: db
+          mountPath: /var/lib/fluent-bit/db
+
+## -----------------------------------------------------------
+## Values for OpenTelemetry Collector configuration
+## -----------------------------------------------------------
+opentelemetry-collector:
+  enabled: true
+
+  clusterRole:
+    create: true
+    rules:
+      - apiGroups: [""]
+        resources: ["pods"]
+        verbs: ["list", "watch"]
+      - apiGroups: ["apps"]
+        resources: ["replicasets"]
+        verbs: ["list", "watch"]
+
+  configMap:
+    create: false
+    existingName: "opentelemetry-collector-config"
+
+  fullnameOverride: "opentelemetry-collector"
+
+  image:
+    repository: otel/opentelemetry-collector-contrib
+
+  mode: deployment
+
+  resources:
+    limits:
+      cpu: 100m
+      memory: 200Mi
+    requests:
+      cpu: 50m
+      memory: 100Mi
+
+  service:
+    type: LoadBalancer

--- a/observability-logs-moesif/module.yaml
+++ b/observability-logs-moesif/module.yaml
@@ -1,0 +1,8 @@
+# Copyright 2026 The OpenChoreo Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Module manifest used by the CI workflow to discover Docker images to build.
+# Each entry defines the image name, build context, Dockerfile path, and the
+# corresponding field in helm/values.yaml to update with the published image URI.
+
+images: []


### PR DESCRIPTION
- Adding Moesif logs module

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds an Observability Logs module with Helm install for Moesif; deploys Fluent Bit and OpenTelemetry Collector, supports multi-environment log routing with per-environment ingestion and optional endpoint/secret-based credentials.

* **Documentation**
  * Adds a comprehensive README with prerequisites, Helm install/values examples, multi-environment configuration, troubleshooting tips, and uninstall instructions.

* **Chores**
  * Adds Helm packaging ignore rules and chart metadata for distribution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->