### PR TITLE
fix: update the default port of OpenObserve tracing adapter's HTTP server

### DIFF
--- a/observability-tracing-openobserve/README.md
+++ b/observability-tracing-openobserve/README.md
@@ -26,7 +26,7 @@ helm upgrade --install observability-tracing-openobserve \
   oci://ghcr.io/openchoreo/charts/observability-tracing-openobserve \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.1.0
+  --version 0.1.1
 ```
 
 > **Note:** If OpenObserve is already installed by another module (e.g., `observability-logs-openobserve`), disable it to avoid conflicts:
@@ -36,6 +36,6 @@ helm upgrade --install observability-tracing-openobserve \
 >  oci://ghcr.io/openchoreo/charts/observability-tracing-openobserve \
 >  --create-namespace \
 >  --namespace openchoreo-observability-plane \
->  --version 0.1.0 \
+>  --version 0.1.1 \
 >  --set openObserve.enabled=false
 >```

--- a/observability-tracing-openobserve/helm/Chart.yaml
+++ b/observability-tracing-openobserve/helm/Chart.yaml
@@ -5,8 +5,8 @@ apiVersion: v2
 name: observability-tracing-openobserve
 description: A Helm chart for OpenChoreo Tracing Module for OpenObserve
 type: application
-version: 0.1.0
-appVersion: "0.1.0"
+version: 0.1.1
+appVersion: "0.1.1"
 keywords:
   - openobserve
   - openchoreo

--- a/observability-tracing-openobserve/helm/templates/adapter/deployment.yaml
+++ b/observability-tracing-openobserve/helm/templates/adapter/deployment.yaml
@@ -30,9 +30,9 @@ spec:
         - containerPort: 9100
         env:
         - name: SERVER_PORT
-          value: "9100"
+          value: {{ .Values.adapter.serverPort | quote }}
         - name: OPENOBSERVE_URL
-          value: "http://openobserve:5080"
+          value: {{ .Values.adapter.openObserveUrl | quote }}
         - name: OPENOBSERVE_ORG
           value: {{ .Values.common.openObserveOrg | quote }}
         - name: OPENOBSERVE_STREAM

--- a/observability-tracing-openobserve/helm/values.yaml
+++ b/observability-tracing-openobserve/helm/values.yaml
@@ -77,6 +77,7 @@ adapter:
   image:
     repository: "ghcr.io/openchoreo/observability-tracing-openobserve-adapter"
     tag: ""  # Defaults to Chart.AppVersion via the template
+  openObserveUrl: "http://openobserve:5080"
   resources:
     limits:
       cpu: 200m
@@ -84,6 +85,7 @@ adapter:
     requests:
       cpu: 50m
       memory: 128Mi
+  serverPort: 9100
 
 
 opentelemetryCollectorCustomizations:

--- a/observability-tracing-openobserve/internal/config.go
+++ b/observability-tracing-openobserve/internal/config.go
@@ -23,7 +23,7 @@ type Config struct {
 
 // LoadConfig loads configuration from environment variables
 func LoadConfig() (*Config, error) {
-	serverPort := getEnv("SERVER_PORT", "9099")
+	serverPort := getEnv("SERVER_PORT", "9100")
 	openObserveURL := getEnv("OPENOBSERVE_URL", "")
 	openObserveOrg := getEnv("OPENOBSERVE_ORG", "default")
 	openObserveStream := getEnv("OPENOBSERVE_STREAM", "default")


### PR DESCRIPTION
## Purpose
https://github.com/openchoreo/openchoreo/issues/2203

## Goals
change the default port of OpenObserve tracing adapter's HTTP server from 9099 to 9100 to be consistent with Kubernetes deployment manifests. Also 9099 is to be used for metrics adapters

## Approach
Updated the default value of the environment variable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Helm chart version bumped to 0.1.1
  * Default server port updated to 9100

* **New Features**
  * Adapter now exposes configurable server port and OpenObserve URL via chart values, enabling runtime customization without code changes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->