### PR TITLE
feat: add instructions on how to enable logs and tracing adapters in observer

### DIFF
--- a/observability-logs-openobserve/README.md
+++ b/observability-logs-openobserve/README.md
@@ -4,7 +4,8 @@ This module collects container logs using Fluent Bit and stores them in OpenObse
 
 ## Prerequisites
 
-- [OpenChoreo](https://github.com/openchoreo/openchoreo) must be installed with the **observability plane** enabled for this module to work.
+- [OpenChoreo](https://github.com/openchoreo/openchoreo) must be installed with the **observability plane** enabled for this module to work. Deploy the `openchoreo-observability-plane` helm chart with the helm value `observer.logsAdapter.enabled="true"` to enable the observer to fetch data from this logs module.
+
 
 ## Installation
 

--- a/observability-tracing-openobserve/README.md
+++ b/observability-tracing-openobserve/README.md
@@ -4,7 +4,7 @@ This module collects distributed traces using OpenTelemetry collector and stores
 
 ## Prerequisites
 
-- [OpenChoreo](https://github.com/openchoreo/openchoreo) must be installed with the **observability plane** enabled for this module to work.
+- [OpenChoreo](https://github.com/openchoreo/openchoreo) must be installed with the **observability plane** enabled for this module to work. Deploy the `openchoreo-observability-plane` helm chart with the helm value `observer.tracingAdapter.enabled="true"` to enable the observer to fetch data from this tracing module.
 
 ## Installation
 


### PR DESCRIPTION
## Purpose
https://github.com/openchoreo/openchoreo/issues/2203

## Goals
Update instructions on how to use OpenObserve modules

## Approach
Added instructions on how to enable logs and tracing modules in observer


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated prerequisites and deployment instructions for observability modules to include deploying the observability plane and enabling observer adapters for collecting logs and tracing data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->