### PR TITLE
update path of helm charts published to GitHub container registry

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -135,8 +135,8 @@ jobs:
 
             helm package "${chart_dir}" -d .packages
 
-            echo "Pushing ${chart_name}:${CHART_VERSION} to ghcr.io/${REPO_OWNER}/charts..."
-            helm push ".packages/${chart_name}-${CHART_VERSION}.tgz" "oci://ghcr.io/${REPO_OWNER}/charts"
+            echo "Pushing ${chart_name}:${CHART_VERSION} to ghcr.io/${REPO_OWNER}/helm-charts..."
+            helm push ".packages/${chart_name}-${CHART_VERSION}.tgz" "oci://ghcr.io/${REPO_OWNER}/helm-charts"
 
             echo "::endgroup::"
           done

--- a/observability-logs-openobserve/README.md
+++ b/observability-logs-openobserve/README.md
@@ -24,7 +24,7 @@ Install this module in your OpenChoreo cluster using:
 
 ```bash
 helm upgrade --install observability-logs-openobserve \
-  oci://ghcr.io/openchoreo/charts/observability-logs-openobserve \
+  oci://ghcr.io/openchoreo/helm-charts/observability-logs-openobserve \
   --create-namespace \
   --namespace openchoreo-observability-plane \
   --version 0.2.1
@@ -36,7 +36,7 @@ Enable Fluent Bit to start collecting logs from the cluster and publish to OpenO
 
 ```bash
 helm upgrade observability-logs-openobserve \
-  oci://ghcr.io/openchoreo/charts/observability-logs-openobserve \
+  oci://ghcr.io/openchoreo/helm-charts/observability-logs-openobserve \
   --namespace openchoreo-observability-plane \
   --version 0.2.1 \
   --reuse-values \

--- a/observability-logs-opensearch/README.md
+++ b/observability-logs-opensearch/README.md
@@ -54,7 +54,7 @@ helm install opensearch-operator opensearch-operator/opensearch-operator \
 
 ```bash
 helm upgrade --install observability-logs-opensearch \
-  oci://ghcr.io/openchoreo/charts/observability-logs-opensearch \
+  oci://ghcr.io/openchoreo/helm-charts/observability-logs-opensearch \
   --create-namespace \
   --namespace openchoreo-observability-plane \
   --version 0.3.2 \
@@ -65,7 +65,7 @@ helm upgrade --install observability-logs-opensearch \
 >
 > ```bash
 > helm upgrade --install observability-logs-opensearch \
->   oci://ghcr.io/openchoreo/charts/observability-logs-opensearch \
+>   oci://ghcr.io/openchoreo/helm-charts/observability-logs-opensearch \
 >   --create-namespace \
 >   --namespace openchoreo-observability-plane \
 >   --version 0.3.2 \
@@ -79,7 +79,7 @@ Enable Fluent Bit to start collecting logs from the cluster and publish to OpenS
 
 ```bash
 helm upgrade observability-logs-opensearch \
-  oci://ghcr.io/openchoreo/charts/observability-logs-opensearch \
+  oci://ghcr.io/openchoreo/helm-charts/observability-logs-opensearch \
   --create-namespace \
   --namespace openchoreo-observability-plane \
   --version 0.3.2 \

--- a/observability-metrics-prometheus/README.md
+++ b/observability-metrics-prometheus/README.md
@@ -12,7 +12,7 @@ Install this module in your OpenChoreo cluster using:
 
 ```bash
 helm install observability-metrics-prometheus \
-  oci://ghcr.io/openchoreo/charts/observability-metrics-prometheus \
+  oci://ghcr.io/openchoreo/helm-charts/observability-metrics-prometheus \
   --create-namespace \
   --namespace openchoreo-observability-plane \
   --version 0.2.2

--- a/observability-tracing-openobserve/README.md
+++ b/observability-tracing-openobserve/README.md
@@ -23,7 +23,7 @@ Install this module in your OpenChoreo cluster using:
 
 ```bash
 helm upgrade --install observability-tracing-openobserve \
-  oci://ghcr.io/openchoreo/charts/observability-tracing-openobserve \
+  oci://ghcr.io/openchoreo/helm-charts/observability-tracing-openobserve \
   --create-namespace \
   --namespace openchoreo-observability-plane \
   --version 0.1.1
@@ -33,7 +33,7 @@ helm upgrade --install observability-tracing-openobserve \
 >
 > ```bash
 > helm upgrade --install observability-tracing-openobserve \
->  oci://ghcr.io/openchoreo/charts/observability-tracing-openobserve \
+>  oci://ghcr.io/openchoreo/helm-charts/observability-tracing-openobserve \
 >  --create-namespace \
 >  --namespace openchoreo-observability-plane \
 >  --version 0.1.1 \

--- a/observability-tracing-opensearch/README.md
+++ b/observability-tracing-opensearch/README.md
@@ -54,7 +54,7 @@ helm install opensearch-operator opensearch-operator/opensearch-operator \
 
 ```bash
 helm upgrade --install observability-tracing-opensearch \
-  oci://ghcr.io/openchoreo/charts/observability-tracing-opensearch \
+  oci://ghcr.io/openchoreo/helm-charts/observability-tracing-opensearch \
   --create-namespace \
   --namespace openchoreo-observability-plane \
   --version 0.3.3 \
@@ -65,7 +65,7 @@ helm upgrade --install observability-tracing-opensearch \
 >
 > ```bash
 > helm upgrade --install observability-tracing-opensearch \
->   oci://ghcr.io/openchoreo/charts/observability-tracing-opensearch \
+>   oci://ghcr.io/openchoreo/helm-charts/observability-tracing-opensearch \
 >   --create-namespace \
 >   --namespace openchoreo-observability-plane \
 >   --version 0.3.3 \


### PR DESCRIPTION
## Purpose
https://github.com/openchoreo/openchoreo/issues/2501

## Goals
Make the path of helm charts consistent across openchoreo org

## Approach
Updated the helm push command in workflow script


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Helm chart publication location

<!-- end of auto-generated comment: release notes by coderabbit.ai -->