### PR TITLE
refactor: rename sort to sortOrder in tracing adapter API

### DIFF
--- a/observability-tracing-openobserve/README.md
+++ b/observability-tracing-openobserve/README.md
@@ -26,7 +26,7 @@ helm upgrade --install observability-tracing-openobserve \
   oci://ghcr.io/openchoreo/helm-charts/observability-tracing-openobserve \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.1.1
+  --version 0.1.2
 ```
 
 > **Note:** If OpenObserve is already installed by another module (e.g., `observability-logs-openobserve`), disable it to avoid conflicts:
@@ -36,6 +36,6 @@ helm upgrade --install observability-tracing-openobserve \
 >  oci://ghcr.io/openchoreo/helm-charts/observability-tracing-openobserve \
 >  --create-namespace \
 >  --namespace openchoreo-observability-plane \
->  --version 0.1.1 \
+>  --version 0.1.2 \
 >  --set openObserve.enabled=false
 >```

--- a/observability-tracing-openobserve/helm/Chart.yaml
+++ b/observability-tracing-openobserve/helm/Chart.yaml
@@ -5,8 +5,8 @@ apiVersion: v2
 name: observability-tracing-openobserve
 description: A Helm chart for OpenChoreo Tracing Module for OpenObserve
 type: application
-version: 0.1.1
-appVersion: "0.1.1"
+version: 0.1.2
+appVersion: "0.1.2"
 keywords:
   - openobserve
   - openchoreo

--- a/observability-tracing-openobserve/internal/api/gen/models.gen.go
+++ b/observability-tracing-openobserve/internal/api/gen/models.gen.go
@@ -19,10 +19,10 @@ const (
 	Unauthorized        ErrorResponseTitle = "unauthorized"
 )
 
-// Defines values for TracesQueryRequestSort.
+// Defines values for TracesQueryRequestSortOrder.
 const (
-	Asc  TracesQueryRequestSort = "asc"
-	Desc TracesQueryRequestSort = "desc"
+	Asc  TracesQueryRequestSortOrder = "asc"
+	Desc TracesQueryRequestSortOrder = "desc"
 )
 
 // ComponentSearchScope defines model for ComponentSearchScope.
@@ -162,15 +162,15 @@ type TracesQueryRequest struct {
 	Limit       *int                 `json:"limit,omitempty"`
 	SearchScope ComponentSearchScope `json:"searchScope"`
 
-	// Sort The sort order of the query
-	Sort *TracesQueryRequestSort `json:"sort,omitempty"`
+	// SortOrder The sort order of the query
+	SortOrder *TracesQueryRequestSortOrder `json:"sortOrder,omitempty"`
 
 	// StartTime The start time of the query
 	StartTime time.Time `json:"startTime"`
 }
 
-// TracesQueryRequestSort The sort order of the query
-type TracesQueryRequestSort string
+// TracesQueryRequestSortOrder The sort order of the query
+type TracesQueryRequestSortOrder string
 
 // QueryTracesJSONRequestBody defines body for QueryTraces for application/json ContentType.
 type QueryTracesJSONRequestBody = TracesQueryRequest

--- a/observability-tracing-openobserve/internal/handlers.go
+++ b/observability-tracing-openobserve/internal/handlers.go
@@ -138,8 +138,8 @@ func toTracesQueryParams(req *gen.TracesQueryRequest) openobserve.TracesQueryPar
 	if req.Limit != nil {
 		params.Limit = *req.Limit
 	}
-	if req.Sort != nil {
-		params.Sort = string(*req.Sort)
+	if req.SortOrder != nil {
+		params.SortOrder = string(*req.SortOrder)
 	}
 	if req.SearchScope.Project != nil {
 		params.Scope.ProjectID = *req.SearchScope.Project

--- a/observability-tracing-openobserve/internal/openobserve/client.go
+++ b/observability-tracing-openobserve/internal/openobserve/client.go
@@ -28,7 +28,7 @@ type TracesQueryParams struct {
 	StartTime time.Time `json:"startTime"`
 	EndTime   time.Time `json:"endTime"`
 	Limit     int       `json:"limit"`
-	Sort      string    `json:"sort"`
+	SortOrder string    `json:"sortOrder"`
 	Scope     Scope     `json:"scope"`
 	TraceID   string    `json:"-"`
 	SpanID    string    `json:"-"`

--- a/observability-tracing-openobserve/internal/openobserve/queries.go
+++ b/observability-tracing-openobserve/internal/openobserve/queries.go
@@ -60,7 +60,7 @@ func generateTracesListQuery(params TracesQueryParams, stream string, logger *sl
 	}
 
 	// Add sort order
-	if params.Sort == "asc" || params.Sort == "ASC" {
+	if params.SortOrder == "asc" || params.SortOrder == "ASC" {
 		sql += " ORDER BY start_time ASC"
 	} else {
 		sql += " ORDER BY start_time DESC"
@@ -112,7 +112,7 @@ func generateSpansListQuery(params TracesQueryParams, stream string, logger *slo
 	)
 
 	// Add sort order
-	if params.Sort == "asc" || params.Sort == "ASC" {
+	if params.SortOrder == "asc" || params.SortOrder == "ASC" {
 		sql += " ORDER BY start_time ASC"
 	} else {
 		sql += " ORDER BY start_time DESC"

--- a/observability-tracing-openobserve/openapi/openapi.yaml
+++ b/observability-tracing-openobserve/openapi/openapi.yaml
@@ -270,7 +270,7 @@ components:
           minimum: 1
           maximum: 1000
           description: The maximum number of items to return
-        sort:
+        sortOrder:
           type: string
           description: The sort order of the query
           enum:


### PR DESCRIPTION
## Summary
- Rename `sort` to `sortOrder` in the tracing OpenObserve adapter to align with the upstream observer API change (openchoreo/openchoreo@c709ef4)

## Changes
- Updated OpenAPI spec field name from `sort` to `sortOrder`
- Renamed `TracesQueryRequestSort` type to `TracesQueryRequestSortOrder` in generated models
- Updated all references in handlers, query builder, and client structs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **API Changes**
  * Renamed the sort parameter to sortOrder in traces query requests for improved naming consistency.

* **Documentation**
  * Updated README examples to reflect a version bump.

* **Chores**
  * Bumped chart package version and application version to 0.1.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->