### PR TITLE
chore: upgrade helm chart dependencies

### DIFF
--- a/observability-logs-openobserve/README.md
+++ b/observability-logs-openobserve/README.md
@@ -27,7 +27,7 @@ helm upgrade --install observability-logs-openobserve \
   oci://ghcr.io/openchoreo/helm-charts/observability-logs-openobserve \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.3.2
+  --version 0.3.3
 ```
 
 ## Enable log collection
@@ -38,7 +38,7 @@ Enable Fluent Bit to start collecting logs from the cluster and publish to OpenO
 helm upgrade observability-logs-openobserve \
   oci://ghcr.io/openchoreo/helm-charts/observability-logs-openobserve \
   --namespace openchoreo-observability-plane \
-  --version 0.3.2 \
+  --version 0.3.3 \
   --reuse-values \
   --set fluent-bit.enabled=true
 ```

--- a/observability-logs-openobserve/helm/Chart.lock
+++ b/observability-logs-openobserve/helm/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: fluent-bit
   repository: https://fluent.github.io/helm-charts
-  version: 0.48.0
-digest: sha256:3c022df812429962972a2648527ef1a317a0879d1f82388d3cee3f4b4dace318
-generated: "2026-01-28T11:30:52.542502+05:30"
+  version: 0.56.0
+digest: sha256:e120960dbb5fbcfb6bccdd7bb486bd94fd013387bfd4490fada383d43f492cf5
+generated: "2026-03-09T12:36:21.83531+05:30"

--- a/observability-logs-openobserve/helm/Chart.yaml
+++ b/observability-logs-openobserve/helm/Chart.yaml
@@ -5,8 +5,8 @@ apiVersion: v2
 name: observability-logs-openobserve
 description: A Helm chart for OpenChoreo Logs Module for OpenObserve
 type: application
-version: 0.3.2
-appVersion: "0.3.2"
+version: 0.3.3
+appVersion: "0.3.3"
 keywords:
   - openobserve
   - openchoreo
@@ -16,6 +16,6 @@ maintainers:
 home: https://github.com/openchoreo/community-modules
 dependencies:
   - name: fluent-bit
-    version: "0.48.0"
+    version: "0.56.0"
     repository: https://fluent.github.io/helm-charts
     condition: fluent-bit.enabled

--- a/observability-logs-opensearch/README.md
+++ b/observability-logs-opensearch/README.md
@@ -57,7 +57,7 @@ helm upgrade --install observability-logs-opensearch \
   oci://ghcr.io/openchoreo/helm-charts/observability-logs-opensearch \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.3.3 \
+  --version 0.3.5 \
   --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials"
 ```
 
@@ -68,7 +68,7 @@ helm upgrade --install observability-logs-opensearch \
 >   oci://ghcr.io/openchoreo/helm-charts/observability-logs-opensearch \
 >   --create-namespace \
 >   --namespace openchoreo-observability-plane \
->   --version 0.3.3 \
+>   --version 0.3.5 \
 >   --set openSearch.enabled=false \
 >   --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials"
 > ```
@@ -82,7 +82,7 @@ helm upgrade observability-logs-opensearch \
   oci://ghcr.io/openchoreo/helm-charts/observability-logs-opensearch \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.3.3 \
+  --version 0.3.5 \
   --reuse-values \
   --set fluent-bit.enabled=true
 ```

--- a/observability-logs-opensearch/helm/Chart.lock
+++ b/observability-logs-opensearch/helm/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 3.3.0
 - name: fluent-bit
   repository: https://fluent.github.io/helm-charts
-  version: 0.54.0
-digest: sha256:4861e6e8f360efd522d323592981162ca1bd9b0e54af9ed414a4965a98d0a56f
-generated: "2026-02-12T00:10:11.68638+05:30"
+  version: 0.56.0
+digest: sha256:2545d53be9380f982afe7f1095ae7ed0dd76704aa9f8e2001f768d2352252546
+generated: "2026-03-09T12:36:46.795126+05:30"

--- a/observability-logs-opensearch/helm/Chart.yaml
+++ b/observability-logs-opensearch/helm/Chart.yaml
@@ -5,8 +5,8 @@ apiVersion: v2
 name: observability-logs-opensearch
 description: A Helm chart for OpenChoreo Observability Logs module with Fluent Bit and OpenSearch
 type: application
-version: 0.3.4
-appVersion: "0.3.4"
+version: 0.3.5
+appVersion: "0.3.5"
 keywords:
   - opensearch
   - observability
@@ -22,5 +22,5 @@ dependencies:
     condition: openSearch.enabled
   - name: fluent-bit
     repository: https://fluent.github.io/helm-charts
-    version: 0.54.0
+    version: 0.56.0
     condition: fluent-bit.enabled

--- a/observability-metrics-prometheus/README.md
+++ b/observability-metrics-prometheus/README.md
@@ -15,5 +15,5 @@ helm install observability-metrics-prometheus \
   oci://ghcr.io/openchoreo/helm-charts/observability-metrics-prometheus \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.2.3
+  --version 0.2.4
 ```

--- a/observability-metrics-prometheus/helm/Chart.lock
+++ b/observability-metrics-prometheus/helm/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: kube-prometheus-stack
   repository: https://prometheus-community.github.io/helm-charts
-  version: 78.3.0
-digest: sha256:2b6bea4602a34743d2a89386645648fc46e564e9b55340f43bbb62b84a3d66a6
-generated: "2026-02-12T15:21:39.040575+05:30"
+  version: 81.6.3
+digest: sha256:c5fc872d6ffdcbceeb5ea2c5727dd5e091df4b50fca4bdcb34eb9422e3cf7ae8
+generated: "2026-03-09T12:37:22.330724+05:30"

--- a/observability-metrics-prometheus/helm/Chart.yaml
+++ b/observability-metrics-prometheus/helm/Chart.yaml
@@ -5,8 +5,8 @@ apiVersion: v2
 name: observability-metrics-prometheus
 description: A Helm chart for OpenChoreo Observability Metrics module based on Prometheus
 type: application
-version: 0.2.3
-appVersion: "0.2.3"
+version: 0.2.4
+appVersion: "0.2.4"
 keywords:
   - prometheus
   - observability
@@ -17,5 +17,5 @@ maintainers:
 dependencies:
   - name: kube-prometheus-stack
     repository: https://prometheus-community.github.io/helm-charts
-    version: 78.3.0
+    version: 81.6.3
     condition: kube-prometheus-stack.enabled

--- a/observability-tracing-openobserve/README.md
+++ b/observability-tracing-openobserve/README.md
@@ -26,7 +26,7 @@ helm upgrade --install observability-tracing-openobserve \
   oci://ghcr.io/openchoreo/helm-charts/observability-tracing-openobserve \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.1.3
+  --version 0.1.4
 ```
 
 > **Note:** If OpenObserve is already installed by another module (e.g., `observability-logs-openobserve`), disable it to avoid conflicts:
@@ -36,6 +36,6 @@ helm upgrade --install observability-tracing-openobserve \
 >  oci://ghcr.io/openchoreo/helm-charts/observability-tracing-openobserve \
 >  --create-namespace \
 >  --namespace openchoreo-observability-plane \
->  --version 0.1.3 \
+>  --version 0.1.4 \
 >  --set openObserve.enabled=false
 >```

--- a/observability-tracing-openobserve/helm/Chart.lock
+++ b/observability-tracing-openobserve/helm/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: opentelemetry-collector
   repository: https://open-telemetry.github.io/opentelemetry-helm-charts
-  version: 0.140.0
-digest: sha256:95b44d32f6aa013cfb900bb0a34e42551bf87c4891cabba2cfc56b1898c13a3b
-generated: "2026-02-24T15:18:38.443507+05:30"
+  version: 0.146.1
+digest: sha256:5c2e1ccda7de58680e652026f89d9f8c004493920cef11720fd8b2da584195ff
+generated: "2026-03-09T12:37:55.691904+05:30"

--- a/observability-tracing-openobserve/helm/Chart.yaml
+++ b/observability-tracing-openobserve/helm/Chart.yaml
@@ -5,8 +5,8 @@ apiVersion: v2
 name: observability-tracing-openobserve
 description: A Helm chart for OpenChoreo Tracing Module for OpenObserve
 type: application
-version: 0.1.3
-appVersion: "0.1.3"
+version: 0.1.4
+appVersion: "0.1.4"
 keywords:
   - openobserve
   - openchoreo
@@ -17,5 +17,5 @@ home: https://github.com/openchoreo/community-modules
 dependencies:
   - name: opentelemetry-collector
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts
-    version: 0.140.0
+    version: 0.146.1
     condition: opentelemetry-collector.enabled

--- a/observability-tracing-opensearch/README.md
+++ b/observability-tracing-opensearch/README.md
@@ -57,7 +57,7 @@ helm upgrade --install observability-tracing-opensearch \
   oci://ghcr.io/openchoreo/helm-charts/observability-tracing-opensearch \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.3.3 \
+  --version 0.3.5 \
   --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials"
 ```
 
@@ -68,7 +68,7 @@ helm upgrade --install observability-tracing-opensearch \
 >   oci://ghcr.io/openchoreo/helm-charts/observability-tracing-opensearch \
 >   --create-namespace \
 >   --namespace openchoreo-observability-plane \
->   --version 0.3.3 \
+>   --version 0.3.5 \
 >   --set openSearch.enabled=false \
 >   --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials"
 > ```

--- a/observability-tracing-opensearch/helm/Chart.lock
+++ b/observability-tracing-opensearch/helm/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 3.3.0
 - name: opentelemetry-collector
   repository: https://open-telemetry.github.io/opentelemetry-helm-charts
-  version: 0.140.0
-digest: sha256:b23203e9d12f22cb3ee2b2567da712a6f7d11e10ca79af1bc9f041f48ffb04cb
-generated: "2026-02-13T13:19:57.697783+05:30"
+  version: 0.146.1
+digest: sha256:f70cc7eeaf304d3090b50f01c2c5f22c8ba74c42c1b603803b0d1970aa37403d
+generated: "2026-03-09T12:37:49.059589+05:30"

--- a/observability-tracing-opensearch/helm/Chart.yaml
+++ b/observability-tracing-opensearch/helm/Chart.yaml
@@ -5,8 +5,8 @@ apiVersion: v2
 name: observability-tracing-opensearch
 description: A Helm chart for OpenChoreo Observability Tracing module with OpenTelemetry Collector and OpenSearch
 type: application
-version: 0.3.4
-appVersion: "0.3.4"
+version: 0.3.5
+appVersion: "0.3.5"
 keywords:
   - opensearch
   - observability
@@ -22,5 +22,5 @@ dependencies:
     condition: openSearch.enabled
   - name: opentelemetry-collector
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts
-    version: 0.140.0
+    version: 0.146.1
     condition: opentelemetry-collector.enabled


### PR DESCRIPTION
Upgrades helm chart dependencies across observability modules:

- fluent-bit: 0.48.0/0.54.0 → 0.56.0
- kube-prometheus-stack: 78.3.0 → 81.6.3
- opentelemetry-collector: 0.140.0 → 0.146.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped multiple observability Helm chart versions.
  * Updated chart dependencies to newer releases for Fluent Bit, Prometheus stack, and OpenTelemetry Collector.
  * Applied these updates across logs, metrics, and tracing charts (both OpenSearch and OpenObserve variants).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->