### PR TITLE
feat: add webhook API and GET and UPDATE APIs for alert rules in OpenObserve

### DIFF
--- a/observability-logs-openobserve/README.md
+++ b/observability-logs-openobserve/README.md
@@ -27,7 +27,7 @@ helm upgrade --install observability-logs-openobserve \
   oci://ghcr.io/openchoreo/helm-charts/observability-logs-openobserve \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.2.2
+  --version 0.3.0
 ```
 
 ## Enable log collection
@@ -38,7 +38,7 @@ Enable Fluent Bit to start collecting logs from the cluster and publish to OpenO
 helm upgrade observability-logs-openobserve \
   oci://ghcr.io/openchoreo/helm-charts/observability-logs-openobserve \
   --namespace openchoreo-observability-plane \
-  --version 0.2.2 \
+  --version 0.3.0 \
   --reuse-values \
   --set fluent-bit.enabled=true
 ```

--- a/observability-logs-openobserve/helm/Chart.yaml
+++ b/observability-logs-openobserve/helm/Chart.yaml
@@ -5,8 +5,8 @@ apiVersion: v2
 name: observability-logs-openobserve
 description: A Helm chart for OpenChoreo Logs Module for OpenObserve
 type: application
-version: 0.2.2
-appVersion: "0.2.2"
+version: 0.3.0
+appVersion: "0.3.0"
 keywords:
   - openobserve
   - openchoreo

--- a/observability-logs-openobserve/helm/templates/adapter/configmap.yaml
+++ b/observability-logs-openobserve/helm/templates/adapter/configmap.yaml
@@ -1,0 +1,16 @@
+# Copyright 2026 The OpenChoreo Authors
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: logs-adapter-openobserve
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: logs-adapter-openobserve
+data:
+  SERVER_PORT: "9098"
+  OPENOBSERVE_URL: "http://openobserve:5080"
+  OPENOBSERVE_ORG: {{ .Values.common.openObserveOrg | quote }}
+  OPENOBSERVE_STREAM: {{ .Values.common.openObserveStream | quote }}
+  OBSERVER_URL: {{ .Values.adapter.observerUrl | quote }}

--- a/observability-logs-openobserve/helm/templates/adapter/deployment.yaml
+++ b/observability-logs-openobserve/helm/templates/adapter/deployment.yaml
@@ -15,6 +15,8 @@ spec:
       app: logs-adapter-openobserve
   template:
     metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/adapter/configmap.yaml") . | sha256sum }}
       labels:
         app: logs-adapter-openobserve
     spec:
@@ -28,15 +30,10 @@ spec:
         imagePullPolicy: {{ .Values.adapter.image.pullPolicy | default "IfNotPresent" }}
         ports:
         - containerPort: 9098
+        envFrom:
+        - configMapRef:
+            name: logs-adapter-openobserve
         env:
-        - name: SERVER_PORT
-          value: "9098"
-        - name: OPENOBSERVE_URL
-          value: "http://openobserve:5080"
-        - name: OPENOBSERVE_ORG
-          value: {{ .Values.common.openObserveOrg | quote }}
-        - name: OPENOBSERVE_STREAM
-          value: {{ .Values.common.openObserveStream | quote }}
         - name: OPENOBSERVE_USER
           valueFrom:
             secretKeyRef:

--- a/observability-logs-openobserve/helm/values.yaml
+++ b/observability-logs-openobserve/helm/values.yaml
@@ -154,6 +154,7 @@ openObserve:
 ## -----------------------------------------------------------
 
 adapter:
+  observerUrl: "http://observer-internal.openchoreo-observability-plane:8081"
   image:
     repository: "ghcr.io/openchoreo/observability-logs-openobserve-adapter"
     tag: "latest"

--- a/observability-logs-openobserve/init/setup-openobserve.sh
+++ b/observability-logs-openobserve/init/setup-openobserve.sh
@@ -94,7 +94,7 @@ fi
 ## 3. Create a webhook based alert destination in OpenObserve
 
 DESTINATION_NAME="openchoreo_alerts"
-WEBHOOK_URL="http://logs-adapter:9098/api/alerting/webhook"
+WEBHOOK_URL="http://logs-adapter:9098/api/v1alpha1/alerts/webhook"
 
 echo "Configuring webhook based alert destination..."
 
@@ -103,8 +103,60 @@ echo "Checking if destination '$DESTINATION_NAME' already exists..."
 EXISTING_DESTINATIONS=$(curl -s -u "$OPENOBSERVE_USERNAME:$OPENOBSERVE_PASSWORD" \
   "$OPENOBSERVE_URL/api/$OPENOBSERVE_ORG/alerts/destinations")
 
-if echo "$EXISTING_DESTINATIONS" | grep -q "\"name\"[[:space:]]*:[[:space:]]*\"$DESTINATION_NAME\""; then
-  echo "Destination '$DESTINATION_NAME' already exists. Skipping creation."
+# Extract the existing destination's URL if it exists using jq for reliable JSON parsing
+EXISTING_URL=$(echo "$EXISTING_DESTINATIONS" | jq -r --arg dest_name "$DESTINATION_NAME" \
+  'try (.destinations[] // .[]) catch .[] | select(.name == $dest_name) | .url // empty' 2>/dev/null)
+
+if [ -n "$EXISTING_URL" ]; then
+  echo "Destination '$DESTINATION_NAME' already exists with URL: $EXISTING_URL"
+
+  if [ "$EXISTING_URL" = "$WEBHOOK_URL" ]; then
+    echo "Webhook URL matches the stored URL. No update needed."
+  else
+    echo "Webhook URL differs from the stored URL. Updating destination..."
+
+    # Delete existing destination
+    DELETE_RESPONSE=$(curl -s -w "\n%{http_code}" -u "$OPENOBSERVE_USERNAME:$OPENOBSERVE_PASSWORD" \
+      -X DELETE "$OPENOBSERVE_URL/api/$OPENOBSERVE_ORG/alerts/destinations/$DESTINATION_NAME")
+
+    DELETE_HTTP_CODE=$(echo "$DELETE_RESPONSE" | tail -n1)
+    DELETE_BODY=$(echo "$DELETE_RESPONSE" | head -n-1)
+
+    if [ "$DELETE_HTTP_CODE" = "200" ] || [ "$DELETE_HTTP_CODE" = "204" ]; then
+      echo "Existing destination deleted successfully."
+    else
+      echo "ERROR: Failed to delete existing destination (HTTP $DELETE_HTTP_CODE). Response: $DELETE_BODY"
+      exit 1
+    fi
+
+    # Recreate with new URL
+    echo "Creating webhook based alert destination '$DESTINATION_NAME' with new URL..."
+
+    CREATE_RESPONSE=$(curl -s -w "\n%{http_code}" -u "$OPENOBSERVE_USERNAME:$OPENOBSERVE_PASSWORD" \
+      -X POST "$OPENOBSERVE_URL/api/$OPENOBSERVE_ORG/alerts/destinations" \
+      -H "Content-Type: application/json" \
+      -d "{
+        \"name\": \"$DESTINATION_NAME\",
+        \"url\": \"$WEBHOOK_URL\",
+        \"method\": \"post\",
+        \"type\": \"http\",
+        \"template\": \"$TEMPLATE_NAME\",
+        \"skip_tls_verify\": false,
+        \"headers\": {
+          \"Content-Type\": \"application/json\"
+        }
+      }")
+
+    HTTP_CODE=$(echo "$CREATE_RESPONSE" | tail -n1)
+    BODY=$(echo "$CREATE_RESPONSE" | head -n-1)
+
+    if [ "$HTTP_CODE" = "200" ] || [ "$HTTP_CODE" = "201" ]; then
+      echo "Webhook based alert destination updated successfully!"
+    else
+      echo "ERROR: Failed to update webhook based alert destination (HTTP $HTTP_CODE). Response: $BODY"
+      exit 1
+    fi
+  fi
 else
   echo "Creating webhook based alert destination '$DESTINATION_NAME'..."
 

--- a/observability-logs-openobserve/internal/api/gen/client.gen.go
+++ b/observability-logs-openobserve/internal/api/gen/client.gen.go
@@ -102,6 +102,19 @@ type ClientInterface interface {
 	// DeleteAlertRule request
 	DeleteAlertRule(ctx context.Context, ruleName string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// GetAlertRule request
+	GetAlertRule(ctx context.Context, ruleName string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UpdateAlertRuleWithBody request with any body
+	UpdateAlertRuleWithBody(ctx context.Context, ruleName string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UpdateAlertRule(ctx context.Context, ruleName string, body UpdateAlertRuleJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// HandleAlertWebhookWithBody request with any body
+	HandleAlertWebhookWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	HandleAlertWebhook(ctx context.Context, body HandleAlertWebhookJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// Health request
 	Health(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
 }
@@ -156,6 +169,66 @@ func (c *Client) CreateAlertRule(ctx context.Context, body CreateAlertRuleJSONRe
 
 func (c *Client) DeleteAlertRule(ctx context.Context, ruleName string, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewDeleteAlertRuleRequest(c.Server, ruleName)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetAlertRule(ctx context.Context, ruleName string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetAlertRuleRequest(c.Server, ruleName)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateAlertRuleWithBody(ctx context.Context, ruleName string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateAlertRuleRequestWithBody(c.Server, ruleName, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateAlertRule(ctx context.Context, ruleName string, body UpdateAlertRuleJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateAlertRuleRequest(c.Server, ruleName, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) HandleAlertWebhookWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewHandleAlertWebhookRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) HandleAlertWebhook(ctx context.Context, body HandleAlertWebhookJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewHandleAlertWebhookRequest(c.Server, body)
 	if err != nil {
 		return nil, err
 	}
@@ -292,6 +365,127 @@ func NewDeleteAlertRuleRequest(server string, ruleName string) (*http.Request, e
 	return req, nil
 }
 
+// NewGetAlertRuleRequest generates requests for GetAlertRule
+func NewGetAlertRuleRequest(server string, ruleName string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "ruleName", runtime.ParamLocationPath, ruleName)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1alpha1/alerts/rules/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewUpdateAlertRuleRequest calls the generic UpdateAlertRule builder with application/json body
+func NewUpdateAlertRuleRequest(server string, ruleName string, body UpdateAlertRuleJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewUpdateAlertRuleRequestWithBody(server, ruleName, "application/json", bodyReader)
+}
+
+// NewUpdateAlertRuleRequestWithBody generates requests for UpdateAlertRule with any type of body
+func NewUpdateAlertRuleRequestWithBody(server string, ruleName string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "ruleName", runtime.ParamLocationPath, ruleName)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1alpha1/alerts/rules/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PUT", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewHandleAlertWebhookRequest calls the generic HandleAlertWebhook builder with application/json body
+func NewHandleAlertWebhookRequest(server string, body HandleAlertWebhookJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewHandleAlertWebhookRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewHandleAlertWebhookRequestWithBody generates requests for HandleAlertWebhook with any type of body
+func NewHandleAlertWebhookRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1alpha1/alerts/webhook")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
 // NewHealthRequest generates requests for Health
 func NewHealthRequest(server string) (*http.Request, error) {
 	var err error
@@ -375,6 +569,19 @@ type ClientWithResponsesInterface interface {
 	// DeleteAlertRuleWithResponse request
 	DeleteAlertRuleWithResponse(ctx context.Context, ruleName string, reqEditors ...RequestEditorFn) (*DeleteAlertRuleResponse, error)
 
+	// GetAlertRuleWithResponse request
+	GetAlertRuleWithResponse(ctx context.Context, ruleName string, reqEditors ...RequestEditorFn) (*GetAlertRuleResponse, error)
+
+	// UpdateAlertRuleWithBodyWithResponse request with any body
+	UpdateAlertRuleWithBodyWithResponse(ctx context.Context, ruleName string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateAlertRuleResponse, error)
+
+	UpdateAlertRuleWithResponse(ctx context.Context, ruleName string, body UpdateAlertRuleJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateAlertRuleResponse, error)
+
+	// HandleAlertWebhookWithBodyWithResponse request with any body
+	HandleAlertWebhookWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*HandleAlertWebhookResponse, error)
+
+	HandleAlertWebhookWithResponse(ctx context.Context, body HandleAlertWebhookJSONRequestBody, reqEditors ...RequestEditorFn) (*HandleAlertWebhookResponse, error)
+
 	// HealthWithResponse request
 	HealthWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*HealthResponse, error)
 }
@@ -408,8 +615,9 @@ func (r QueryLogsResponse) StatusCode() int {
 type CreateAlertRuleResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *AlertingRuleSyncResponse
+	JSON201      *AlertingRuleSyncResponse
 	JSON400      *ErrorResponse
+	JSON409      *ErrorResponse
 	JSON500      *ErrorResponse
 }
 
@@ -434,6 +642,7 @@ type DeleteAlertRuleResponse struct {
 	HTTPResponse *http.Response
 	JSON200      *AlertingRuleSyncResponse
 	JSON400      *ErrorResponse
+	JSON404      *ErrorResponse
 	JSON500      *ErrorResponse
 }
 
@@ -447,6 +656,79 @@ func (r DeleteAlertRuleResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r DeleteAlertRuleResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type GetAlertRuleResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *AlertRuleResponse
+	JSON400      *ErrorResponse
+	JSON404      *ErrorResponse
+	JSON500      *ErrorResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r GetAlertRuleResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetAlertRuleResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type UpdateAlertRuleResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *AlertingRuleSyncResponse
+	JSON400      *ErrorResponse
+	JSON500      *ErrorResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r UpdateAlertRuleResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UpdateAlertRuleResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type HandleAlertWebhookResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *AlertWebhookResponse
+	JSON400      *ErrorResponse
+	JSON500      *ErrorResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r HandleAlertWebhookResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r HandleAlertWebhookResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -522,6 +804,49 @@ func (c *ClientWithResponses) DeleteAlertRuleWithResponse(ctx context.Context, r
 		return nil, err
 	}
 	return ParseDeleteAlertRuleResponse(rsp)
+}
+
+// GetAlertRuleWithResponse request returning *GetAlertRuleResponse
+func (c *ClientWithResponses) GetAlertRuleWithResponse(ctx context.Context, ruleName string, reqEditors ...RequestEditorFn) (*GetAlertRuleResponse, error) {
+	rsp, err := c.GetAlertRule(ctx, ruleName, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetAlertRuleResponse(rsp)
+}
+
+// UpdateAlertRuleWithBodyWithResponse request with arbitrary body returning *UpdateAlertRuleResponse
+func (c *ClientWithResponses) UpdateAlertRuleWithBodyWithResponse(ctx context.Context, ruleName string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateAlertRuleResponse, error) {
+	rsp, err := c.UpdateAlertRuleWithBody(ctx, ruleName, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateAlertRuleResponse(rsp)
+}
+
+func (c *ClientWithResponses) UpdateAlertRuleWithResponse(ctx context.Context, ruleName string, body UpdateAlertRuleJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateAlertRuleResponse, error) {
+	rsp, err := c.UpdateAlertRule(ctx, ruleName, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateAlertRuleResponse(rsp)
+}
+
+// HandleAlertWebhookWithBodyWithResponse request with arbitrary body returning *HandleAlertWebhookResponse
+func (c *ClientWithResponses) HandleAlertWebhookWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*HandleAlertWebhookResponse, error) {
+	rsp, err := c.HandleAlertWebhookWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseHandleAlertWebhookResponse(rsp)
+}
+
+func (c *ClientWithResponses) HandleAlertWebhookWithResponse(ctx context.Context, body HandleAlertWebhookJSONRequestBody, reqEditors ...RequestEditorFn) (*HandleAlertWebhookResponse, error) {
+	rsp, err := c.HandleAlertWebhook(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseHandleAlertWebhookResponse(rsp)
 }
 
 // HealthWithResponse request returning *HealthResponse
@@ -601,12 +926,12 @@ func ParseCreateAlertRuleResponse(rsp *http.Response) (*CreateAlertRuleResponse,
 	}
 
 	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
 		var dest AlertingRuleSyncResponse
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
-		response.JSON200 = &dest
+		response.JSON201 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
 		var dest ErrorResponse
@@ -614,6 +939,13 @@ func ParseCreateAlertRuleResponse(rsp *http.Response) (*CreateAlertRuleResponse,
 			return nil, err
 		}
 		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 409:
+		var dest ErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON409 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest ErrorResponse
@@ -643,6 +975,140 @@ func ParseDeleteAlertRuleResponse(rsp *http.Response) (*DeleteAlertRuleResponse,
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest AlertingRuleSyncResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest ErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest ErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest ErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetAlertRuleResponse parses an HTTP response from a GetAlertRuleWithResponse call
+func ParseGetAlertRuleResponse(rsp *http.Response) (*GetAlertRuleResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetAlertRuleResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest AlertRuleResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest ErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest ErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest ErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUpdateAlertRuleResponse parses an HTTP response from a UpdateAlertRuleWithResponse call
+func ParseUpdateAlertRuleResponse(rsp *http.Response) (*UpdateAlertRuleResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UpdateAlertRuleResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest AlertingRuleSyncResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest ErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest ErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseHandleAlertWebhookResponse parses an HTTP response from a HandleAlertWebhookWithResponse call
+func ParseHandleAlertWebhookResponse(rsp *http.Response) (*HandleAlertWebhookResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &HandleAlertWebhookResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest AlertWebhookResponse
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/observability-logs-openobserve/internal/api/gen/models.gen.go
+++ b/observability-logs-openobserve/internal/api/gen/models.gen.go
@@ -17,31 +17,48 @@ const (
 
 // Defines values for AlertRuleRequestConditionOperator.
 const (
-	Eq  AlertRuleRequestConditionOperator = "eq"
-	Gt  AlertRuleRequestConditionOperator = "gt"
-	Gte AlertRuleRequestConditionOperator = "gte"
-	Lt  AlertRuleRequestConditionOperator = "lt"
-	Lte AlertRuleRequestConditionOperator = "lte"
-	Neq AlertRuleRequestConditionOperator = "neq"
+	AlertRuleRequestConditionOperatorEq  AlertRuleRequestConditionOperator = "eq"
+	AlertRuleRequestConditionOperatorGt  AlertRuleRequestConditionOperator = "gt"
+	AlertRuleRequestConditionOperatorGte AlertRuleRequestConditionOperator = "gte"
+	AlertRuleRequestConditionOperatorLt  AlertRuleRequestConditionOperator = "lt"
+	AlertRuleRequestConditionOperatorLte AlertRuleRequestConditionOperator = "lte"
+	AlertRuleRequestConditionOperatorNeq AlertRuleRequestConditionOperator = "neq"
 )
 
 // Defines values for AlertRuleRequestSourceMetric.
 const (
-	CpuUsage    AlertRuleRequestSourceMetric = "cpu_usage"
-	MemoryUsage AlertRuleRequestSourceMetric = "memory_usage"
+	AlertRuleRequestSourceMetricCpuUsage    AlertRuleRequestSourceMetric = "cpu_usage"
+	AlertRuleRequestSourceMetricMemoryUsage AlertRuleRequestSourceMetric = "memory_usage"
 )
 
-// Defines values for AlertRuleRequestSourceType.
+// Defines values for AlertRuleResponseConditionOperator.
 const (
-	Log    AlertRuleRequestSourceType = "log"
-	Metric AlertRuleRequestSourceType = "metric"
+	AlertRuleResponseConditionOperatorEq  AlertRuleResponseConditionOperator = "eq"
+	AlertRuleResponseConditionOperatorGt  AlertRuleResponseConditionOperator = "gt"
+	AlertRuleResponseConditionOperatorGte AlertRuleResponseConditionOperator = "gte"
+	AlertRuleResponseConditionOperatorLt  AlertRuleResponseConditionOperator = "lt"
+	AlertRuleResponseConditionOperatorLte AlertRuleResponseConditionOperator = "lte"
+	AlertRuleResponseConditionOperatorNeq AlertRuleResponseConditionOperator = "neq"
+)
+
+// Defines values for AlertRuleResponseSourceMetric.
+const (
+	AlertRuleResponseSourceMetricCpuUsage    AlertRuleResponseSourceMetric = "cpu_usage"
+	AlertRuleResponseSourceMetricMemoryUsage AlertRuleResponseSourceMetric = "memory_usage"
+)
+
+// Defines values for AlertWebhookResponseStatus.
+const (
+	Error   AlertWebhookResponseStatus = "error"
+	Success AlertWebhookResponseStatus = "success"
 )
 
 // Defines values for AlertingRuleSyncResponseAction.
 const (
-	Created AlertingRuleSyncResponseAction = "created"
-	Deleted AlertingRuleSyncResponseAction = "deleted"
-	Updated AlertingRuleSyncResponseAction = "updated"
+	Created   AlertingRuleSyncResponseAction = "created"
+	Deleted   AlertingRuleSyncResponseAction = "deleted"
+	Unchanged AlertingRuleSyncResponseAction = "unchanged"
+	Updated   AlertingRuleSyncResponseAction = "updated"
 )
 
 // Defines values for AlertingRuleSyncResponseStatus.
@@ -53,6 +70,7 @@ const (
 // Defines values for ErrorResponseTitle.
 const (
 	BadRequest          ErrorResponseTitle = "badRequest"
+	Conflict            ErrorResponseTitle = "conflict"
 	Forbidden           ErrorResponseTitle = "forbidden"
 	InternalServerError ErrorResponseTitle = "internalServerError"
 	NotFound            ErrorResponseTitle = "notFound"
@@ -113,9 +131,6 @@ type AlertRuleRequest struct {
 
 		// Query The query to execute for log based alerts
 		Query *string `json:"query,omitempty"`
-
-		// Type The type of the source
-		Type *AlertRuleRequestSourceType `json:"type,omitempty"`
 	} `json:"source,omitempty"`
 }
 
@@ -125,8 +140,66 @@ type AlertRuleRequestConditionOperator string
 // AlertRuleRequestSourceMetric The metric to query for metric based alerts
 type AlertRuleRequestSourceMetric string
 
-// AlertRuleRequestSourceType The type of the source
-type AlertRuleRequestSourceType string
+// AlertRuleResponse defines model for AlertRuleResponse.
+type AlertRuleResponse struct {
+	Condition *struct {
+		// Enabled Whether the alert rule is enabled
+		Enabled *bool `json:"enabled,omitempty"`
+
+		// Interval The interval of time to query for the alert rule
+		Interval *string `json:"interval,omitempty"`
+
+		// Operator The operator to use for the alert rule
+		Operator *AlertRuleResponseConditionOperator `json:"operator,omitempty"`
+
+		// Threshold The threshold value to use for the alert rule
+		Threshold *float32 `json:"threshold,omitempty"`
+
+		// Window The window of time to query for the alert rule
+		Window *string `json:"window,omitempty"`
+	} `json:"condition,omitempty"`
+	Metadata *struct {
+		// ComponentUid The OpenChoreo component UID to query
+		ComponentUid *openapi_types.UUID `json:"componentUid,omitempty"`
+
+		// EnvironmentUid The OpenChoreo environment UID to query
+		EnvironmentUid *openapi_types.UUID `json:"environmentUid,omitempty"`
+
+		// Name The name of the alert rule
+		Name *string `json:"name,omitempty"`
+
+		// Namespace The namespace of the alert rule CR
+		Namespace *string `json:"namespace,omitempty"`
+
+		// ProjectUid The OpenChoreo project UID to query
+		ProjectUid *openapi_types.UUID `json:"projectUid,omitempty"`
+	} `json:"metadata,omitempty"`
+	Source *struct {
+		// Metric The metric to query for metric based alerts
+		Metric *AlertRuleResponseSourceMetric `json:"metric,omitempty"`
+
+		// Query The query to execute for log based alerts
+		Query *string `json:"query,omitempty"`
+	} `json:"source,omitempty"`
+}
+
+// AlertRuleResponseConditionOperator The operator to use for the alert rule
+type AlertRuleResponseConditionOperator string
+
+// AlertRuleResponseSourceMetric The metric to query for metric based alerts
+type AlertRuleResponseSourceMetric string
+
+// AlertWebhookResponse defines model for AlertWebhookResponse.
+type AlertWebhookResponse struct {
+	// Message The message of the alert webhook
+	Message *string `json:"message,omitempty"`
+
+	// Status The status of the alert webhook
+	Status *AlertWebhookResponseStatus `json:"status,omitempty"`
+}
+
+// AlertWebhookResponseStatus The status of the alert webhook
+type AlertWebhookResponseStatus string
 
 // AlertingRuleSyncResponse defines model for AlertingRuleSyncResponse.
 type AlertingRuleSyncResponse struct {
@@ -287,11 +360,20 @@ type WorkflowSearchScope struct {
 	WorkflowRunName *string `json:"workflowRunName,omitempty"`
 }
 
+// HandleAlertWebhookJSONBody defines parameters for HandleAlertWebhook.
+type HandleAlertWebhookJSONBody = map[string]interface{}
+
 // QueryLogsJSONRequestBody defines body for QueryLogs for application/json ContentType.
 type QueryLogsJSONRequestBody = LogsQueryRequest
 
 // CreateAlertRuleJSONRequestBody defines body for CreateAlertRule for application/json ContentType.
 type CreateAlertRuleJSONRequestBody = AlertRuleRequest
+
+// UpdateAlertRuleJSONRequestBody defines body for UpdateAlertRule for application/json ContentType.
+type UpdateAlertRuleJSONRequestBody = AlertRuleRequest
+
+// HandleAlertWebhookJSONRequestBody defines body for HandleAlertWebhook for application/json ContentType.
+type HandleAlertWebhookJSONRequestBody = HandleAlertWebhookJSONBody
 
 // AsComponentSearchScope returns the union data inside the LogsQueryRequest_SearchScope as a ComponentSearchScope
 func (t LogsQueryRequest_SearchScope) AsComponentSearchScope() (ComponentSearchScope, error) {

--- a/observability-logs-openobserve/internal/api/gen/server.gen.go
+++ b/observability-logs-openobserve/internal/api/gen/server.gen.go
@@ -33,6 +33,15 @@ type ServerInterface interface {
 	// Delete alert rule
 	// (DELETE /api/v1alpha1/alerts/rules/{ruleName})
 	DeleteAlertRule(w http.ResponseWriter, r *http.Request, ruleName string)
+	// Get alert rule
+	// (GET /api/v1alpha1/alerts/rules/{ruleName})
+	GetAlertRule(w http.ResponseWriter, r *http.Request, ruleName string)
+	// Update alert rule
+	// (PUT /api/v1alpha1/alerts/rules/{ruleName})
+	UpdateAlertRule(w http.ResponseWriter, r *http.Request, ruleName string)
+	// Handles triggered alerts from the alerting backend
+	// (POST /api/v1alpha1/alerts/webhook)
+	HandleAlertWebhook(w http.ResponseWriter, r *http.Request)
 	// Health check
 	// (GET /health)
 	Health(w http.ResponseWriter, r *http.Request)
@@ -109,6 +118,82 @@ func (siw *ServerInterfaceWrapper) DeleteAlertRule(w http.ResponseWriter, r *htt
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.DeleteAlertRule(w, r, ruleName)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetAlertRule operation middleware
+func (siw *ServerInterfaceWrapper) GetAlertRule(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// ------------- Path parameter "ruleName" -------------
+	var ruleName string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "ruleName", r.PathValue("ruleName"), &ruleName, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "ruleName", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetAlertRule(w, r, ruleName)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// UpdateAlertRule operation middleware
+func (siw *ServerInterfaceWrapper) UpdateAlertRule(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// ------------- Path parameter "ruleName" -------------
+	var ruleName string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "ruleName", r.PathValue("ruleName"), &ruleName, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "ruleName", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.UpdateAlertRule(w, r, ruleName)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// HandleAlertWebhook operation middleware
+func (siw *ServerInterfaceWrapper) HandleAlertWebhook(w http.ResponseWriter, r *http.Request) {
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.HandleAlertWebhook(w, r)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -255,6 +340,9 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 	m.HandleFunc("POST "+options.BaseURL+"/api/v1/logs/query", wrapper.QueryLogs)
 	m.HandleFunc("POST "+options.BaseURL+"/api/v1alpha1/alerts/rules", wrapper.CreateAlertRule)
 	m.HandleFunc("DELETE "+options.BaseURL+"/api/v1alpha1/alerts/rules/{ruleName}", wrapper.DeleteAlertRule)
+	m.HandleFunc("GET "+options.BaseURL+"/api/v1alpha1/alerts/rules/{ruleName}", wrapper.GetAlertRule)
+	m.HandleFunc("PUT "+options.BaseURL+"/api/v1alpha1/alerts/rules/{ruleName}", wrapper.UpdateAlertRule)
+	m.HandleFunc("POST "+options.BaseURL+"/api/v1alpha1/alerts/webhook", wrapper.HandleAlertWebhook)
 	m.HandleFunc("GET "+options.BaseURL+"/health", wrapper.Health)
 
 	return m
@@ -321,11 +409,11 @@ type CreateAlertRuleResponseObject interface {
 	VisitCreateAlertRuleResponse(w http.ResponseWriter) error
 }
 
-type CreateAlertRule200JSONResponse AlertingRuleSyncResponse
+type CreateAlertRule201JSONResponse AlertingRuleSyncResponse
 
-func (response CreateAlertRule200JSONResponse) VisitCreateAlertRuleResponse(w http.ResponseWriter) error {
+func (response CreateAlertRule201JSONResponse) VisitCreateAlertRuleResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(200)
+	w.WriteHeader(201)
 
 	return json.NewEncoder(w).Encode(response)
 }
@@ -335,6 +423,15 @@ type CreateAlertRule400JSONResponse ErrorResponse
 func (response CreateAlertRule400JSONResponse) VisitCreateAlertRuleResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(400)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type CreateAlertRule409JSONResponse ErrorResponse
+
+func (response CreateAlertRule409JSONResponse) VisitCreateAlertRuleResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(409)
 
 	return json.NewEncoder(w).Encode(response)
 }
@@ -374,9 +471,133 @@ func (response DeleteAlertRule400JSONResponse) VisitDeleteAlertRuleResponse(w ht
 	return json.NewEncoder(w).Encode(response)
 }
 
+type DeleteAlertRule404JSONResponse ErrorResponse
+
+func (response DeleteAlertRule404JSONResponse) VisitDeleteAlertRuleResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
 type DeleteAlertRule500JSONResponse ErrorResponse
 
 func (response DeleteAlertRule500JSONResponse) VisitDeleteAlertRuleResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(500)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetAlertRuleRequestObject struct {
+	RuleName string `json:"ruleName"`
+}
+
+type GetAlertRuleResponseObject interface {
+	VisitGetAlertRuleResponse(w http.ResponseWriter) error
+}
+
+type GetAlertRule200JSONResponse AlertRuleResponse
+
+func (response GetAlertRule200JSONResponse) VisitGetAlertRuleResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetAlertRule400JSONResponse ErrorResponse
+
+func (response GetAlertRule400JSONResponse) VisitGetAlertRuleResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetAlertRule404JSONResponse ErrorResponse
+
+func (response GetAlertRule404JSONResponse) VisitGetAlertRuleResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetAlertRule500JSONResponse ErrorResponse
+
+func (response GetAlertRule500JSONResponse) VisitGetAlertRuleResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(500)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type UpdateAlertRuleRequestObject struct {
+	RuleName string `json:"ruleName"`
+	Body     *UpdateAlertRuleJSONRequestBody
+}
+
+type UpdateAlertRuleResponseObject interface {
+	VisitUpdateAlertRuleResponse(w http.ResponseWriter) error
+}
+
+type UpdateAlertRule200JSONResponse AlertingRuleSyncResponse
+
+func (response UpdateAlertRule200JSONResponse) VisitUpdateAlertRuleResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type UpdateAlertRule400JSONResponse ErrorResponse
+
+func (response UpdateAlertRule400JSONResponse) VisitUpdateAlertRuleResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type UpdateAlertRule500JSONResponse ErrorResponse
+
+func (response UpdateAlertRule500JSONResponse) VisitUpdateAlertRuleResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(500)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type HandleAlertWebhookRequestObject struct {
+	Body *HandleAlertWebhookJSONRequestBody
+}
+
+type HandleAlertWebhookResponseObject interface {
+	VisitHandleAlertWebhookResponse(w http.ResponseWriter) error
+}
+
+type HandleAlertWebhook200JSONResponse AlertWebhookResponse
+
+func (response HandleAlertWebhook200JSONResponse) VisitHandleAlertWebhookResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type HandleAlertWebhook400JSONResponse ErrorResponse
+
+func (response HandleAlertWebhook400JSONResponse) VisitHandleAlertWebhookResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type HandleAlertWebhook500JSONResponse ErrorResponse
+
+func (response HandleAlertWebhook500JSONResponse) VisitHandleAlertWebhookResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(500)
 
@@ -424,6 +645,15 @@ type StrictServerInterface interface {
 	// Delete alert rule
 	// (DELETE /api/v1alpha1/alerts/rules/{ruleName})
 	DeleteAlertRule(ctx context.Context, request DeleteAlertRuleRequestObject) (DeleteAlertRuleResponseObject, error)
+	// Get alert rule
+	// (GET /api/v1alpha1/alerts/rules/{ruleName})
+	GetAlertRule(ctx context.Context, request GetAlertRuleRequestObject) (GetAlertRuleResponseObject, error)
+	// Update alert rule
+	// (PUT /api/v1alpha1/alerts/rules/{ruleName})
+	UpdateAlertRule(ctx context.Context, request UpdateAlertRuleRequestObject) (UpdateAlertRuleResponseObject, error)
+	// Handles triggered alerts from the alerting backend
+	// (POST /api/v1alpha1/alerts/webhook)
+	HandleAlertWebhook(ctx context.Context, request HandleAlertWebhookRequestObject) (HandleAlertWebhookResponseObject, error)
 	// Health check
 	// (GET /health)
 	Health(ctx context.Context, request HealthRequestObject) (HealthResponseObject, error)
@@ -546,6 +776,96 @@ func (sh *strictHandler) DeleteAlertRule(w http.ResponseWriter, r *http.Request,
 	}
 }
 
+// GetAlertRule operation middleware
+func (sh *strictHandler) GetAlertRule(w http.ResponseWriter, r *http.Request, ruleName string) {
+	var request GetAlertRuleRequestObject
+
+	request.RuleName = ruleName
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.GetAlertRule(ctx, request.(GetAlertRuleRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "GetAlertRule")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(GetAlertRuleResponseObject); ok {
+		if err := validResponse.VisitGetAlertRuleResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// UpdateAlertRule operation middleware
+func (sh *strictHandler) UpdateAlertRule(w http.ResponseWriter, r *http.Request, ruleName string) {
+	var request UpdateAlertRuleRequestObject
+
+	request.RuleName = ruleName
+
+	var body UpdateAlertRuleJSONRequestBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		sh.options.RequestErrorHandlerFunc(w, r, fmt.Errorf("can't decode JSON body: %w", err))
+		return
+	}
+	request.Body = &body
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.UpdateAlertRule(ctx, request.(UpdateAlertRuleRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "UpdateAlertRule")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(UpdateAlertRuleResponseObject); ok {
+		if err := validResponse.VisitUpdateAlertRuleResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// HandleAlertWebhook operation middleware
+func (sh *strictHandler) HandleAlertWebhook(w http.ResponseWriter, r *http.Request) {
+	var request HandleAlertWebhookRequestObject
+
+	var body HandleAlertWebhookJSONRequestBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		sh.options.RequestErrorHandlerFunc(w, r, fmt.Errorf("can't decode JSON body: %w", err))
+		return
+	}
+	request.Body = &body
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.HandleAlertWebhook(ctx, request.(HandleAlertWebhookRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "HandleAlertWebhook")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(HandleAlertWebhookResponseObject); ok {
+		if err := validResponse.VisitHandleAlertWebhookResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
 // Health operation middleware
 func (sh *strictHandler) Health(w http.ResponseWriter, r *http.Request) {
 	var request HealthRequestObject
@@ -573,45 +893,49 @@ func (sh *strictHandler) Health(w http.ResponseWriter, r *http.Request) {
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+waTXPbuPWvYNDOpJ2hJTnJHqqb4jhdbb1x1k6ag6PpQOQTiTUI0ABoR/Hov3ceAFKU",
-	"BNqy4mx72ItNEsD7/obuaarKSkmQ1tDxPTVpASVzjxMB2l7UAi7gpgZj8VulVQXacnA7UiUzbrmSu0sg",
-	"2VxAho8ZmFTzyu+jnwuwBWhiCyAMMRBdCyDckOZIQu2yAjqmc6UEMElXCeXSgr5lYhfexwJIs0rUglhe",
-	"ArGK3NSgl2ShtjGtwRurucwROhLOrNJx6M0qQq0NxGGCrEs6vqK5pQnNLX4S1v1xqzc0oRJu6CyC3RYa",
-	"TKFEFkffLpNbJmp4kIoAW9blHDTCvuMyU3dxwH7tMJmt2i9q/jukFnGVYFnGLIvZSTCxT7yHyfMK5Emh",
-	"NCjSbiafpm9bqmhCF0qXzNIxrWuexdQI8pZrJcs9EXW2PxmVZCXEEeCKk+mjVoc7TcXSBwC55V1o5OQi",
-	"BrDSCnWxD+9h6xP5jmndqFp7FjZ1XoLVPI0T4tc2LS58mzMDmWfVdNwqrer/1IblKMgSSqWX4TXmUJ6b",
-	"KGaPzyoCXyGtrXcjofJtvLtO6j5E/XNZtSoKwljTLVTuKHaymO0h0JiIXSDmMsdYfLmU6QWYSkkTETpL",
-	"m2i8S6dfI5ZdgyT40BfCUg3MujhcV1l4ykAAPsXELZixSBZkE9sjIl6CsaysGjnhEWKWMo2JGsl5w9Jr",
-	"kNm0x5LnfplM35K/oQkvtCqJmhvMAnMuuF02W/6+ny/i9zOV85SJPpzCLzuc6Jt7QjaW2drEQfq1KJxG",
-	"GcYJFl2TcRFVQMxiTpoYeqbyU2m9N2yaioBbEL2cEr8c07bK+0+VYIKT7pzrZodoRHCrrYGonIAjPOnL",
-	"Je97Q3A0mbi4bAtmSQ4SEzpkDaYYud+TsvqQPJpVUiUt4xJ0P2/tlqcy1Ml2e0mumx0PR3VQHj5Yfm3K",
-	"3IvDdYJ9In+VyvoR/Kueg5ZgwZBKZQeCfkpZsIXwCbh8DbCXrJp64ansHFiRHGgBsVDY5p59U1Mn8rTo",
-	"MA0e4Vb6tPB7CUynxWWqKni8Kt7Djx6uIR8R/y7hGm5qrrFLu+pAmkU4OtVa6f66A3D5RGU9huSWSaoy",
-	"6GZq0AT/cV8wfWVlJRDp+ZvLo38fH50dvXwZzyM+xewg+rkumTzSwDJsIwPOdUJaI/iVG8NlThruyYKD",
-	"yAx5YSzT9iMv4QVhMiMvQGbuLVoPcise5LaDOaTyOcuaTjqhtWS1LZTm33x2V3rOswwk9onKvlO1xM+u",
-	"sZVMXDpxOSXsWQGcqdz8hsVub/MeuOvhQWa+KwxesdMgPOARCRW85KEUXLBaWDo+Ho2SWNpnX3lZl8Q3",
-	"rIiMWygNFugabK1RHGGPgzFKaMlleG0Ro5Ry3+8KlZ9h5eI4dLA8q14Db0/ffPonTej0/btzmtDPk4v3",
-	"NKGnFxfnF/HO3H9gWrOl0xm/qWHqoVpdA5Z3zsM/FJqZuA+azRCgJJwv6Pjqnv5Vw4KO6V+G6wHMMExf",
-	"htEAskoePvRZ6euFUHcbZ2auRdP2XGegN1Ti1EFjWsH9ROGBbfU3gmTtyajcWkfqLXu1Pdi8tuLWGlfS",
-	"mvSm1GcPu0dfTBMqN72VrnEkc8iIqdMUjFnUQiAHa/221reXottCfdvsUOt7gWrU3w8JbcEqdf2r6c+F",
-	"oT9sW3Pb8MslKbkQ3ECqZNbpkTveZ5XtG9G5pY6fd2UYgRULaTsMxlR2UG/yv6gRYt66w9DD6f0ugLio",
-	"ZVPEHZ7jXahKa83t8hItyhPwBpgGPaltgW9z9/au4fiXzx934scvnz8Sq9CEFkoTzHEgLU8ZLg/IVKai",
-	"zsAJ0e/ifhAxCcnQ7SMFMAw+zJAXngDypR6NXqXuiHuEFwP0ckcoHQfC1oIvrK3oauUGxwsVRtWWpbYR",
-	"KtYZ69rzI7ASBbqtem7I5MOUmApSvghMkAwWXIJxZCNUzVLrK1aGhpFjacEyVlnQpKyNJRzrDizivkir",
-	"3Kw6x7qW3HFbOCgdSs5DZTQgrjxu6qSUCeEwGpeaK8WlxSz5RXovdd6ENUvJJMu7owTjK65gtY64ZnhS",
-	"aXXLM8jI3Lt5qbJawOALJl3BUwhRMYhrUrG0APJyMMJMqEWQshkPh3d3dwPmlgdK58Nw1gzPpien7y9P",
-	"j14ORoPClqJTN9Ednpu5DUZmMgnym3yY0oTegjZeJceD0WAUJvaSVZyO6avBaPCKJrRitnAmO2QVH94e",
-	"D1Emw3YUWCkTGU79tpZeK6ZIcepvALiS06w5hGRS711g7BuVLRsrA+kQsaoSwWSGvxs/lPOh+rFAvlO6",
-	"rTb9OFQeOmQux/TL0ehH4A+50RGwKbmz3hy4SujrvahpK/KN/oHSTo1/WK0eTKxTb6+SPXnf7HMifE/l",
-	"LRM8I3oN+fXo+Jm4bYBj+xAYdyGvw9RG3/B8bH3aAvt69OqZeLqsXYIJEfzr8puP36RghkhFKtCOVeVq",
-	"jlsOd94d1YK0gxCyUCohH8KAYM50Qtq6iczZN0wip50hUoYdgKrwuSO5dYv1fGJ714X50/dY/brr/ceG",
-	"+DoMxJrB5zRsD5148CTARwR1WTKMop1wiWQxrI+vXCSgM9wYIi8TVcGOh/4uZeiSUH8EPnGXDYTJjctg",
-	"uV8k9ofbe+ofFI937sH/4Hjce/0T0eJkLcRwjXNgcP5x4fKnPxb/41bdmODGNU4w7om/EHzEvIf3+A/j",
-	"1cpbuAAb6X3fuu8H2ro/vGnr/18GF+4I/zS4xwyusYMHDQ4rWs1KsKCNmyc84acGHHdgQUybXyrQxkDp",
-	"duTqJpDt7hGpGBbAhG//cogF8ALSa0eC37h1qblt14Mdw/7Zw/9Oe97sm9eXruuxrydvuU93vqvWS089",
-	"4YY0cJxlvfoOIl3636QR2xo/uhpjbynB39mHu98Hb5fXQGr5XKyuIXXHA3R8Neuas1cgSdEQOpYc9Dpb",
-	"bZ3dHCpczVaz9sz9bpNBNFjN4ZaJdeO7tmpXe6yS+/6g5BtiVxZGzgdv24XQ5Sl2MDC3mq3+GwAA///v",
-	"wz4jQScAAA==",
+	"H4sIAAAAAAAC/+waW2/buvmvENyAboBiO233cPzmpmmPu5ymJ2mXhzQYaPGzxBOKVEgqqRv4vw+8SJZt",
+	"yrHd9DIgL60jkt/9Tt7jVBalFCCMxsN7rNMcCuJ+jjgoc1ZxOIObCrSx30olS1CGgduRSkGZYVKsL4Eg",
+	"Ew7U/qSgU8VKvw9f5GByUMjkgIjFgFTFATGN6iMJNrMS8BBPpORABJ4nmAkD6pbwdXgfc0D1KpJTZFgB",
+	"yEh0U4GaoalcxbQAr41iIrPQLeHESBWHXq9aqJWGOEwQVYGHlzgzOMGZsZ+4cf+41RucYAE3+CqC3eQK",
+	"dC45jaNvltEt4RVspCLAFlUxAWVh3zFB5V0csF/bT2bz5ouc/AWpsbgKMIQSQ2J2EkzsE+tg8rQEcZRL",
+	"BRI1m9Gn8euGKpzgqVQFMXiIq4rRmBpB3DIlRbElotb2nVEJUkAcgV1xMn3Q6uxOXZJ0AyC3vA4NHZ3F",
+	"AJZKWl1sw3vYuiPfMa1rWSnPwrLOCzCKpXFC/NqyxYVvE6KBelZ1y63SsvpvpUlmBVlAIdUs/BlzKM9N",
+	"FLPHZySCL5BWxrsRl9kq3gcZj4miFTB1KYWGp4j5FDGfIuZTxHyKmJsi5gVMcimvu4NmAdpR3iEZt7is",
+	"8jsPMqZybYipdByWX+sCVUtWV2kK2slaKakiAu1klYnM5ofzmUi72SVpnSDWKfRryJBrEMj+6IqqqQJi",
+	"XGqoSlr/EmlOROZ+U+Bgv8asgRNtLIlAR6YjwrICtCFFWcvKHkF6JtKYyC1pr0h6DYKOOxxt4pfR+DX6",
+	"h/WwqZIFkhNtk9SEcWZm9ZZ/bhcq7PcTmbGU8C6c3C87nDZ0bAl5VwNaUYx2grWRgzAeVUDMeo7qEH8i",
+	"s2NhvLMumw2HW+CdnCK/HNO2zLpP1a4XOddOXtGA5VYbA5EZAkd40pXq3ndmiGiuc2nD5MSgDIStN4DW",
+	"mGLkfktG7ULyYNJLpTCECVDdvDVbdmWolYy3klw7ee+Paq8yYW/5NRl9Kw4X+X9H/kpJuxH8u5qAEmBA",
+	"o1LSPUHvUrWsINwBly9RtpJVXc7sys6eBdOeFhALhU3u2TY1tSJPg86mxAO7Fe8Wfs+BqDQ/T2UJDxft",
+	"W/jR5hL3AfGvE67gpmLKNpGXLUhXEY6ObenSXYO4yuZI0g5DcssolRTamRoUsv+x1OW7L6QouUV6+ur8",
+	"4D+HBycHz5/H80hHdfd7VRBxoIBQ2+UGnIuEtEDwB9OaiQzV3KMpA041eqYNUeYjK+AZIoKiZyCo+ytG",
+	"hmGGb+S2hTmk8gmh9WjUFlekMrlU7KvP7lJNGKUgbBsrzRtZCfs5lWLKWWoPuBZcEH7uJHe8Qyl5IjP9",
+	"py3LOwezgdEOdgT1/WtwkLVWZoNzJJizgoWqcEoqbvDwcDBIYhUA+cKKqkC+tbbImIFC21ZCgamUlUzY",
+	"42AMElwwEf5sEFspZb4z5zI7sUWM49DB8qx6Zbw+fvXpLU7w+P2bU5zgi9HZe5zg47Oz07P4DMF/IEqR",
+	"mVMfu6lg7KEaVYGt9Jyzf8gV0XF31MvRQAo4neLh5T3+u4IpHuK/9RfD9X6YrPejsWSebD50IdX1lMu7",
+	"pTNXrplU5lRRUEsqcerAMa3Y/UjaA6vqrwVJmpNRuTU+1VkBK7O3ea2EsAWupDHpZalfbXaPrvDGZaY7",
+	"i17tSGZAUej0phXnloOFfhvr20rRTc2+anZW61uBqtXfDcnagpHy+g/dnRZD29gMEUzNLxOoYJwzDakU",
+	"tNXNt7zPSNM1THRLLT9vyzACKxbS1hiMqWyvNuVnlAsxb11jaHOmvwsgzipR13P7p3sXqtJKMTM7txbl",
+	"CXgFRIEaVSa3f03cX29qjt9dfFyLH+8uPiIjrQlNpUI23YEwLCV2uYfGIuUVBSdEv4v5+cQo5EW3D+VA",
+	"bPAhGj3zBKDP1WDwInVH3E941rNe7gjFw0DYQvC5MSWez92IeyrDUN2Q1NRCtSXHogz9CKSwAl1VPdNo",
+	"9GGMdAkpmwYmEIUpE6Ad2RaqIqnxxSuxhpHZKoNQUhpQqKi0QcyWILae+yyMdFP1zJa46I6Z3EFpUXIa",
+	"iqQecpVyXTKlhHOHUbvUXEomjM2Sn4X3UudNtnwpiCBZe6qgffEVrNYRV89RSiVvGQWKJt7NC0krDr3P",
+	"NulylkKIikFco5KkOaDnvYHNhIoHKethv393d9cjbrknVdYPZ3X/ZHx0/P78+OB5b9DLTcFbJRRe47ke",
+	"4djIjEZBfqMPY5zgW1Daq+SwN+gNwt2CICXDQ/yiN+i9wAkuicmdyfZJyfq3h30rk34ztCyljsyp/lxI",
+	"rxFTpE71dxVMijGtD1kysfcu0OaVpLPaykA4RKQseTCZ/l/az+p8qH4okK+VbvNlPw6VhwqZyzH9fDD4",
+	"HvhDbnQELEvupDMHzhP8citqmuJ8qZXAuFXu71e2BxNrld7zZEvel1ueCN9jcUs4o0gtIL8cHD4StzVw",
+	"20kExl3IazG11EI8HlufVsC+HLx4JJ7OK5dgQgT/Mvvq4zfKiUZCohKUY1W6muOWwZ13RzlFzUwETaVM",
+	"0IcwK5gQlaCmbkIT8tUmkePWPInaDkCW9ndLcotu6/HE9qYN81/fYvWLBvi3JfG1GIg1g49p2B468uBR",
+	"gG8RVEVBbBRthUtLFrH18aWLBPjKbgyRl/AyJ4d9f+vTd0moOwIfuTsIRMTStbXYLhL7w82V+neKx2tv",
+	"nLaKx4ePiz92KxTR4mghxHC7s2dw/p7h8rcfh78lD8IVEDpD8IVpo7d32B/oX7UzLN0tBTcb+UvUBxyt",
+	"f2//s5Fz7n2Ng4l04a/d9z29zh9e9rrvVIrsafrh4vIXNP2XP8X0hTRo6qaLv6LV18a40eoTnEEkfbwF",
+	"s2LFXe3Omhm/BfPjbHjpxddmZSkwisHtk/n+n5ivM8EHbLckihRgQGk3GtzhfROzO2xvi+vnUbiO8Hi1",
+	"CGnXgquDoKsEl1XEgT65lx/xTPCQB/mzv2b59dNzUHhS88s58S/nP7UF7lX01C+vOvuL34mgHDQyimUZ",
+	"qOY12iJPkKDfTjP3INrP0L7B0tddP0BCE0lnKCUCTaw7ztC789P3yE9nE0Q0omw6BWX721WKNSrIDGkQ",
+	"tLWpJDMuCdU9vD7q/fH+s/p+r9N3gkJR7oT+5D5d7hNG9Xh4edV2pr3MPeptORDup/7Rwusoh/TaAfQb",
+	"V561rTYRvXWv8vC/0fCWr0sWz+4WF/+evNlWr0/XFHDuqUdMoxqOs4EX30CkfxC6RKMsQfgbyyFKpRDg",
+	"X3CG138b3xcugFTisVhdQNpoal7vqTWElhEFvV7NV84u3yVdXtmKJJy5X58t11Uw4Yv7jkUF5EZO8+S+",
+	"O/v6exA3DYycD4a+DqHNU+xgYG5+Nf9fAAAA//83VSsXFDcAAA==",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/observability-logs-openobserve/internal/config.go
+++ b/observability-logs-openobserve/internal/config.go
@@ -6,19 +6,21 @@ package app
 import (
 	"fmt"
 	"log/slog"
+	"net/url"
 	"os"
 	"strconv"
 	"strings"
 )
 
 type Config struct {
-	ServerPort          string
-	OpenObserveURL      string
-	OpenObserveOrg      string
-	OpenObserveStream   string
-	OpenObserveUser     string
+	ServerPort        string
+	OpenObserveURL    string
+	OpenObserveOrg    string
+	OpenObserveStream string
+	OpenObserveUser   string
 	OpenObservePassword string
-	LogLevel            slog.Level
+	ObserverURL       string
+	LogLevel          slog.Level
 }
 
 // LoadConfig loads configuration from environment variables
@@ -29,6 +31,7 @@ func LoadConfig() (*Config, error) {
 	openObserveStream := getEnv("OPENOBSERVE_STREAM", "default")
 	openObserveUser := getEnv("OPENOBSERVE_USER", "")
 	openObservePassword := getEnv("OPENOBSERVE_PASSWORD", "")
+	observerURL := getEnv("OBSERVER_URL", "")
 
 	// Parse log level
 	logLevel := slog.LevelInfo
@@ -57,18 +60,27 @@ func LoadConfig() (*Config, error) {
 		return nil, fmt.Errorf("Environment variable OPENOBSERVE_PASSWORD is required")
 	}
 
+	if observerURL == "" {
+		return nil, fmt.Errorf("environment variable OBSERVER_URL is required")
+	}
+	parsedURL, err := url.Parse(observerURL)
+	if err != nil || parsedURL.Scheme == "" || parsedURL.Host == "" {
+		return nil, fmt.Errorf("OBSERVER_URL must be a valid URL with scheme and host, got: %q", observerURL)
+	}
+
 	if _, err := strconv.Atoi(serverPort); err != nil {
 		return nil, fmt.Errorf("invalid SERVER_PORT: %w", err)
 	}
 
 	return &Config{
-		ServerPort:          serverPort,
-		OpenObserveURL:      openObserveURL,
-		OpenObserveOrg:      openObserveOrg,
-		OpenObserveStream:   openObserveStream,
-		OpenObserveUser:     openObserveUser,
+		ServerPort:      serverPort,
+		OpenObserveURL:  openObserveURL,
+		OpenObserveOrg:  openObserveOrg,
+		OpenObserveStream: openObserveStream,
+		OpenObserveUser: openObserveUser,
 		OpenObservePassword: openObservePassword,
-		LogLevel:            logLevel,
+		ObserverURL:     observerURL,
+		LogLevel:        logLevel,
 	}, nil
 }
 

--- a/observability-logs-openobserve/internal/handlers.go
+++ b/observability-logs-openobserve/internal/handlers.go
@@ -13,19 +13,22 @@ import (
 	openapi_types "github.com/oapi-codegen/runtime/types"
 
 	"github.com/openchoreo/community-modules/observability-logs-openobserve/internal/api/gen"
+	"github.com/openchoreo/community-modules/observability-logs-openobserve/internal/observer"
 	"github.com/openchoreo/community-modules/observability-logs-openobserve/internal/openobserve"
 )
 
 // LogsHandler implements the generated StrictServerInterface.
 type LogsHandler struct {
-	client *openobserve.Client
-	logger *slog.Logger
+	client         *openobserve.Client
+	observerClient *observer.Client
+	logger         *slog.Logger
 }
 
-func NewLogsHandler(client *openobserve.Client, logger *slog.Logger) *LogsHandler {
+func NewLogsHandler(client *openobserve.Client, observerClient *observer.Client, logger *slog.Logger) *LogsHandler {
 	return &LogsHandler{
-		client: client,
-		logger: logger,
+		client:         client,
+		observerClient: observerClient,
+		logger:         logger,
 	}
 }
 
@@ -127,7 +130,7 @@ func (h *LogsHandler) CreateAlertRule(ctx context.Context, request gen.CreateAle
 	}
 
 	now := time.Now().UTC().Format(time.RFC3339)
-	return gen.CreateAlertRule200JSONResponse{
+	return gen.CreateAlertRule201JSONResponse{
 		Action:        ptr(gen.Created),
 		Status:        ptr(gen.Synced),
 		RuleLogicalId: params.Name,
@@ -158,6 +161,151 @@ func (h *LogsHandler) DeleteAlertRule(ctx context.Context, request gen.DeleteAle
 		RuleLogicalId: &request.RuleName,
 		RuleBackendId: &alertID,
 		LastSyncedAt:  &now,
+	}, nil
+}
+
+// GetAlertRule implements GET /api/v1alpha1/alerts/rules/{ruleName}.
+func (h *LogsHandler) GetAlertRule(ctx context.Context, request gen.GetAlertRuleRequestObject) (gen.GetAlertRuleResponseObject, error) {
+	alert, err := h.client.GetAlert(ctx, request.RuleName)
+	if err != nil {
+		h.logger.Error("Failed to get alert",
+			slog.String("function", "GetAlertRule"),
+			slog.String("ruleName", request.RuleName),
+			slog.Any("error", err),
+		)
+		if strings.Contains(err.Error(), "not found") {
+			return gen.GetAlertRule404JSONResponse{
+				Title:   ptr(gen.NotFound),
+				Message: ptr("alert rule not found"),
+			}, nil
+		}
+		return gen.GetAlertRule500JSONResponse{
+			Title:   ptr(gen.InternalServerError),
+			Message: ptr("internal server error"),
+		}, nil
+	}
+
+	searchPattern := openobserve.ExtractSearchPattern(alert.SQL)
+	operator := gen.AlertRuleResponseConditionOperator(openobserve.ReverseMapOperator(alert.Operator))
+	threshold := float32(alert.Threshold)
+	window := openobserve.ToDurationString(alert.Period, alert.FrequencyType)
+	interval := openobserve.ToDurationString(alert.Frequency, alert.FrequencyType)
+
+	metadata := &struct {
+		ComponentUid   *openapi_types.UUID `json:"componentUid,omitempty"`
+		EnvironmentUid *openapi_types.UUID `json:"environmentUid,omitempty"`
+		Name           *string             `json:"name,omitempty"`
+		Namespace      *string             `json:"namespace,omitempty"`
+		ProjectUid     *openapi_types.UUID `json:"projectUid,omitempty"`
+	}{
+		Name:      &alert.Name,
+		Namespace: strPtr(alert.Namespace),
+	}
+	if alert.ProjectUID != "" {
+		if uid, ok := parseUUID(alert.ProjectUID); ok {
+			metadata.ProjectUid = &uid
+		}
+	}
+	if alert.EnvironmentUID != "" {
+		if uid, ok := parseUUID(alert.EnvironmentUID); ok {
+			metadata.EnvironmentUid = &uid
+		}
+	}
+	if alert.ComponentUID != "" {
+		if uid, ok := parseUUID(alert.ComponentUID); ok {
+			metadata.ComponentUid = &uid
+		}
+	}
+
+	response := gen.AlertRuleResponse{
+		Metadata: metadata,
+		Source: &struct {
+			Metric *gen.AlertRuleResponseSourceMetric `json:"metric,omitempty"`
+			Query  *string                            `json:"query,omitempty"`
+		}{
+			Metric: ptr(gen.AlertRuleResponseSourceMetric("log")),
+			Query:  &searchPattern,
+		},
+		Condition: &struct {
+			Enabled   *bool                                  `json:"enabled,omitempty"`
+			Interval  *string                                `json:"interval,omitempty"`
+			Operator  *gen.AlertRuleResponseConditionOperator `json:"operator,omitempty"`
+			Threshold *float32                               `json:"threshold,omitempty"`
+			Window    *string                                `json:"window,omitempty"`
+		}{
+			Enabled:   &alert.Enabled,
+			Operator:  &operator,
+			Threshold: &threshold,
+			Window:    &window,
+			Interval:  &interval,
+		},
+	}
+
+	return gen.GetAlertRule200JSONResponse(response), nil
+}
+
+// UpdateAlertRule implements PUT /api/v1alpha1/alerts/rules/{ruleName}.
+func (h *LogsHandler) UpdateAlertRule(ctx context.Context, request gen.UpdateAlertRuleRequestObject) (gen.UpdateAlertRuleResponseObject, error) {
+	if request.Body == nil {
+		return gen.UpdateAlertRule400JSONResponse{
+			Title:   ptr(gen.BadRequest),
+			Message: ptr("request body is required"),
+		}, nil
+	}
+
+	params := toLogAlertParams(request.Body)
+
+	alertID, err := h.client.UpdateAlert(ctx, request.RuleName, params)
+	if err != nil {
+		h.logger.Error("Failed to update alert",
+			slog.String("function", "UpdateAlertRule"),
+			slog.String("ruleName", request.RuleName),
+			slog.Any("error", err),
+		)
+		if strings.Contains(err.Error(), "not found") {
+			return gen.UpdateAlertRule404JSONResponse{
+				Title:   ptr(gen.NotFound),
+				Message: ptr("alert rule not found"),
+			}, nil
+		}
+		if strings.Contains(err.Error(), "invalid") {
+			return gen.UpdateAlertRule400JSONResponse{
+				Title:   ptr(gen.BadRequest),
+				Message: ptr(err.Error()),
+			}, nil
+		}
+		return gen.UpdateAlertRule500JSONResponse{
+			Title:   ptr(gen.InternalServerError),
+			Message: ptr("internal server error"),
+		}, nil
+	}
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	return gen.UpdateAlertRule200JSONResponse{
+		Action:        ptr(gen.Updated),
+		Status:        ptr(gen.Synced),
+		RuleLogicalId: &request.RuleName,
+		RuleBackendId: &alertID,
+		LastSyncedAt:  &now,
+	}, nil
+}
+
+// HandleAlertWebhook implements POST /api/v1alpha1/alerts/webhook.
+func (h *LogsHandler) HandleAlertWebhook(ctx context.Context, _ gen.HandleAlertWebhookRequestObject) (gen.HandleAlertWebhookResponseObject, error) {
+	go func() {
+		forwardCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		if err := h.observerClient.ForwardAlert(forwardCtx, "", "", 0, time.Time{}); err != nil {
+			h.logger.Error("Failed to forward alert webhook to observer API",
+				slog.Any("error", err),
+			)
+		}
+	}()
+
+	return gen.HandleAlertWebhook200JSONResponse{
+		Message: ptr("alert webhook received successfully"),
+		Status:  ptr(gen.Success),
 	}, nil
 }
 
@@ -272,6 +420,9 @@ func toLogAlertParams(req *gen.AlertRuleRequest) openobserve.LogAlertParams {
 		}
 	}
 	if req.Condition != nil {
+		if req.Condition.Enabled != nil {
+			params.Enabled = req.Condition.Enabled
+		}
 		if req.Condition.Operator != nil {
 			params.Operator = string(*req.Condition.Operator)
 		}

--- a/observability-logs-openobserve/internal/observer/client.go
+++ b/observability-logs-openobserve/internal/observer/client.go
@@ -1,0 +1,76 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package observer
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+type Client struct {
+	baseURL    string
+	httpClient *http.Client
+}
+
+func NewClient(baseURL string) *Client {
+	return &Client{
+		baseURL: strings.TrimRight(baseURL, "/"),
+		httpClient: &http.Client{
+			Timeout: 10 * time.Second,
+		},
+	}
+}
+
+type alertWebhookRequest struct {
+	RuleName       string    `json:"ruleName"`
+	RuleNamespace  string    `json:"ruleNamespace"`
+	AlertValue     float64   `json:"alertValue"`
+	AlertTimestamp time.Time `json:"alertTimestamp"`
+}
+
+func (c *Client) ForwardAlert(
+	ctx context.Context,
+	ruleName string,
+	ruleNamespace string,
+	alertValue float64,
+	alertTimestamp time.Time,
+) error {
+	payload := alertWebhookRequest{
+		RuleName:       ruleName,
+		RuleNamespace:  ruleNamespace,
+		AlertValue:     alertValue,
+		AlertTimestamp: alertTimestamp,
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("failed to marshal webhook payload: %w", err)
+	}
+
+	url := c.baseURL + "/api/v1alpha1/alerts/webhook"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to call observer webhook endpoint: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("observer webhook endpoint returned status %d: %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
+	}
+
+	return nil
+}

--- a/observability-logs-openobserve/internal/openobserve/client.go
+++ b/observability-logs-openobserve/internal/openobserve/client.go
@@ -70,6 +70,7 @@ type LogAlertParams struct {
 	ThresholdValue float32 `json:"thresholdValue"`
 	Window         string  `json:"window"`
 	Interval       string  `json:"interval"`
+	Enabled        *bool   `json:"enabled"`
 }
 
 // ComponentLogsEntry represents a parsed log entry.
@@ -313,15 +314,15 @@ func (c *Client) CreateAlert(ctx context.Context, params LogAlertParams) (string
 		return "", fmt.Errorf("openobserve returned status %d: %s", resp.StatusCode, string(body))
 	}
 
-	// Try to extract alert_id from response
+	// Try to extract id from response
 	var createResp struct {
-		AlertID string `json:"alert_id"`
+		AlertID string `json:"id"`
 	}
 	if err := json.Unmarshal(body, &createResp); err == nil && createResp.AlertID != "" {
 		return createResp.AlertID, nil
 	}
 
-	return "", fmt.Errorf("openobserve create alert response missing alert_id")
+	return "", fmt.Errorf("openobserve create alert response missing id")
 }
 
 // DeleteAlert deletes an alert from OpenObserve by name and returns the backend alert ID.
@@ -414,6 +415,175 @@ func (c *Client) getAlertIDByName(ctx context.Context, name string) (string, err
 	}
 
 	return "", fmt.Errorf("alert %q not found", name)
+}
+
+// AlertDetail represents the parsed details of an OpenObserve alert.
+type AlertDetail struct {
+	Name           string
+	Enabled        bool
+	SQL            string
+	Operator       string
+	Threshold      float64
+	Period         int
+	Frequency      int
+	FrequencyType  string
+	Namespace      string
+	ProjectUID     string
+	EnvironmentUID string
+	ComponentUID   string
+}
+
+// UpdateAlert updates an alert in OpenObserve by name and returns the alert ID.
+// It first looks up the alert ID by name, then updates it with the provided config.
+func (c *Client) UpdateAlert(ctx context.Context, alertName string, params LogAlertParams) (string, error) {
+	// Look up the alert ID by name
+	alertID, err := c.getAlertIDByName(ctx, alertName)
+	if err != nil {
+		return "", fmt.Errorf("failed to find alert %q: %w", alertName, err)
+	}
+
+	// Ensure the canonical alertName from the path is used, not the one from the request body
+	params.Name = &alertName
+
+	// Generate alert configuration JSON
+	alertJSON, err := generateAlertConfig(params, c.stream, c.logger)
+	if err != nil {
+		c.logger.Error("Failed to generate alert config", slog.Any("error", err))
+		return "", fmt.Errorf("failed to generate alert config: %w", err)
+	}
+
+	// Build the API endpoint
+	url := fmt.Sprintf("%s/api/v2/%s/alerts/%s", c.baseURL, c.org, alertID)
+
+	// Create request
+	req, err := http.NewRequestWithContext(ctx, "PUT", url, bytes.NewBuffer(alertJSON))
+	if err != nil {
+		c.logger.Error("Failed to create request", slog.Any("error", err))
+		return "", fmt.Errorf("failed to create request: %w", err)
+	}
+
+	// Set headers
+	req.Header.Set("Content-Type", "application/json")
+	req.SetBasicAuth(c.user, c.token)
+
+	// Execute request
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		c.logger.Error("Failed to execute alert update request", slog.Any("error", err))
+		return "", fmt.Errorf("failed to execute request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Read response body
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		c.logger.Error("Failed to read response body", slog.Any("error", err))
+		return "", fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	// Check status code
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		c.logger.Error("OpenObserve returned error",
+			slog.Int("statusCode", resp.StatusCode),
+			slog.String("body", string(body)))
+		return "", fmt.Errorf("openobserve returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	return alertID, nil
+}
+
+// GetAlert retrieves an alert from OpenObserve by name and returns its details.
+// It first looks up the alert ID by name using the list API, then fetches the
+// full alert details (including context_attributes) using the individual get API.
+func (c *Client) GetAlert(ctx context.Context, alertName string) (*AlertDetail, error) {
+	alertID, err := c.getAlertIDByName(ctx, alertName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find alert %q: %w", alertName, err)
+	}
+
+	url := fmt.Sprintf("%s/api/v2/%s/alerts/%s", c.baseURL, c.org, alertID)
+
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		c.logger.Error("Failed to create request", slog.Any("error", err))
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.SetBasicAuth(c.user, c.token)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		c.logger.Error("Failed to execute get alert request", slog.Any("error", err))
+		return nil, fmt.Errorf("failed to execute request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		c.logger.Error("Failed to read response body", slog.Any("error", err))
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		c.logger.Error("OpenObserve returned error",
+			slog.Int("statusCode", resp.StatusCode),
+			slog.String("body", string(body)))
+		return nil, fmt.Errorf("openobserve returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var raw map[string]interface{}
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
+	}
+
+	detail := &AlertDetail{}
+
+	if name, ok := raw["name"].(string); ok {
+		detail.Name = name
+	}
+	if enabled, ok := raw["enabled"].(bool); ok {
+		detail.Enabled = enabled
+	}
+
+	if qc, ok := raw["query_condition"].(map[string]interface{}); ok {
+		if sql, ok := qc["sql"].(string); ok {
+			detail.SQL = sql
+		}
+	}
+
+	if tc, ok := raw["trigger_condition"].(map[string]interface{}); ok {
+		if op, ok := tc["operator"].(string); ok {
+			detail.Operator = op
+		}
+		if threshold, ok := tc["threshold"].(float64); ok {
+			detail.Threshold = threshold
+		}
+		if period, ok := tc["period"].(float64); ok {
+			detail.Period = int(period)
+		}
+		if freq, ok := tc["frequency"].(float64); ok {
+			detail.Frequency = int(freq)
+		}
+		if ft, ok := tc["frequency_type"].(string); ok {
+			detail.FrequencyType = ft
+		}
+	}
+
+	if ca, ok := raw["context_attributes"].(map[string]interface{}); ok {
+		if v, ok := ca["namespace"].(string); ok {
+			detail.Namespace = v
+		}
+		if v, ok := ca["projectUid"].(string); ok {
+			detail.ProjectUID = v
+		}
+		if v, ok := ca["environmentUid"].(string); ok {
+			detail.EnvironmentUID = v
+		}
+		if v, ok := ca["componentUid"].(string); ok {
+			detail.ComponentUID = v
+		}
+	}
+
+	return detail, nil
 }
 
 // parseApplicationLogEntry parses an application log from OpenObserve response

--- a/observability-logs-openobserve/internal/openobserve/queries.go
+++ b/observability-logs-openobserve/internal/openobserve/queries.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"regexp"
 	"strings"
 )
 
@@ -44,6 +45,80 @@ func mapOperator(op string) (string, error) {
 	}
 }
 
+// ReverseMapOperator maps the OpenObserve SQL operator back to the API operator string.
+func ReverseMapOperator(op string) string {
+	switch op {
+	case "=":
+		return "eq"
+	case ">":
+		return "gt"
+	case ">=":
+		return "gte"
+	case "<":
+		return "lt"
+	case "<=":
+		return "lte"
+	case "!=":
+		return "neq"
+	default:
+		return op
+	}
+}
+
+// strMatchPattern matches str_match(log, 'pattern') in SQL queries.
+// The pattern allows embedded doubled single quotes (SQL escape: '' for ').
+var strMatchPattern = regexp.MustCompile(`str_match\s*\(\s*log\s*,\s*'((?:[^']|'')*)'\s*\)`)
+
+// ExtractSearchPattern extracts the search pattern from a str_match SQL expression.
+// It unescapes SQL-escaped doubled single quotes ('') and doubled backslashes (\\)
+// to reverse the escaping performed by escapeSQLString.
+func ExtractSearchPattern(sql string) string {
+	matches := strMatchPattern.FindStringSubmatch(sql)
+	if len(matches) >= 2 {
+		// Unescape SQL-escaped doubled quotes and backslashes.
+		// Order matters: unescape quotes first, then backslashes, to properly
+		// reverse the escaping done by escapeSQLString.
+		pattern := matches[1]
+		pattern = strings.ReplaceAll(pattern, "''", "'")
+		pattern = strings.ReplaceAll(pattern, "\\\\", "\\")
+		return pattern
+	}
+	return ""
+}
+
+// ToDurationString converts a period value and frequency type to a duration string.
+func ToDurationString(value int, frequencyType string) string {
+	switch frequencyType {
+	case "minutes":
+		return fmt.Sprintf("%dm", value)
+	case "hours":
+		return fmt.Sprintf("%dh", value)
+	default:
+		return fmt.Sprintf("%dm", value)
+	}
+}
+
+// parseDurationMinutes parses a duration string like "5m" or "2h" and returns the value in minutes.
+func parseDurationMinutes(duration string) (int, error) {
+	if len(duration) < 2 {
+		return 0, fmt.Errorf("invalid duration string: %q", duration)
+	}
+	unit := duration[len(duration)-1]
+	valueStr := duration[:len(duration)-1]
+	var value int
+	if _, err := fmt.Sscanf(valueStr, "%d", &value); err != nil {
+		return 0, fmt.Errorf("invalid duration value in %q: %w", duration, err)
+	}
+	switch unit {
+	case 'm':
+		return value, nil
+	case 'h':
+		return value * 60, nil
+	default:
+		return 0, fmt.Errorf("unsupported duration unit %q in %q", string(unit), duration)
+	}
+}
+
 // generateAlertConfig generates an OpenObserve alert configuration as JSON
 func generateAlertConfig(params LogAlertParams, streamName string, logger *slog.Logger) ([]byte, error) {
 	query := fmt.Sprintf(
@@ -63,20 +138,41 @@ func generateAlertConfig(params LogAlertParams, streamName string, logger *slog.
 		alertName = *params.Name
 	}
 
+	period, err := parseDurationMinutes(params.Window)
+	if err != nil {
+		return nil, fmt.Errorf("invalid alert window: %w", err)
+	}
+
+	frequency, err := parseDurationMinutes(params.Interval)
+	if err != nil {
+		return nil, fmt.Errorf("invalid alert interval: %w", err)
+	}
+
 	alertConfig := map[string]interface{}{
-		"name":        alertName,
-		"stream_name": streamName,
-		"query":       query,
-		"condition": map[string]interface{}{
-			"column":   "match_count",
-			"operator": sqlOperator,
-			"value":    params.ThresholdValue,
+		"name":         alertName,
+		"stream_name":  streamName,
+		"stream_type":  "logs",
+		"enabled":      *params.Enabled,
+		"is_real_time": false,
+		"query_condition": map[string]interface{}{
+			"type":       "sql",
+			"sql":        query,
+			"conditions": nil,
 		},
-		"duration":     params.Window,
-		"frequency":    params.Interval,
-		"is_realtime":  "no",
+		"trigger_condition": map[string]interface{}{
+			"period":    period,
+			"frequency": frequency,
+			"threshold": params.ThresholdValue,
+			"operator":  sqlOperator,
+			"silence":   0,
+		},
 		"destinations": []string{"openchoreo_alerts"},
-		"alert_type":   "scheduled",
+		"context_attributes": map[string]interface{}{
+			"namespace":      params.Namespace,
+			"projectUid":     params.ProjectUID,
+			"environmentUid": params.EnvironmentUID,
+			"componentUid":   params.ComponentUID,
+		},
 	}
 
 	if logger.Enabled(nil, slog.LevelDebug) {

--- a/observability-logs-openobserve/main.go
+++ b/observability-logs-openobserve/main.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	app "github.com/openchoreo/community-modules/observability-logs-openobserve/internal"
+	"github.com/openchoreo/community-modules/observability-logs-openobserve/internal/observer"
 	"github.com/openchoreo/community-modules/observability-logs-openobserve/internal/openobserve"
 )
 
@@ -94,8 +95,9 @@ func main() {
 
 	logger.Info("Successfully connected to OpenObserve")
 
-	// Create handlers and server
-	logsHandler := app.NewLogsHandler(client, logger)
+	// Create observer client and handlers
+	observerClient := observer.NewClient(cfg.ObserverURL)
+	logsHandler := app.NewLogsHandler(client, observerClient, logger)
 	srv := app.NewServer(cfg.ServerPort, logsHandler, logger)
 
 	go func() {


### PR DESCRIPTION
## Purpose

Add webhook API endpoint and GET/UPDATE operations for alert rules management in the OpenObserve adapter. This enables integration with OpenObserve and provides complete CRUD operations for alert rule management.

## Goals
1. Implement a webhook API endpoint (POST /api/v1alpha1/alerts/webhook) to receive alert notifications from OpenObserve and forward them to external observer service
2. Add GET endpoint (GET /api/v1alpha1/alerts/rules/{ruleName}) to retrieve existing alert rule details
3. Add UPDATE endpoint (PUT /api/v1alpha1/alerts/rules/{ruleName}) to modify alert rule configurations
4. Introduce Observer service client for forwarding alert webhooks to external systems
5. Move environment variables to a centralized ConfigMap in the Helm chart for better configuration management

## Approach

API Enhancements:
- Added three new API handlers: GetAlertRule(), UpdateAlertRule(), and HandleWebhook()
- Implemented alert status tracking with fields for conditions, state, and metadata
- Added OpenChoreo integration metadata (project, environment, component UIDs)

Observer Integration:
- Created new observer/client.go package to handle webhook forwarding with:
   - Alert serialization with rule name, namespace, value, and timestamp
   - HTTP-based webhook posting to external observer services with configurable timeout
- Updated handlers to inject and use the observer client for alert forwarding

Configuration Management:
- Added OBSERVER_URL environment variable (defaults to http://observer:8080)
- Created Helm ConfigMap template (templates/adapter/configmap.yaml) centralizing environment variables:
  - SERVER_PORT, OPENOBSERVE_URL, OPENOBSERVE_ORG, OPENOBSERVE_STREAM, OBSERVER_URL
- Updated Helm values with adapter.observerUrl configuration
- Updated deployment to use envFrom.configMapRef for automatic environment variable injection


## Related PRs
https://github.com/openchoreo/openchoreo/issues/2587

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added endpoints to retrieve and update alert rules
  * Integrated an observer client to forward alert webhooks asynchronously

* **Bug Fixes**
  * More robust webhook destination handling with update/delete/create and HTTP status checks

* **Chores**
  * Bumped Helm chart to 0.3.0
  * Switched adapter environment sourcing to a ConfigMap
  * Added configurable observer URL

* **Documentation**
  * Updated installation/usage commands to reference the new chart version
<!-- end of auto-generated comment: release notes by coderabbit.ai -->