### PR TITLE
refactor: get default image tag of OpenSearch module jobs from Helm chart's AppVersion

### DIFF
--- a/observability-logs-opensearch/helm/Chart.yaml
+++ b/observability-logs-opensearch/helm/Chart.yaml
@@ -5,8 +5,8 @@ apiVersion: v2
 name: observability-logs-opensearch
 description: A Helm chart for OpenChoreo Observability Logs module with Fluent Bit and OpenSearch
 type: application
-version: 0.3.3
-appVersion: "0.3.3"
+version: 0.3.4
+appVersion: "0.3.4"
 keywords:
   - opensearch
   - observability

--- a/observability-logs-opensearch/helm/templates/opensearch-setup-logs/job.yaml
+++ b/observability-logs-opensearch/helm/templates/opensearch-setup-logs/job.yaml
@@ -37,7 +37,7 @@ spec:
           value: "{{ .Values.openSearchSetup.dataRetentionTime.containerLogs }}"
         - name: RCA_REPORTS_MIN_INDEX_AGE
           value: "{{ .Values.openSearchSetup.dataRetentionTime.rcaReports }}"
-        image: "{{ .Values.openSearchSetup.image.repository }}:{{ .Values.openSearchSetup.image.tag | default .Chart.Version }}"
+        image: "{{ .Values.openSearchSetup.image.repository }}:{{ .Values.openSearchSetup.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.openSearchSetup.image.pullPolicy | default "IfNotPresent" }}
         resources:
           requests:

--- a/observability-tracing-opensearch/helm/Chart.yaml
+++ b/observability-tracing-opensearch/helm/Chart.yaml
@@ -5,8 +5,8 @@ apiVersion: v2
 name: observability-tracing-opensearch
 description: A Helm chart for OpenChoreo Observability Tracing module with OpenTelemetry Collector and OpenSearch
 type: application
-version: 0.3.3
-appVersion: "0.3.3"
+version: 0.3.4
+appVersion: "0.3.4"
 keywords:
   - opensearch
   - observability

--- a/observability-tracing-opensearch/helm/templates/opensearch-setup/job.yaml
+++ b/observability-tracing-opensearch/helm/templates/opensearch-setup/job.yaml
@@ -33,7 +33,7 @@ spec:
               key: password
         - name: OTEL_TRACES_MIN_INDEX_AGE
           value: "{{ .Values.openSearchSetup.dataRetentionTime.traces }}"
-        image: "{{ .Values.openSearchSetup.image.repository }}:{{ .Values.openSearchSetup.image.tag | default .Chart.Version }}"
+        image: "{{ .Values.openSearchSetup.image.repository }}:{{ .Values.openSearchSetup.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.openSearchSetup.image.pullPolicy | default "IfNotPresent" }}
         resources:
           requests:


### PR DESCRIPTION
## Purpose
Change the logic which sets the default image tag of setup jobs in OpenSearch modules. It is currently set based on the Chart version. But some CD tools override the chart version and this can break deployments

## Goals
Change how setup jobs gets the image tag

## Approach
Change from using Chart.version to Chart.AppVersion


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped chart and app versions (0.3.3 → 0.3.4) for OpenSearch Helm charts.
  * Updated container image tag resolution to use the application version, improving consistency of deployed OpenSearch setup jobs with release versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->