### PR TITLE
fix: address OpenObserve logs module build failure and add PR check to identify them

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -10,6 +10,10 @@ on:
       - "**/init/**"
       - "**/helm/**"
       - "**/module.yaml"
+      - "**/*.go"
+      - "**/go.mod"
+      - "**/go.sum"
+      - "**/Dockerfile"
 
 permissions:
   contents: read
@@ -77,3 +81,74 @@ jobs:
 
           echo ""
           echo "All changed modules have version bumps. ✓"
+
+  docker-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install yq
+        uses: mikefarah/yq@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker images for changed modules
+        run: |
+          set -euo pipefail
+
+          # Get the list of changed files compared to the base branch
+          CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
+
+          echo "Changed files:"
+          echo "$CHANGED_FILES"
+          echo ""
+
+          BUILD_COUNT=0
+
+          for module_dir in */; do
+            module="${module_dir%/}"
+
+            # Skip if this module has no module.yaml
+            if [ ! -f "${module}/module.yaml" ]; then
+              continue
+            fi
+
+            # Check if any files in this module were changed
+            if ! echo "$CHANGED_FILES" | grep -q "^${module}/"; then
+              continue
+            fi
+
+            image_count=$(yq '.images | length' "${module}/module.yaml")
+            if [ "$image_count" = "0" ] || [ "$image_count" = "null" ]; then
+              echo "Skipping ${module}: no images defined"
+              continue
+            fi
+
+            for i in $(seq 0 $((image_count - 1))); do
+              image_name=$(yq ".images[${i}].name" "${module}/module.yaml")
+              context=$(yq ".images[${i}].context" "${module}/module.yaml")
+              dockerfile=$(yq ".images[${i}].dockerfile" "${module}/module.yaml")
+
+              echo "::group::Building ${image_name} (${module})"
+              docker buildx build \
+                --platform linux/amd64 \
+                --load \
+                -t "${image_name}:pr-validation" \
+                -f "${module}/${dockerfile}" \
+                "${module}/${context}"
+              echo "::endgroup::"
+
+              BUILD_COUNT=$((BUILD_COUNT + 1))
+            done
+          done
+
+          echo ""
+          if [ "$BUILD_COUNT" -eq 0 ]; then
+            echo "No Docker images to build for changed modules."
+          else
+            echo "Successfully built ${BUILD_COUNT} image(s). ✓"
+          fi

--- a/observability-logs-openobserve/README.md
+++ b/observability-logs-openobserve/README.md
@@ -27,7 +27,7 @@ helm upgrade --install observability-logs-openobserve \
   oci://ghcr.io/openchoreo/helm-charts/observability-logs-openobserve \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.3.0
+  --version 0.3.1
 ```
 
 ## Enable log collection
@@ -38,7 +38,7 @@ Enable Fluent Bit to start collecting logs from the cluster and publish to OpenO
 helm upgrade observability-logs-openobserve \
   oci://ghcr.io/openchoreo/helm-charts/observability-logs-openobserve \
   --namespace openchoreo-observability-plane \
-  --version 0.3.0 \
+  --version 0.3.1 \
   --reuse-values \
   --set fluent-bit.enabled=true
 ```

--- a/observability-logs-openobserve/helm/Chart.yaml
+++ b/observability-logs-openobserve/helm/Chart.yaml
@@ -5,8 +5,8 @@ apiVersion: v2
 name: observability-logs-openobserve
 description: A Helm chart for OpenChoreo Logs Module for OpenObserve
 type: application
-version: 0.3.0
-appVersion: "0.3.0"
+version: 0.3.1
+appVersion: "0.3.1"
 keywords:
   - openobserve
   - openchoreo

--- a/observability-logs-openobserve/internal/handlers.go
+++ b/observability-logs-openobserve/internal/handlers.go
@@ -263,8 +263,8 @@ func (h *LogsHandler) UpdateAlertRule(ctx context.Context, request gen.UpdateAle
 			slog.Any("error", err),
 		)
 		if strings.Contains(err.Error(), "not found") {
-			return gen.UpdateAlertRule404JSONResponse{
-				Title:   ptr(gen.NotFound),
+			return gen.UpdateAlertRule500JSONResponse{
+				Title:   ptr(gen.InternalServerError),
 				Message: ptr("alert rule not found"),
 			}, nil
 		}


### PR DESCRIPTION
## Purpose
Fix build failure in OpenObserve logs module
Add PR check to identify build failures during PR checks

## Goals
Fix build failure and prevent recurrence 

## Approach
Fixed the build failure in the OpenObserve logs module
Added a job to the PR workflow to run Docker builds as a PR check

## Related PRs
https://github.com/openchoreo/openchoreo/issues/2587

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Helm chart bumped to v0.3.1.
  * CI enhanced to automatically build and validate Docker images for changed modules in pull requests.

* **Bug Fixes**
  * Adjusted error response handling for alert rule updates (status code returned for not-found cases changed).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->