### PR TITLE
fix: update body of OpenObserve log's module's webhook API

### DIFF
--- a/observability-logs-openobserve/README.md
+++ b/observability-logs-openobserve/README.md
@@ -27,7 +27,7 @@ helm upgrade --install observability-logs-openobserve \
   oci://ghcr.io/openchoreo/helm-charts/observability-logs-openobserve \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.3.1
+  --version 0.3.2
 ```
 
 ## Enable log collection
@@ -38,7 +38,7 @@ Enable Fluent Bit to start collecting logs from the cluster and publish to OpenO
 helm upgrade observability-logs-openobserve \
   oci://ghcr.io/openchoreo/helm-charts/observability-logs-openobserve \
   --namespace openchoreo-observability-plane \
-  --version 0.3.1 \
+  --version 0.3.2 \
   --reuse-values \
   --set fluent-bit.enabled=true
 ```

--- a/observability-logs-openobserve/helm/Chart.yaml
+++ b/observability-logs-openobserve/helm/Chart.yaml
@@ -5,8 +5,8 @@ apiVersion: v2
 name: observability-logs-openobserve
 description: A Helm chart for OpenChoreo Logs Module for OpenObserve
 type: application
-version: 0.3.1
-appVersion: "0.3.1"
+version: 0.3.2
+appVersion: "0.3.2"
 keywords:
   - openobserve
   - openchoreo

--- a/observability-logs-openobserve/init/setup-openobserve.sh
+++ b/observability-logs-openobserve/init/setup-openobserve.sh
@@ -75,7 +75,7 @@ else
     -H "Content-Type: application/json" \
     -d "{
       \"name\": \"$TEMPLATE_NAME\",
-      \"body\": \"{alert_name} {alert_type} {org_name} {stream_name}\",
+      \"body\": {\"alertName\": \"{alert_name}\", \"alertTriggerTimeMicroSeconds\": \"{alert_trigger_time}\", \"alertCount\": \"{alert_count}\"},
       \"type\": \"http\"
     }")
 

--- a/observability-logs-openobserve/internal/handlers.go
+++ b/observability-logs-openobserve/internal/handlers.go
@@ -5,7 +5,9 @@ package app
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
+	"strconv"
 	"strings"
 	"time"
 
@@ -291,12 +293,40 @@ func (h *LogsHandler) UpdateAlertRule(ctx context.Context, request gen.UpdateAle
 }
 
 // HandleAlertWebhook implements POST /api/v1alpha1/alerts/webhook.
-func (h *LogsHandler) HandleAlertWebhook(ctx context.Context, _ gen.HandleAlertWebhookRequestObject) (gen.HandleAlertWebhookResponseObject, error) {
+func (h *LogsHandler) HandleAlertWebhook(ctx context.Context, request gen.HandleAlertWebhookRequestObject) (gen.HandleAlertWebhookResponseObject, error) {
+	if request.Body == nil {
+		h.logger.Warn("Alert webhook received with nil body")
+		return gen.HandleAlertWebhook200JSONResponse{
+			Message: ptr("alert webhook received successfully"),
+			Status:  ptr(gen.Success),
+		}, nil
+	}
+	body := *request.Body
+
+	alertName, ruleName, alertCount, alertTimestamp, err := parseAlertWebhookBody(body)
+	if err != nil {
+		h.logger.Error("Failed to parse alert webhook body", slog.Any("error", err))
+		return gen.HandleAlertWebhook200JSONResponse{
+			Message: ptr("alert webhook received successfully"),
+			Status:  ptr(gen.Success),
+		}, nil
+	}
+
 	go func() {
 		forwardCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
 
-		if err := h.observerClient.ForwardAlert(forwardCtx, "", "", 0, time.Time{}); err != nil {
+		// Retrieve the alert details from OpenObserve to get the namespace. This is because the webhook body does not contain the namespace, but the observer's webhook API requires it.
+		alertDetail, err := h.client.GetAlert(forwardCtx, alertName)
+		if err != nil {
+			h.logger.Error("Failed to get alert details from OpenObserve",
+				slog.String("alertName", alertName),
+				slog.Any("error", err),
+			)
+			return
+		}
+
+		if err := h.observerClient.ForwardAlert(forwardCtx, ruleName, alertDetail.Namespace, alertCount, alertTimestamp); err != nil {
 			h.logger.Error("Failed to forward alert webhook to observer API",
 				slog.Any("error", err),
 			)
@@ -307,6 +337,51 @@ func (h *LogsHandler) HandleAlertWebhook(ctx context.Context, _ gen.HandleAlertW
 		Message: ptr("alert webhook received successfully"),
 		Status:  ptr(gen.Success),
 	}, nil
+}
+
+// parseAlertWebhookBody extracts alert fields from the incoming OpenObserve webhook body.
+// It returns the alertName, ruleName (same as alertName), alertCount, and alertTimestamp.
+func parseAlertWebhookBody(body map[string]interface{}) (alertName string, ruleName string, alertCount float64, alertTimestamp time.Time, err error) {
+	nameVal, ok := body["alertName"]
+	if !ok {
+		return "", "", 0, time.Time{}, fmt.Errorf("missing alertName in webhook body")
+	}
+	alertName, ok = nameVal.(string)
+	if !ok {
+		return "", "", 0, time.Time{}, fmt.Errorf("alertName is not a string")
+	}
+	ruleName = alertName
+
+	if countVal, ok := body["alertCount"]; ok {
+		switch v := countVal.(type) {
+		case float64:
+			alertCount = v
+		case string:
+			alertCount, err = strconv.ParseFloat(v, 64)
+			if err != nil {
+				return "", "", 0, time.Time{}, fmt.Errorf("failed to parse alertCount %q: %w", v, err)
+			}
+		}
+	}
+
+	if tsVal, ok := body["alertTriggerTimeMicroSeconds"]; ok {
+		switch v := tsVal.(type) {
+		case float64:
+			alertTimestamp = time.UnixMicro(int64(v))
+		case string:
+			usec, parseErr := strconv.ParseInt(v, 10, 64)
+			if parseErr != nil {
+				return "", "", 0, time.Time{}, fmt.Errorf("failed to parse alertTriggerTimeMicroSeconds %q: %w", v, parseErr)
+			}
+			alertTimestamp = time.UnixMicro(usec)
+		default:
+			alertTimestamp = time.Now()
+		}
+	} else {
+		alertTimestamp = time.Now()
+	}
+
+	return alertName, ruleName, alertCount, alertTimestamp, nil
 }
 
 // toWorkflowLogsParams converts the generated request to internal workflow query params.


### PR DESCRIPTION
## Purpose
When an OpenObserve alert is triggered, the adapter's webhook endpoint receives the alert notification but does not extract or forward the alert details to the observer. 

## Goals
- Parse the incoming OpenObserve webhook body to extract alertName, alertCount, and alertTriggerTimeMicroSeconds.
- Resolve the ruleNamespace (not present in the incoming webhook body) by fetching the alert details from OpenObserve using the existing GetAlert function.
- Forward a fully populated webhook request to the observer matching its expected AlertWebhookRequest schema (ruleName, ruleNamespace, alertValue, alertTimestamp).

## Approach
- Updated the OpenObserve alert template to send a JSON object with alert details
- Updated HandleAlertWebhook in internal/handlers.go to parse the incoming request body and extract alert fields.
- Added a parseAlertWebhookBody helper that extracts alertName (mapped to ruleName), alertCount (mapped to alertValue), and alertTriggerTimeMicroSeconds (converted from microseconds to time.Time and mapped to alertTimestamp).
- Within the async goroutine, calls the existing GetAlert method on the OpenObserve client to look up the alert by name. This internally uses getAlertIDByName (GET /api/v2/{org}/alerts) to resolve the alert ID, then fetches the full alert details (GET /api/v2/{org}/alerts/{alertID}) to retrieve context_attributes.namespace.
- Passes the extracted namespace as ruleNamespace along with the other parsed fields to ForwardAlert, which POSTs the complete AlertWebhookRequest payload to the observer.

## Related PRs
https://github.com/openchoreo/openchoreo/issues/2587

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped Helm chart and app version to 0.3.2.

* **Bug Fixes**
  * Improved alert webhook handling to more reliably parse and forward alert details.
  * Changed alert notification payload to a structured JSON format for more consistent processing and delivery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->