### PR TITLE
fix: add helm hook policies for observability setup jobs

### DIFF
--- a/observability-logs-openobserve/README.md
+++ b/observability-logs-openobserve/README.md
@@ -27,7 +27,7 @@ helm upgrade --install observability-logs-openobserve \
   oci://ghcr.io/openchoreo/helm-charts/observability-logs-openobserve \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.3.3
+  --version 0.3.4
 ```
 
 ## Enable log collection
@@ -38,7 +38,7 @@ Enable Fluent Bit to start collecting logs from the cluster and publish to OpenO
 helm upgrade observability-logs-openobserve \
   oci://ghcr.io/openchoreo/helm-charts/observability-logs-openobserve \
   --namespace openchoreo-observability-plane \
-  --version 0.3.3 \
+  --version 0.3.4 \
   --reuse-values \
   --set fluent-bit.enabled=true
 ```

--- a/observability-logs-openobserve/helm/Chart.yaml
+++ b/observability-logs-openobserve/helm/Chart.yaml
@@ -5,8 +5,8 @@ apiVersion: v2
 name: observability-logs-openobserve
 description: A Helm chart for OpenChoreo Logs Module for OpenObserve
 type: application
-version: 0.3.3
-appVersion: "0.3.3"
+version: 0.3.4
+appVersion: "0.3.4"
 keywords:
   - openobserve
   - openchoreo

--- a/observability-logs-openobserve/helm/templates/openobserve-setup/job.yaml
+++ b/observability-logs-openobserve/helm/templates/openobserve-setup/job.yaml
@@ -6,6 +6,9 @@ kind: Job
 metadata:
   name: openobserve-setup-logs
   namespace: {{ .Release.Namespace }}
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation
   labels:
     app: openobserve-setup-logs
 spec:

--- a/observability-logs-opensearch/README.md
+++ b/observability-logs-opensearch/README.md
@@ -68,7 +68,7 @@ helm upgrade --install observability-logs-opensearch \
 >   oci://ghcr.io/openchoreo/helm-charts/observability-logs-opensearch \
 >   --create-namespace \
 >   --namespace openchoreo-observability-plane \
->   --version 0.3.5 \
+>   --version 0.3.6 \
 >   --set openSearch.enabled=false \
 >   --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials"
 > ```
@@ -82,7 +82,7 @@ helm upgrade observability-logs-opensearch \
   oci://ghcr.io/openchoreo/helm-charts/observability-logs-opensearch \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.3.5 \
+  --version 0.3.6 \
   --reuse-values \
   --set fluent-bit.enabled=true
 ```

--- a/observability-logs-opensearch/helm/Chart.yaml
+++ b/observability-logs-opensearch/helm/Chart.yaml
@@ -5,8 +5,8 @@ apiVersion: v2
 name: observability-logs-opensearch
 description: A Helm chart for OpenChoreo Observability Logs module with Fluent Bit and OpenSearch
 type: application
-version: 0.3.5
-appVersion: "0.3.5"
+version: 0.3.6
+appVersion: "0.3.6"
 keywords:
   - opensearch
   - observability

--- a/observability-logs-opensearch/helm/templates/opensearch-setup-logs/job.yaml
+++ b/observability-logs-opensearch/helm/templates/opensearch-setup-logs/job.yaml
@@ -12,6 +12,7 @@ metadata:
   namespace: {{.Release.Namespace}}
   annotations:
     helm.sh/hook: post-install, post-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation
 spec:
   template:
     spec:

--- a/observability-tracing-opensearch/README.md
+++ b/observability-tracing-opensearch/README.md
@@ -57,7 +57,7 @@ helm upgrade --install observability-tracing-opensearch \
   oci://ghcr.io/openchoreo/helm-charts/observability-tracing-opensearch \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.3.5 \
+  --version 0.3.6 \
   --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials"
 ```
 
@@ -68,7 +68,7 @@ helm upgrade --install observability-tracing-opensearch \
 >   oci://ghcr.io/openchoreo/helm-charts/observability-tracing-opensearch \
 >   --create-namespace \
 >   --namespace openchoreo-observability-plane \
->   --version 0.3.5 \
+>   --version 0.3.6 \
 >   --set openSearch.enabled=false \
 >   --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials"
 > ```

--- a/observability-tracing-opensearch/helm/Chart.yaml
+++ b/observability-tracing-opensearch/helm/Chart.yaml
@@ -5,8 +5,8 @@ apiVersion: v2
 name: observability-tracing-opensearch
 description: A Helm chart for OpenChoreo Observability Tracing module with OpenTelemetry Collector and OpenSearch
 type: application
-version: 0.3.5
-appVersion: "0.3.5"
+version: 0.3.6
+appVersion: "0.3.6"
 keywords:
   - opensearch
   - observability

--- a/observability-tracing-opensearch/helm/templates/opensearch-setup/job.yaml
+++ b/observability-tracing-opensearch/helm/templates/opensearch-setup/job.yaml
@@ -12,6 +12,7 @@ metadata:
   namespace: {{.Release.Namespace}}
   annotations:
     helm.sh/hook: post-install, post-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation
 spec:
   template:
     spec:


### PR DESCRIPTION
## Purpose
https://github.com/openchoreo/openchoreo/issues/2636
Ensure that observability setup jobs will get deleted and recreated during helm chart upgrades

## Goals
Ensure that helm upgrades won't get blocked due to observability setup jobs

## Approach
1. Added `helm.sh/hook: post-install,post-upgrade` and `helm.sh/hook-delete-policy: before-hook-creation` annotation to observability-logs-openobserve module
2. Added `helm.sh/hook-delete-policy: before-hook-creation` in observability-*-opensearch modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Releases**
  * OpenObserve observability module released as v0.3.3
  * OpenSearch-based observability modules (logging and tracing) released as v0.3.5

* **Documentation**
  * Installation guides updated with current Helm version references

* **Chores**
  * Helm chart metadata bumped to new release versions
  * Setup jobs configured to run as install/upgrade hooks to streamline deployments
<!-- end of auto-generated comment: release notes by coderabbit.ai -->