### PR TITLE
refactor: read OpenSearch credentials for Fluent Bit from env variables and update resource values

### DIFF
--- a/observability-logs-openobserve/README.md
+++ b/observability-logs-openobserve/README.md
@@ -27,7 +27,7 @@ helm upgrade --install observability-logs-openobserve \
   oci://ghcr.io/openchoreo/helm-charts/observability-logs-openobserve \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.3.5
+  --version 0.3.6
 ```
 
 ## Enable log collection
@@ -38,7 +38,7 @@ Enable Fluent Bit to start collecting logs from the cluster and publish to OpenO
 helm upgrade observability-logs-openobserve \
   oci://ghcr.io/openchoreo/helm-charts/observability-logs-openobserve \
   --namespace openchoreo-observability-plane \
-  --version 0.3.5 \
+  --version 0.3.6 \
   --reuse-values \
   --set fluent-bit.enabled=true
 ```

--- a/observability-logs-openobserve/helm/Chart.yaml
+++ b/observability-logs-openobserve/helm/Chart.yaml
@@ -5,8 +5,8 @@ apiVersion: v2
 name: observability-logs-openobserve
 description: A Helm chart for OpenChoreo Logs Module for OpenObserve
 type: application
-version: 0.3.5
-appVersion: "0.3.5"
+version: 0.3.6
+appVersion: "0.3.6"
 keywords:
   - openobserve
   - openchoreo

--- a/observability-logs-openobserve/helm/values.yaml
+++ b/observability-logs-openobserve/helm/values.yaml
@@ -25,7 +25,7 @@ fluent-bit:
           DB /var/lib/fluent-bit/db/tail-container-logs.db
           Exclude_Path /var/log/containers/fluent-bit-*_openchoreo-observability-plane_*.log
           Inotify_Watcher false
-          Mem_Buf_Limit 256MB
+          Mem_Buf_Limit 100MB
           Path /var/log/containers/*.log
           multiline.parser docker, cri
           Read_from_Head On
@@ -36,7 +36,7 @@ fluent-bit:
     filters: |
       [FILTER]
           Name kubernetes
-          Buffer_Size 32MB
+          Buffer_Size 15MB
           K8S-Logging.Parser On
           K8S-Logging.Exclude On
           Keep_Log On
@@ -91,11 +91,11 @@ fluent-bit:
 
   resources:
     limits:
-      cpu: 200m
-      memory: 256Mi
-    requests:
       cpu: 100m
-      memory: 128Mi
+      memory: 150Mi
+    requests:
+      cpu: 25m
+      memory: 125Mi
 
   securityContext:
     allowPrivilegeEscalation: false

--- a/observability-logs-opensearch/README.md
+++ b/observability-logs-opensearch/README.md
@@ -57,7 +57,7 @@ helm upgrade --install observability-logs-opensearch \
   oci://ghcr.io/openchoreo/helm-charts/observability-logs-opensearch \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.3.5 \
+  --version 0.3.7 \
   --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials"
 ```
 
@@ -68,7 +68,7 @@ helm upgrade --install observability-logs-opensearch \
 >   oci://ghcr.io/openchoreo/helm-charts/observability-logs-opensearch \
 >   --create-namespace \
 >   --namespace openchoreo-observability-plane \
->   --version 0.3.6 \
+>   --version 0.3.7 \
 >   --set openSearch.enabled=false \
 >   --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials"
 > ```
@@ -82,7 +82,7 @@ helm upgrade observability-logs-opensearch \
   oci://ghcr.io/openchoreo/helm-charts/observability-logs-opensearch \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.3.6 \
+  --version 0.3.7 \
   --reuse-values \
   --set fluent-bit.enabled=true
 ```

--- a/observability-logs-opensearch/helm/Chart.yaml
+++ b/observability-logs-opensearch/helm/Chart.yaml
@@ -5,8 +5,8 @@ apiVersion: v2
 name: observability-logs-opensearch
 description: A Helm chart for OpenChoreo Observability Logs module with Fluent Bit and OpenSearch
 type: application
-version: 0.3.6
-appVersion: "0.3.6"
+version: 0.3.7
+appVersion: "0.3.7"
 keywords:
   - opensearch
   - observability

--- a/observability-logs-opensearch/helm/values.yaml
+++ b/observability-logs-opensearch/helm/values.yaml
@@ -21,7 +21,7 @@ fluent-bit:
           DB /var/lib/fluent-bit/db/tail-container-logs.db
           Exclude_Path /var/log/containers/fluent-bit-*.log
           Inotify_Watcher false
-          Mem_Buf_Limit 256MB
+          Mem_Buf_Limit 100MB
           Path /var/log/containers/*.log
           multiline.parser docker, cri
           Read_from_Head On
@@ -32,7 +32,7 @@ fluent-bit:
     filters: |
       [FILTER]
           Name kubernetes
-          Buffer_Size 32MB
+          Buffer_Size 15MB
           K8S-Logging.Parser On
           K8S-Logging.Exclude On
           Keep_Log On
@@ -46,8 +46,8 @@ fluent-bit:
           Name opensearch
           Host opensearch
           Generate_ID On
-          HTTP_Passwd ThisIsTheOpenSearchPassword1
-          HTTP_User admin
+          HTTP_Passwd ${OPENSEARCH_PASSWORD}
+          HTTP_User ${OPENSEARCH_USERNAME}
           Logstash_Format On
           Logstash_DateFormat %Y-%m-%d
           Logstash_Prefix container-logs
@@ -57,6 +57,18 @@ fluent-bit:
           Suppress_Type_Name On
           tls On
           tls.verify Off
+
+  env:
+  - name: OPENSEARCH_USERNAME
+    valueFrom:
+      secretKeyRef:
+        name: opensearch-admin-credentials
+        key: username
+  - name: OPENSEARCH_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: opensearch-admin-credentials
+        key: password
 
   dnsPolicy: ClusterFirstWithHostNet
   fullnameOverride: "fluent-bit"
@@ -78,11 +90,11 @@ fluent-bit:
 
   resources:
     limits:
-      cpu: 200m
-      memory: 256Mi
-    requests:
       cpu: 100m
-      memory: 128Mi
+      memory: 150Mi
+    requests:
+      cpu: 25m
+      memory: 125Mi
 
   securityContext:
     allowPrivilegeEscalation: false


### PR DESCRIPTION
## Purpose
The observability-logs-opensearch Helm chart had OpenSearch credentials (username and password) in the Fluent Bit output configuration. Additionally, Fluent Bit resource limits and requests across both charts were over-provisioned for typical workloads.

## Goals
- Eliminate OpenSearch credentials from the Fluent Bit configuration
- Right-size Fluent Bit resource allocations in both observability-logs-opensearch and observability-logs-openobserve charts to reduce resource consumption

## Approach
- Credential handling (observability-logs-opensearch): Read username and password from environment variables
- Resource tuning (both charts): Reduced Fluent Bit resource requests and limits 
  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Replaced hardcoded OpenSearch credentials with secret-backed environment variables.

* **Chores**
  * Bumped observability-logs-openobserve to v0.3.6 and observability-logs-opensearch to v0.3.7.
  * Reduced Fluent Bit memory/buffer settings and lowered CPU/memory requests & limits for smaller resource footprint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->