### PR TITLE
feat: disable dynamic mapping of fields in OpenSearch indices and update workflow namespace

### DIFF
--- a/observability-logs-openobserve/internal/openobserve/queries.go
+++ b/observability-logs-openobserve/internal/openobserve/queries.go
@@ -191,7 +191,7 @@ func generateWorkflowLogsQuery(params WorkflowLogsParams, stream string, logger 
 
 	// Add namespace filter
 	if params.Namespace != "" {
-		conditions = append(conditions, "kubernetes_namespace_name = 'openchoreo-ci-"+escapeSQLString(params.Namespace)+"'")
+		conditions = append(conditions, "kubernetes_namespace_name = 'workflows-"+escapeSQLString(params.Namespace)+"'")
 	}
 
 	// Add workflow run name filter

--- a/observability-logs-opensearch/README.md
+++ b/observability-logs-opensearch/README.md
@@ -57,7 +57,7 @@ helm upgrade --install observability-logs-opensearch \
   oci://ghcr.io/openchoreo/helm-charts/observability-logs-opensearch \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.3.7 \
+  --version 0.3.8 \
   --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials"
 ```
 
@@ -68,7 +68,7 @@ helm upgrade --install observability-logs-opensearch \
 >   oci://ghcr.io/openchoreo/helm-charts/observability-logs-opensearch \
 >   --create-namespace \
 >   --namespace openchoreo-observability-plane \
->   --version 0.3.7 \
+>   --version 0.3.8 \
 >   --set openSearch.enabled=false \
 >   --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials"
 > ```
@@ -82,7 +82,7 @@ helm upgrade observability-logs-opensearch \
   oci://ghcr.io/openchoreo/helm-charts/observability-logs-opensearch \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.3.7 \
+  --version 0.3.8 \
   --reuse-values \
   --set fluent-bit.enabled=true
 ```

--- a/observability-logs-opensearch/helm/Chart.yaml
+++ b/observability-logs-opensearch/helm/Chart.yaml
@@ -5,8 +5,8 @@ apiVersion: v2
 name: observability-logs-opensearch
 description: A Helm chart for OpenChoreo Observability Logs module with Fluent Bit and OpenSearch
 type: application
-version: 0.3.7
-appVersion: "0.3.7"
+version: 0.3.8
+appVersion: "0.3.8"
 keywords:
   - opensearch
   - observability

--- a/observability-logs-opensearch/init/setup-opensearch.sh
+++ b/observability-logs-opensearch/init/setup-opensearch.sh
@@ -65,9 +65,70 @@ containerLogsIndexTemplate='
       "number_of_replicas": 1
     },
     "mappings": {
+      "dynamic": "false",
       "properties": {
-        "timestamp": {
+        "@timestamp": {
           "type": "date"
+        },
+        "kubernetes": {
+          "properties": {
+            "annotations": {
+              "properties": {
+                "workflows_argoproj_io/node-name": {
+                  "type": "keyword"
+                }
+              }
+            },
+            "container_name": {
+              "type": "keyword"
+            },
+            "labels": {
+              "properties": {
+                "build-name": {
+                  "type": "keyword"
+                },
+                "openchoreo_dev/component": {
+                  "type": "keyword"
+                },
+                "openchoreo_dev/component-uid": {
+                  "type": "keyword"
+                },
+                "openchoreo_dev/environment": {
+                  "type": "keyword"
+                },
+                "openchoreo_dev/environment-uid": {
+                  "type": "keyword"
+                },
+                "openchoreo_dev/namespace": {
+                  "type": "keyword"
+                },
+                "openchoreo_dev/project": {
+                  "type": "keyword"
+                },
+                "openchoreo_dev/project-uid": {
+                  "type": "keyword"
+                },
+                "target": {
+                  "type": "keyword"
+                },
+                "uuid": {
+                  "type": "keyword"
+                },
+                "version": {
+                  "type": "keyword"
+                },
+                "version_id": {
+                  "type": "keyword"
+                }
+              }
+            },
+            "namespace_name": {
+              "type": "keyword"
+            },
+            "pod_name": {
+              "type": "keyword"
+            }
+          }
         },
         "log": {
           "type": "wildcard"
@@ -89,6 +150,7 @@ rcaReportsIndexTemplate='
       "number_of_replicas": 1
     },
     "mappings": {
+      "dynamic": "false",
       "properties": {
         "@timestamp": {
           "type": "date"

--- a/observability-tracing-opensearch/README.md
+++ b/observability-tracing-opensearch/README.md
@@ -57,7 +57,7 @@ helm upgrade --install observability-tracing-opensearch \
   oci://ghcr.io/openchoreo/helm-charts/observability-tracing-opensearch \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.3.6 \
+  --version 0.3.7 \
   --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials"
 ```
 
@@ -68,7 +68,7 @@ helm upgrade --install observability-tracing-opensearch \
 >   oci://ghcr.io/openchoreo/helm-charts/observability-tracing-opensearch \
 >   --create-namespace \
 >   --namespace openchoreo-observability-plane \
->   --version 0.3.6 \
+>   --version 0.3.7 \
 >   --set openSearch.enabled=false \
 >   --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials"
 > ```

--- a/observability-tracing-opensearch/helm/Chart.yaml
+++ b/observability-tracing-opensearch/helm/Chart.yaml
@@ -5,8 +5,8 @@ apiVersion: v2
 name: observability-tracing-opensearch
 description: A Helm chart for OpenChoreo Observability Tracing module with OpenTelemetry Collector and OpenSearch
 type: application
-version: 0.3.6
-appVersion: "0.3.6"
+version: 0.3.7
+appVersion: "0.3.7"
 keywords:
   - opensearch
   - observability

--- a/observability-tracing-opensearch/init/setup-opensearch.sh
+++ b/observability-tracing-opensearch/init/setup-opensearch.sh
@@ -53,6 +53,7 @@ otelTracesIndexTemplate='
       "number_of_replicas": 1
     },
     "mappings": {
+      "dynamic": "false",
       "properties": {
         "endTime": {
           "type": "date_nanos"


### PR DESCRIPTION
## Purpose
https://github.com/openchoreo/openchoreo/issues/2670

## Goals
Currently, log fields are dynamically mapped in OpenSearch. This means that even fields that are not queried get mapped. This is not required. Hence this PR disabled it.
Also updates the workflow name

## Approach
1. Set dynamic to strict in the index mapping
2. Added missing fields to the index mapping
3. Workflow namespace has been changed from `openchoreo-ci-<namespace>` to `workflows-<namespace>`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Index templates now enforce non-dynamic mappings and standardize timestamps to @timestamp.
  * Logs observability includes expanded Kubernetes metadata (node, pod, namespace, container, labels).

* **Chores**
  * Bumped logs Helm chart to 0.3.8.
  * Bumped tracing Helm chart to 0.3.7.

* **Bug Fixes / Behavior**
  * Workflow logs namespace matching now uses the workflows-<namespace> prefix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->