### PR TITLE
feat: add kgateway API gateway module

### DIFF
--- a/gateway-kgateway/README.md
+++ b/gateway-kgateway/README.md
@@ -1,0 +1,299 @@
+# kgateway API Management Module for OpenChoreo Data Plane
+
+This module adds API management capabilities to OpenChoreo components using kgateway's native CRDs. It supports JWT authentication, local rate limiting, and response header modification — all configured declaratively via the `kgateway-api-management` ClusterTrait.
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Installation](#installation)
+- [Trait Parameters](#trait-parameters)
+- [Example Usage](#example-usage)
+- [How It Works](#how-it-works)
+- [Troubleshooting](#troubleshooting)
+
+---
+
+## Overview
+
+kgateway is installed by default as part of the OpenChoreo data plane. It handles all Gateway API resources (Gateway, HTTPRoute) and routes traffic to component services. This module extends kgateway with API management policies by applying the `kgateway-api-management` ClusterTrait to components.
+
+You only need this module if you want to add API management features (JWT auth, rate limiting, response headers) to your components using kgateway's native capabilities.
+
+![kgateway API Management Architecture](kgateway-api-management.svg)
+
+### Key Design Decisions
+
+- **kgateway-native**: Uses kgateway's own CRDs (TrafficPolicy, GatewayExtension, Backend) — no external API management platform required.
+- **No control plane changes**: kgateway is already installed with OpenChoreo. This module only adds a ClusterTrait and RBAC permissions.
+- **JWT provider as infrastructure**: Identity provider configuration (issuer, JWKS URL) is set once in the trait YAML. Component authors only toggle `jwt.enabled: true/false`.
+- **Per-component isolation**: Each component gets its own Backend, GatewayExtension, BackendTLSPolicy, and TrafficPolicy resources. Deleting one component does not affect others.
+- **Per-route policies**: Each TrafficPolicy targets a specific HTTPRoute identified by the `endpointName` parameter.
+
+---
+
+## Installation
+
+### Prerequisites
+
+- An existing OpenChoreo deployment with the data plane installed (kgateway is included by default)
+- kubectl configured with cluster access
+
+### Step 1: Grant RBAC Permissions
+
+The data plane service account needs permissions to manage kgateway API management resources. Create a ClusterRole and bind it to the data plane service account:
+
+```bash
+kubectl apply -f - <<EOF
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kgateway-api-management-module
+rules:
+  - apiGroups: ["gateway.kgateway.dev"]
+    resources: ["trafficpolicies", "gatewayextensions", "backends"]
+    verbs: ["*"]
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources: ["backendtlspolicies"]
+    verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kgateway-api-management-module
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kgateway-api-management-module
+subjects:
+  - kind: ServiceAccount
+    name: cluster-agent-dataplane
+    namespace: openchoreo-data-plane
+EOF
+```
+
+> **Note:** Without these permissions, the Release controller will fail to apply TrafficPolicy, GatewayExtension, Backend, and BackendTLSPolicy resources to the data plane with a "forbidden" error.
+
+### Step 2: Configure the JWT Identity Provider
+
+If you plan to use JWT authentication, update the following fields in `kgateway-api-management-trait.yaml` with your identity provider's details before applying it. These values are configured once in the trait file and used by all JWT-enabled components.
+
+**Fields to update:**
+
+| Field (in trait template)                    | Description                              | Example                                           |
+| -------------------------------------------- | ---------------------------------------- | ------------------------------------------------- |
+| Backend `spec.static.hosts[0].host`          | JWKS endpoint hostname                   | `api.asgardeo.io`                                 |
+| Backend `spec.static.hosts[0].port`          | JWKS endpoint port                       | `443`                                             |
+| BackendTLSPolicy `validation.hostname`       | SNI hostname for TLS (must match Backend host) | `api.asgardeo.io`                            |
+| GatewayExtension `issuer`                    | OIDC issuer URL                          | `https://api.asgardeo.io/t/lahirude/oauth2/token`   |
+| GatewayExtension `jwks.remote.url`           | Full JWKS endpoint URL                   | `https://api.asgardeo.io/t/lahirude/oauth2/jwks`    |
+| GatewayExtension `cacheDuration`             | How long to cache JWKS keys              | `5m`                                              |
+
+> **Note:** You can configure multiple providers in the `providers` array if you need to support multiple identity providers. If you only need rate limiting or response headers (not JWT), you can skip this step.
+
+### Step 3: Apply the ClusterTrait
+
+```bash
+kubectl apply -f kgateway-api-management-trait.yaml
+```
+
+### Step 4: Add to ComponentType
+
+Add `kgateway-api-management` to the `allowedTraits` of the target ComponentType:
+
+```bash
+kubectl patch clustercomponenttype service --type='json' \
+  -p='[{"op": "add", "path": "/spec/allowedTraits/-", "value": {"kind": "ClusterTrait", "name": "kgateway-api-management"}}]'
+```
+
+### Step 5: Verify
+
+```bash
+# Verify the ClusterTrait is registered
+kubectl get clustertrait kgateway-api-management
+
+# After deploying a component with the trait, verify resources are created
+kubectl get trafficpolicy.gateway.kgateway.dev -n <data-plane-namespace> -o wide
+kubectl get gatewayextension -n <data-plane-namespace>
+kubectl get backend.gateway.kgateway.dev -n <data-plane-namespace>
+kubectl get backendtlspolicy -n <data-plane-namespace>
+```
+
+All TrafficPolicies should show `ACCEPTED: True` and `ATTACHED: True`.
+
+---
+
+## Trait Parameters
+
+| Parameter                     | Type    | Default | Required | Description                                                                       |
+| ----------------------------- | ------- | ------- | -------- | --------------------------------------------------------------------------------- |
+| `endpointName`                | string  | —       | **Yes**  | Workload endpoint name to target (must match a key in the Workload's `endpoints`) |
+| `jwt.enabled`                 | boolean | `false` | No       | Enable JWT authentication                                                         |
+| `rateLimiting.enabled`        | boolean | `true`  | No       | Enable local rate limiting                                                        |
+| `rateLimiting.maxTokens`      | integer | `60`    | No       | Maximum number of tokens in the bucket                                            |
+| `rateLimiting.tokensPerFill`  | integer | `60`    | No       | Number of tokens added per refill                                                 |
+| `rateLimiting.fillInterval`   | string  | `"60s"` | No       | Interval between refills (e.g., `"60s"`, `"1m"`)                                  |
+| `addResponseHeaders.enabled`  | boolean | `false` | No       | Enable response header modification                                               |
+| `addResponseHeaders.headers`  | array   | `[]`    | No       | Headers to add to responses (each with `name` and `value`)                        |
+
+---
+
+## Example Usage
+
+### JWT Authentication Only
+
+```yaml
+apiVersion: openchoreo.dev/v1alpha1
+kind: Component
+metadata:
+  name: my-service
+  namespace: default
+spec:
+  owner:
+    projectName: default
+  autoDeploy: true
+  componentType:
+    kind: ClusterComponentType
+    name: deployment/service
+  traits:
+    - name: kgateway-api-management
+      instanceName: my-api
+      kind: ClusterTrait
+      parameters:
+        endpointName: http
+        jwt:
+          enabled: true
+        rateLimiting:
+          enabled: false
+```
+
+### Rate Limiting with Custom Values
+
+```yaml
+traits:
+  - name: kgateway-api-management
+    instanceName: my-api
+    kind: ClusterTrait
+    parameters:
+      endpointName: http
+      rateLimiting:
+        enabled: true
+        maxTokens: 100
+        tokensPerFill: 100
+        fillInterval: "30s"
+```
+
+### All Features Enabled
+
+```yaml
+traits:
+  - name: kgateway-api-management
+    instanceName: my-api
+    kind: ClusterTrait
+    parameters:
+      endpointName: http
+      jwt:
+        enabled: true
+      rateLimiting:
+        enabled: true
+        maxTokens: 100
+        tokensPerFill: 50
+        fillInterval: "60s"
+      addResponseHeaders:
+        enabled: true
+        headers:
+          - name: X-Powered-By
+            value: OpenChoreo
+          - name: X-Gateway
+            value: kgateway
+```
+
+---
+
+## How It Works
+
+The trait uses OpenChoreo's template rendering pipeline to create kgateway resources in the component's data plane namespace. Each feature creates its own set of resources:
+
+### JWT Authentication (`jwt.enabled: true`)
+
+Creates four resources:
+
+1. **Backend** — A `Static` backend pointing to the IdP's JWKS endpoint so kgateway can fetch JWT signing keys.
+2. **BackendTLSPolicy** — Sets the SNI hostname for the TLS connection to the JWKS endpoint. Required for IdPs behind CDN/WAF that need SNI to route requests correctly.
+3. **GatewayExtension** — Defines the JWT provider configuration (issuer, JWKS source, claim-to-header mappings).
+4. **TrafficPolicy** — Attaches JWT validation to the component's HTTPRoute via `targetRefs`.
+
+### Rate Limiting (`rateLimiting.enabled: true`)
+
+Creates one resource:
+
+- **TrafficPolicy** — Applies local token-bucket rate limiting to the component's HTTPRoute. Requests exceeding the limit receive a `429 Too Many Requests` response.
+
+### Response Headers (`addResponseHeaders.enabled: true`)
+
+Creates one resource:
+
+- **TrafficPolicy** — Adds custom headers to every response sent back to the client.
+
+### Resource Naming
+
+All resources are named using `${metadata.name}-${trait.instanceName}-<suffix>` to ensure per-component isolation. The TrafficPolicy `targetRefs` use `oc_generate_name(metadata.componentName, parameters.endpointName)` to match the HTTPRoute name generated by the ComponentType.
+
+---
+
+## Troubleshooting
+
+### TrafficPolicies not showing ACCEPTED/ATTACHED
+
+```bash
+# Check TrafficPolicy status
+kubectl get trafficpolicy.gateway.kgateway.dev -n <data-plane-namespace> -o wide
+
+# Check kgateway controller logs for errors
+kubectl logs -n openchoreo-control-plane -l app.kubernetes.io/name=kgateway --tail=50 | grep -i error
+```
+
+Common causes:
+
+- GatewayExtension or Backend not yet created (check Release controller logs).
+- HTTPRoute name mismatch — ensure `endpointName` matches a key in the Workload's `endpoints`.
+- Missing RBAC permissions (see Step 1).
+
+### JWT returns "Jwks remote fetch is failed"
+
+The JWKS endpoint is reachable but returning an error. Enable debug logging on the gateway to diagnose:
+
+```bash
+# Check the response status code in gateway logs
+kubectl logs -n openchoreo-data-plane -l app.kubernetes.io/name=gateway-default --tail=100 | grep -i "status code"
+```
+
+Common causes:
+
+- Missing `BackendTLSPolicy` — the IdP's CDN/WAF requires SNI to route requests. Ensure the BackendTLSPolicy `hostname` matches the Backend host.
+- Incorrect JWKS URL or issuer in the GatewayExtension template.
+
+### JWT returns "Jwt is missing"
+
+This is expected behavior — the JWT TrafficPolicy is enforcing authentication and no `Authorization: Bearer <token>` header was provided in the request.
+
+### Removing the Module
+
+To remove the API management module:
+
+1. Remove the `kgateway-api-management` trait from all Components.
+2. Delete the ClusterTrait:
+   ```bash
+   kubectl delete clustertrait kgateway-api-management
+   ```
+3. Remove RBAC:
+   ```bash
+   kubectl delete clusterrole kgateway-api-management-module
+   kubectl delete clusterrolebinding kgateway-api-management-module
+   ```
+4. Remove from ComponentType's `allowedTraits`:
+   ```bash
+   kubectl patch clustercomponenttype service --type='json' \
+     -p='[{"op": "remove", "path": "/spec/allowedTraits/2"}]'
+   ```
+
+> **Note:** kgateway itself is part of the OpenChoreo data plane and should not be removed.

--- a/gateway-kgateway/kgateway-api-management-trait.yaml
+++ b/gateway-kgateway/kgateway-api-management-trait.yaml
@@ -1,0 +1,257 @@
+# kgateway API Management Trait for OpenChoreo
+#
+# This trait enables kgateway API management features on HTTPRoutes:
+#   - JWT Authentication: JWT validation via GatewayExtension + Backend + TrafficPolicy
+#   - Rate Limiting: Local token-bucket rate limiting via TrafficPolicy
+#   - Response Headers: Add custom headers to responses via TrafficPolicy
+#
+# Each feature is independently toggleable. The trait conditionally creates kgateway CRDs
+# and patches the HTTPRoute with the appropriate ExtensionRef filters.
+#
+# JWT Identity Provider Configuration:
+#   The JWT provider details (issuer, JWKS URL, audiences, etc.) are configured once
+#   in this trait file before applying it to the cluster. When any component enables JWT,
+#   the trait creates a shared GatewayExtension ("jwt-idp-providers") and Backend
+#   ("jwt-idp-jwks") in the component's data plane namespace. All JWT-enabled components
+#   in the same namespace share these resources.
+#
+#   Update the GatewayExtension and Backend templates below with your identity provider
+#   details before applying this trait. See README.md for configuration guidance.
+#
+# Prerequisites:
+#   - kgateway installed in the data plane
+#   - kgateway CRDs available (TrafficPolicy, GatewayExtension, Backend)
+#   - ComponentType must have an HTTPRoute resource for the patch to target
+#
+# Usage:
+#   1. Update the JWT provider configuration in this file (issuer, JWKS URL, audiences)
+#   2. Apply this trait to the control plane
+#   3. Add "kgateway-api-management" to the ComponentType's allowedTraits
+#   4. Reference it in the Component's traits with desired parameters
+
+---
+apiVersion: openchoreo.dev/v1alpha1
+kind: ClusterTrait
+metadata:
+  name: kgateway-api-management
+spec:
+  parameters:
+    openAPIV3Schema:
+      type: object
+      $defs:
+        # --- JWT authentication configuration ---
+        # Controls JWT validation via kgateway's GatewayExtension and TrafficPolicy.
+        # When enabled, creates a shared GatewayExtension and Backend for the JWT
+        # identity provider, plus a per-route TrafficPolicy for JWT enforcement.
+        # The identity provider details (issuer, JWKS, audiences) are configured
+        # in the trait template below — not as component parameters.
+        JwtConfig:
+          type: object
+          properties:
+            enabled:
+              type: boolean
+              default: false
+
+        # --- local rate-limiting configuration ---
+        # Controls kgateway's local token-bucket rate limiting via TrafficPolicy.
+        # When enabled, creates a TrafficPolicy with a local rate limit.
+        RateLimitConfig:
+          type: object
+          properties:
+            enabled:
+              type: boolean
+              default: true
+            # Maximum number of tokens available in the bucket
+            maxTokens:
+              type: integer
+              default: 60
+            # Number of tokens added per refill
+            tokensPerFill:
+              type: integer
+              default: 60
+            # Interval between refills (e.g., "60s", "1m")
+            fillInterval:
+              type: string
+              default: "60s"
+
+        # --- response header modification configuration ---
+        # Controls adding custom headers to responses via TrafficPolicy.
+        # When enabled, creates a TrafficPolicy with headerModifiers.
+        # Each header entry has "name" and "value" fields.
+        AddResponseHeadersConfig:
+          type: object
+          properties:
+            enabled:
+              type: boolean
+              default: false
+            headers:
+              type: array
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  value:
+                    type: string
+              default: []
+
+      properties:
+        # Name of the workload endpoint this trait targets.
+        # Must match an endpoint key defined in the Workload spec.
+        # Used to resolve the HTTPRoute name via oc_generate_name.
+        endpointName:
+          type: string
+        jwt:
+          $ref: "#/$defs/JwtConfig"
+          default: {}
+        rateLimiting:
+          $ref: "#/$defs/RateLimitConfig"
+          default: {}
+        addResponseHeaders:
+          $ref: "#/$defs/AddResponseHeadersConfig"
+          default: {}
+      required:
+        - endpointName
+
+  creates:
+    # --- Backend: JWKS endpoint for JWT validation ---
+    # Created when jwt.enabled is true.
+    # Points to the external JWKS host so kgateway can fetch signing keys.
+    # Each component gets its own Backend (named per component) so deleting
+    # one component does not affect others in the same namespace.
+    #
+    # >>> UPDATE: Replace host and port with your identity provider's JWKS endpoint.
+    - includeWhen: ${parameters.jwt.enabled}
+      template:
+        apiVersion: gateway.kgateway.dev/v1alpha1
+        kind: Backend
+        metadata:
+          name: ${metadata.name}-${trait.instanceName}-jwks
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+        spec:
+          type: Static
+          static:
+            hosts:
+              - host: api.asgardeo.io    # Replace with your IdP's JWKS host
+                port: 443                 # Replace with the JWKS endpoint port
+
+    # --- BackendTLSPolicy: TLS configuration for the JWKS Backend ---
+    # Created when jwt.enabled is true.
+    # Sets the SNI hostname for the TLS connection to the JWKS endpoint.
+    # Without this, Envoy connects to the static IP without SNI, causing
+    # CDN/WAF fronting the IdP to reject the request.
+    #
+    # >>> UPDATE: Replace hostname with your identity provider's JWKS host.
+    - includeWhen: ${parameters.jwt.enabled}
+      template:
+        apiVersion: gateway.networking.k8s.io/v1alpha3
+        kind: BackendTLSPolicy
+        metadata:
+          name: ${metadata.name}-${trait.instanceName}-jwks-tls
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+        spec:
+          targetRefs:
+            - group: gateway.kgateway.dev
+              kind: Backend
+              name: ${metadata.name}-${trait.instanceName}-jwks
+          validation:
+            hostname: api.asgardeo.io    # Replace with your IdP's JWKS host (must match Backend host)
+            wellKnownCACertificates: System
+
+    # --- GatewayExtension: JWT provider configuration ---
+    # Created when jwt.enabled is true.
+    # Defines the JWT provider with issuer, audiences, JWKS source, and claim mapping.
+    # Each component gets its own GatewayExtension (named per component) so deleting
+    # one component does not affect others in the same namespace.
+    #
+    # >>> UPDATE: Replace issuer, audiences, jwks URL, and claimsToHeaders
+    # >>> with your identity provider's configuration.
+    - includeWhen: ${parameters.jwt.enabled}
+      template:
+        apiVersion: gateway.kgateway.dev/v1alpha1
+        kind: GatewayExtension
+        metadata:
+          name: ${metadata.name}-${trait.instanceName}-jwt
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+        spec:
+          jwt:
+            providers:
+              - name: default
+                issuer: "https://api.asgardeo.io/t/lahirude/oauth2/token"          # Replace with your IdP issuer URL
+                jwks:
+                  remote:
+                    url: "https://api.asgardeo.io/t/lahirude/oauth2/jwks"           # Replace with your JWKS URL
+                    backendRef:
+                      group: gateway.kgateway.dev
+                      kind: Backend
+                      name: ${metadata.name}-${trait.instanceName}-jwks
+                    cacheDuration: "5m"
+
+    # --- TrafficPolicy: JWT authentication enforcement ---
+    # Created when jwt.enabled is true.
+    # Attaches JWT validation to the HTTPRoute via targetRefs.
+    # References the per-component GatewayExtension.
+    - includeWhen: ${parameters.jwt.enabled}
+      template:
+        apiVersion: gateway.kgateway.dev/v1alpha1
+        kind: TrafficPolicy
+        metadata:
+          name: ${metadata.name}-${trait.instanceName}-jwt-auth
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+        spec:
+          targetRefs:
+            - group: gateway.networking.k8s.io
+              kind: HTTPRoute
+              name: ${oc_generate_name(metadata.componentName, parameters.endpointName)}
+          jwtAuth:
+            extensionRef:
+              name: ${metadata.name}-${trait.instanceName}-jwt
+
+    # --- TrafficPolicy: Local Rate Limiting ---
+    # Created when rateLimiting.enabled is true.
+    # Uses token-bucket algorithm for per-route local rate limiting.
+    - includeWhen: ${parameters.rateLimiting.enabled}
+      template:
+        apiVersion: gateway.kgateway.dev/v1alpha1
+        kind: TrafficPolicy
+        metadata:
+          name: ${metadata.name}-${trait.instanceName}-rate-limit
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+        spec:
+          targetRefs:
+            - group: gateway.networking.k8s.io
+              kind: HTTPRoute
+              name: ${oc_generate_name(metadata.componentName, parameters.endpointName)}
+          rateLimit:
+            local:
+              tokenBucket:
+                maxTokens: ${parameters.rateLimiting.maxTokens}
+                tokensPerFill: ${parameters.rateLimiting.tokensPerFill}
+                fillInterval: ${parameters.rateLimiting.fillInterval}
+
+    # --- TrafficPolicy: Response Header Modification ---
+    # Created when addResponseHeaders.enabled is true.
+    # Adds custom headers to every response sent back to the client.
+    - includeWhen: ${parameters.addResponseHeaders.enabled}
+      template:
+        apiVersion: gateway.kgateway.dev/v1alpha1
+        kind: TrafficPolicy
+        metadata:
+          name: ${metadata.name}-${trait.instanceName}-response-headers
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+        spec:
+          targetRefs:
+            - group: gateway.networking.k8s.io
+              kind: HTTPRoute
+              name: ${oc_generate_name(metadata.componentName, parameters.endpointName)}
+          headerModifiers:
+            response:
+              add: ${parameters.addResponseHeaders.headers}
+
+---

--- a/gateway-kgateway/kgateway-api-management.svg
+++ b/gateway-kgateway/kgateway-api-management.svg
@@ -1,0 +1,173 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 620" font-family="'Segoe UI', system-ui, -apple-system, sans-serif">
+  <defs>
+    <linearGradient id="controlPlane" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#e8eaf6"/>
+      <stop offset="100%" stop-color="#c5cae9"/>
+    </linearGradient>
+    <linearGradient id="dataPlane" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#ede7f6"/>
+      <stop offset="100%" stop-color="#d1c4e9"/>
+    </linearGradient>
+    <linearGradient id="kgatewayGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#7e57c2"/>
+      <stop offset="100%" stop-color="#5e35b1"/>
+    </linearGradient>
+    <linearGradient id="kgatewayCtrlGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#9575cd"/>
+      <stop offset="100%" stop-color="#7e57c2"/>
+    </linearGradient>
+    <linearGradient id="componentGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#42a5f5"/>
+      <stop offset="100%" stop-color="#1e88e5"/>
+    </linearGradient>
+    <linearGradient id="controllerGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#5c6bc0"/>
+      <stop offset="100%" stop-color="#3949ab"/>
+    </linearGradient>
+    <linearGradient id="idpGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#ef6c00"/>
+      <stop offset="100%" stop-color="#e65100"/>
+    </linearGradient>
+    <filter id="shadow" x="-2%" y="-2%" width="104%" height="108%">
+      <feDropShadow dx="0" dy="2" stdDeviation="3" flood-opacity="0.12"/>
+    </filter>
+    <filter id="shadowSm" x="-2%" y="-2%" width="104%" height="108%">
+      <feDropShadow dx="0" dy="1" stdDeviation="2" flood-opacity="0.1"/>
+    </filter>
+    <marker id="arrowHead" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6 Z" fill="#546e7a"/>
+    </marker>
+    <marker id="arrowHeadPurple" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6 Z" fill="#7e57c2"/>
+    </marker>
+    <marker id="arrowHeadOrange" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6 Z" fill="#ef6c00"/>
+    </marker>
+  </defs>
+
+  <!-- Background -->
+  <rect width="780" height="620" rx="12" fill="#fafafa"/>
+
+  <!-- Title -->
+  <text x="390" y="36" text-anchor="middle" font-size="18" font-weight="700" fill="#263238">kgateway API Management Module &#x2014; Architecture</text>
+  <text x="390" y="56" text-anchor="middle" font-size="11" fill="#78909c">JWT Authentication &#x00B7; Rate Limiting &#x00B7; Response Headers via kgateway-native CRDs</text>
+
+  <!-- ==================== CONTROL PLANE ==================== -->
+  <rect x="40" y="76" width="700" height="74" rx="8" fill="url(#controlPlane)" filter="url(#shadow)" stroke="#9fa8da" stroke-width="1"/>
+  <text x="52" y="94" font-size="9" font-weight="600" fill="#3949ab" letter-spacing="1">CONTROL PLANE</text>
+
+  <!-- OpenChoreo Controllers -->
+  <rect x="52" y="102" width="290" height="36" rx="5" fill="url(#controllerGrad)" filter="url(#shadowSm)"/>
+  <text x="197" y="122" text-anchor="middle" font-size="11" font-weight="500" fill="#fff">OpenChoreo Controllers</text>
+  <text x="197" y="134" text-anchor="middle" font-size="8" fill="#c5cae9">Renders ClusterTrait templates into kgateway CRDs</text>
+
+  <!-- ClusterTrait badge -->
+  <rect x="370" y="102" width="356" height="36" rx="5" fill="#fff" filter="url(#shadowSm)" stroke="#9fa8da" stroke-width="1"/>
+  <text x="382" y="118" font-size="9" font-weight="600" fill="#3949ab">ClusterTrait</text>
+  <text x="467" y="118" font-size="9" fill="#546e7a">kgateway-api-management</text>
+  <text x="382" y="132" font-size="8" fill="#78909c">Defines JWT, RateLimit, ResponseHeader templates</text>
+
+  <!-- Arrow: Control Plane → Data Plane -->
+  <line x1="197" y1="150" x2="197" y2="182" stroke="#546e7a" stroke-width="1.5" marker-end="url(#arrowHead)"/>
+  <text x="210" y="170" font-size="8" fill="#78909c">applies</text>
+
+  <!-- ==================== DATA PLANE ==================== -->
+  <rect x="40" y="186" width="700" height="400" rx="8" fill="url(#dataPlane)" filter="url(#shadow)" stroke="#b39ddb" stroke-width="1"/>
+  <text x="52" y="204" font-size="9" font-weight="600" fill="#4527a0" letter-spacing="1">DATA PLANE</text>
+
+  <!-- Gateway CR -->
+  <rect x="60" y="216" width="180" height="52" rx="6" fill="#fff" filter="url(#shadowSm)" stroke="#b39ddb" stroke-width="1"/>
+  <text x="72" y="234" font-size="9" font-weight="600" fill="#4527a0">Gateway CR</text>
+  <text x="72" y="248" font-size="9" fill="#546e7a">name: gateway-default</text>
+  <text x="72" y="260" font-size="9" fill="#7e57c2" font-weight="500">class: kgateway</text>
+
+  <!-- HTTPRoute -->
+  <rect x="270" y="216" width="180" height="52" rx="6" fill="#fff" filter="url(#shadowSm)" stroke="#b39ddb" stroke-width="1"/>
+  <text x="282" y="234" font-size="9" font-weight="600" fill="#4527a0">HTTPRoute</text>
+  <text x="282" y="248" font-size="9" fill="#546e7a">parentRef: gateway-default</text>
+  <text x="282" y="260" font-size="9" fill="#546e7a">path: /my-service</text>
+
+  <!-- Arrow: HTTPRoute → Gateway CR -->
+  <line x1="270" y1="242" x2="243" y2="242" stroke="#546e7a" stroke-width="1" stroke-dasharray="4,3" marker-end="url(#arrowHead)"/>
+
+  <!-- kgateway Controller -->
+  <rect x="270" y="290" width="180" height="50" rx="8" fill="url(#kgatewayCtrlGrad)" filter="url(#shadow)"/>
+  <text x="360" y="312" text-anchor="middle" font-size="11" font-weight="600" fill="#fff">kgateway Controller</text>
+  <text x="360" y="328" text-anchor="middle" font-size="9" fill="#e8eaf6">Watches Gateway API CRDs</text>
+
+  <!-- kgateway Proxy -->
+  <rect x="60" y="290" width="180" height="50" rx="8" fill="url(#kgatewayGrad)" filter="url(#shadow)"/>
+  <text x="150" y="310" text-anchor="middle" font-size="11" font-weight="600" fill="#fff">kgateway Proxy</text>
+  <text x="150" y="324" text-anchor="middle" font-size="9" fill="#e8eaf6">Envoy-based &#x00B7; :9080 &#x00B7; :9443</text>
+
+  <!-- Arrow: kgateway controller → kgateway proxy -->
+  <line x1="270" y1="315" x2="243" y2="315" stroke="#d1c4e9" stroke-width="1.5" marker-end="url(#arrowHead)"/>
+
+  <!-- Arrow: Gateway CR → kgateway proxy -->
+  <line x1="150" y1="268" x2="150" y2="287" stroke="#546e7a" stroke-width="1.5" marker-end="url(#arrowHead)"/>
+
+  <!-- Component Pod -->
+  <rect x="80" y="380" width="160" height="42" rx="6" fill="url(#componentGrad)" filter="url(#shadowSm)"/>
+  <text x="160" y="400" text-anchor="middle" font-size="10" font-weight="500" fill="#fff">Component Pod</text>
+  <text x="160" y="414" text-anchor="middle" font-size="9" fill="#e3f2fd">:9090</text>
+
+  <!-- Arrow: kgateway proxy → Pod -->
+  <line x1="150" y1="340" x2="150" y2="377" stroke="#546e7a" stroke-width="1.5" marker-end="url(#arrowHead)"/>
+
+  <!-- ==================== TRAIT RESOURCES (right side) ==================== -->
+  <text x="510" y="210" font-size="9" font-weight="600" fill="#4527a0" letter-spacing="0.5">TRAIT-GENERATED RESOURCES</text>
+
+  <!-- GatewayExtension -->
+  <rect x="500" y="220" width="220" height="42" rx="5" fill="#fff" filter="url(#shadowSm)" stroke="#7e57c2" stroke-width="1"/>
+  <text x="514" y="237" font-size="9" font-weight="600" fill="#7e57c2">GatewayExtension</text>
+  <text x="514" y="252" font-size="8" fill="#546e7a">JWT provider config (issuer, JWKS)</text>
+  <!-- includeWhen badge top-right -->
+  <rect x="654" y="222" width="62" height="14" rx="3" fill="#e8f5e9" stroke="#a5d6a7" stroke-width="0.5"/>
+  <text x="685" y="232" text-anchor="middle" font-size="7" fill="#2e7d32">jwt.enabled</text>
+
+  <!-- Backend -->
+  <rect x="500" y="272" width="220" height="42" rx="5" fill="#fff" filter="url(#shadowSm)" stroke="#7e57c2" stroke-width="1"/>
+  <text x="514" y="289" font-size="9" font-weight="600" fill="#7e57c2">Backend</text>
+  <text x="514" y="304" font-size="8" fill="#546e7a">Static host &#x2192; IdP JWKS endpoint</text>
+  <!-- includeWhen badge top-right -->
+  <rect x="654" y="274" width="62" height="14" rx="3" fill="#e8f5e9" stroke="#a5d6a7" stroke-width="0.5"/>
+  <text x="685" y="284" text-anchor="middle" font-size="7" fill="#2e7d32">jwt.enabled</text>
+
+  <!-- BackendTLSPolicy -->
+  <rect x="500" y="324" width="220" height="42" rx="5" fill="#fff" filter="url(#shadowSm)" stroke="#7e57c2" stroke-width="1"/>
+  <text x="514" y="341" font-size="9" font-weight="600" fill="#7e57c2">BackendTLSPolicy</text>
+  <text x="514" y="356" font-size="8" fill="#546e7a">SNI hostname for JWKS TLS</text>
+  <!-- includeWhen badge top-right -->
+  <rect x="654" y="326" width="62" height="14" rx="3" fill="#e8f5e9" stroke="#a5d6a7" stroke-width="0.5"/>
+  <text x="685" y="336" text-anchor="middle" font-size="7" fill="#2e7d32">jwt.enabled</text>
+
+  <!-- TrafficPolicy badges -->
+  <rect x="500" y="382" width="220" height="28" rx="5" fill="#ede7f6" stroke="#7e57c2" stroke-width="1"/>
+  <text x="610" y="401" text-anchor="middle" font-size="9" font-weight="600" fill="#5e35b1">TrafficPolicy: JWT Auth</text>
+
+  <rect x="500" y="420" width="220" height="28" rx="5" fill="#ede7f6" stroke="#7e57c2" stroke-width="1"/>
+  <text x="610" y="439" text-anchor="middle" font-size="9" font-weight="600" fill="#5e35b1">TrafficPolicy: Rate Limit</text>
+
+  <rect x="500" y="458" width="220" height="28" rx="5" fill="#ede7f6" stroke="#7e57c2" stroke-width="1"/>
+  <text x="610" y="477" text-anchor="middle" font-size="9" font-weight="600" fill="#5e35b1">TrafficPolicy: Resp Headers</text>
+
+  <!-- Single combined arrow: TrafficPolicies → HTTPRoute (targetRef) -->
+  <path d="M500,396 L472,396 L472,250 L453,250" stroke="#7e57c2" stroke-width="1.2" fill="none" stroke-dasharray="4,3" marker-end="url(#arrowHeadPurple)"/>
+  <line x1="500" y1="434" x2="472" y2="434" stroke="#7e57c2" stroke-width="1.2" stroke-dasharray="4,3"/>
+  <line x1="500" y1="472" x2="472" y2="472" stroke="#7e57c2" stroke-width="1.2" stroke-dasharray="4,3"/>
+  <!-- Vertical connector joining all three to single line -->
+  <line x1="472" y1="396" x2="472" y2="472" stroke="#7e57c2" stroke-width="1.2" stroke-dasharray="4,3"/>
+  <text x="478" y="446" font-size="7" fill="#7e57c2">targetRef</text>
+
+  <!-- ==================== EXTERNAL: Identity Provider ==================== -->
+  <rect x="500" y="506" width="220" height="42" rx="8" fill="url(#idpGrad)" filter="url(#shadow)"/>
+  <text x="610" y="526" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">Identity Provider</text>
+  <text x="610" y="540" text-anchor="middle" font-size="8" fill="#ffe0b2">JWKS endpoint (external)</text>
+
+  <!-- Arrow: Backend → IdP (routed to the right to avoid overlapping boxes) -->
+  <path d="M720,293 L738,293 L738,527 L723,527" stroke="#ef6c00" stroke-width="1.5" fill="none" stroke-dasharray="5,3" marker-end="url(#arrowHeadOrange)"/>
+  <text x="742" y="430" font-size="7" fill="#ef6c00" transform="rotate(90,742,430)">fetches JWKS keys</text>
+
+  <!-- Footer -->
+  <text x="390" y="604" text-anchor="middle" font-size="10" fill="#90a4ae">Each feature is independently toggleable. Resources are created per-component for isolation.</text>
+</svg>


### PR DESCRIPTION
## Purpose
This PR adds kgateway API gateway module to OpenChoreo community modules. Kgateway is installed by default without the API management trait. Platform engineers can install the kgateway API management trait and configure it to provide JWT Auth, Rate limit and HTTP request manipulation policies.

related to https://github.com/openchoreo/openchoreo/issues/2589

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced API Management Module with support for JWT authentication, local rate limiting, and dynamic response header modification on HTTP routes.

* **Documentation**
  * Added comprehensive module documentation including installation steps, configuration parameters, usage examples, technical implementation details, and troubleshooting guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->