### PR TITLE
fix: bump opensearch-operator version to 2.8.4

### DIFF
--- a/observability-logs-opensearch/README.md
+++ b/observability-logs-opensearch/README.md
@@ -45,7 +45,7 @@ helm repo update
 helm install opensearch-operator opensearch-operator/opensearch-operator \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 2.8.0
+  --version 2.8.4
 ```
 
 ## Deploy Helm chart


### PR DESCRIPTION
## Summary
- Bumps the opensearch-operator install version in the README from `2.8.0` to `2.8.4`
- v2.8.0 references `gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0` which has been removed from GCR, causing `ImagePullBackOff` when installing in HA mode (`openSearchCluster.enabled=true`)
- v2.8.4 removes the `kube-rbac-proxy` sidecar entirely in favor of controller-runtime's built-in auth

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated OpenSearch operator version in Helm installation instructions throughout documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->