### PR TITLE
fix: update kube RBAC proxy image repository and tag in OpenSearch operator install command

### DIFF
--- a/observability-logs-opensearch/README.md
+++ b/observability-logs-opensearch/README.md
@@ -42,10 +42,12 @@ EOF
 ```bash
 helm repo add opensearch-operator https://opensearch-project.github.io/opensearch-k8s-operator/
 helm repo update
-helm install opensearch-operator opensearch-operator/opensearch-operator \
+helm upgrade --install opensearch-operator opensearch-operator/opensearch-operator \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 2.8.0
+  --version 2.8.0 \
+  --set kubeRbacProxy.image.repository=quay.io/brancz/kube-rbac-proxy \
+  --set kubeRbacProxy.image.tag=v0.15.0
 ```
 
 ## Deploy Helm chart

--- a/observability-tracing-opensearch/README.md
+++ b/observability-tracing-opensearch/README.md
@@ -42,10 +42,12 @@ EOF
 ```bash
 helm repo add opensearch-operator https://opensearch-project.github.io/opensearch-k8s-operator/
 helm repo update
-helm install opensearch-operator opensearch-operator/opensearch-operator \
+helm upgrade --install opensearch-operator opensearch-operator/opensearch-operator \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 2.8.0
+  --version 2.8.0 \
+  --set kubeRbacProxy.image.repository=quay.io/brancz/kube-rbac-proxy \
+  --set kubeRbacProxy.image.tag=v0.15.0
 ```
 
 ### Deploy Helm chart


### PR DESCRIPTION
## Purpose
OpenSearch operator pod goes into a crashLoopBackOff with the following image pull error
```
Failed to pull image "gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0": rpc error: code = NotFound desc = failed to pull and unpack image "gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0": failed to resolve reference "gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0": gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0: not found
```
https://github.com/openchoreo/openchoreo/issues/2709

## Goals
Fix crashLoopBackoff issue in OpenSearch operator pod

## Approach
Since the image given in the default helm values are not available, updated the command to install https://github.com/brancz/kube-rbac-proxy


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Switched installation commands to a Helm "upgrade --install" workflow for the OpenSearch operator.
  * Added explicit configuration options to set the kube-rbac-proxy image repository and tag (quay.io/brancz/kube-rbac-proxy:v0.18.2).
  * Improved command formatting for multi-line Helm invocations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->