### PR TITLE
chore: add unit test and code coverage reporting pipeline

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,16 @@
+# Copyright 2026 The OpenChoreo Authors
+# SPDX-License-Identifier: Apache-2.0
+
+components:
+  - component_id: observability_logs_openobserve
+    name: observability-logs-openobserve
+    paths:
+      - observability-logs-openobserve/**
+  - component_id: observability_metrics_prometheus
+    name: observability-metrics-prometheus
+    paths:
+      - observability-metrics-prometheus/**
+  - component_id: observability_tracing_openobserve
+    name: observability-tracing-openobserve
+    paths:
+      - observability-tracing-openobserve/**

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -17,6 +17,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   check-version-bump:
@@ -152,3 +153,79 @@ jobs:
           else
             echo "Successfully built ${BUILD_COUNT} image(s). ✓"
           fi
+
+  unit-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install yq
+        uses: mikefarah/yq@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.work
+
+      - name: Run unit tests for changed Go modules
+        run: |
+          set -euo pipefail
+
+          # Get the list of changed files compared to the base branch
+          CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
+
+          echo "Changed files:"
+          echo "$CHANGED_FILES"
+          echo ""
+
+          TEST_COUNT=0
+
+          for module_dir in */; do
+            module="${module_dir%/}"
+
+            # Skip if this module has no module.yaml
+            if [ ! -f "${module}/module.yaml" ]; then
+              continue
+            fi
+
+            # Check if any files in this module were changed
+            if ! echo "$CHANGED_FILES" | grep -q "^${module}/"; then
+              continue
+            fi
+
+            # Skip modules without images (no program code)
+            image_count=$(yq '.images | length' "${module}/module.yaml")
+            if [ "$image_count" = "0" ] || [ "$image_count" = "null" ]; then
+              echo "Skipping ${module}: no images defined"
+              continue
+            fi
+
+            # Skip modules without Go code
+            if [ ! -f "${module}/go.mod" ]; then
+              echo "Skipping ${module}: no go.mod found"
+              continue
+            fi
+
+            echo "::group::Testing ${module}"
+            (cd "${module}" && go test -coverprofile="../${module}-coverage.out" ./...)
+            echo "::endgroup::"
+
+            TEST_COUNT=$((TEST_COUNT + 1))
+          done
+
+          echo ""
+          if [ "$TEST_COUNT" -eq 0 ]; then
+            echo "No Go modules to test for changed files."
+          else
+            echo "Successfully tested ${TEST_COUNT} module(s). ✓"
+          fi
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
+        with:
+          files: ./*-coverage.out
+          fail_ci_if_error: false
+          use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}

--- a/observability-logs-openobserve/README.md
+++ b/observability-logs-openobserve/README.md
@@ -1,3 +1,5 @@
+[![Codecov](https://codecov.io/gh/openchoreo/community-modules/branch/main/graph/badge.svg?component=observability_logs_openobserve)](https://codecov.io/gh/openchoreo/community-modules)
+
 # Observability Logs Module for OpenObserve
 
 This module collects container logs using Fluent Bit and stores them in OpenObserve.

--- a/observability-metrics-prometheus/README.md
+++ b/observability-metrics-prometheus/README.md
@@ -1,3 +1,5 @@
+[![Codecov](https://codecov.io/gh/openchoreo/community-modules/branch/main/graph/badge.svg?component=observability_metrics_prometheus)](https://codecov.io/gh/openchoreo/community-modules)
+
 # Observability Metrics Module with Prometheus
 
 This module collects and stores metrics using Prometheus.

--- a/observability-tracing-openobserve/README.md
+++ b/observability-tracing-openobserve/README.md
@@ -1,3 +1,5 @@
+[![Codecov](https://codecov.io/gh/openchoreo/community-modules/branch/main/graph/badge.svg?component=observability_tracing_openobserve)](https://codecov.io/gh/openchoreo/community-modules)
+
 # Observability Tracing Module for OpenObserve
 
 This module collects distributed traces using OpenTelemetry collector and stores them in OpenObserve.


### PR DESCRIPTION
## Purpose
The repository has no unit test or code coverage pipeline. There's no way to track test coverage for Go modules or enforce testing during PR reviews. This PR addresses it
https://github.com/openchoreo/openchoreo/issues/2755

## Goals
- Add a PR check job that runs Go unit tests for modules containing program code
- Report per-module coverage to Codecov using OIDC auth (no secrets needed)
- Add coverage badges to module READMEs for visibility

## Approach
.codecov.yml (new): Defines Codecov components for each Go module (observability-logs-openobserve, observability-metrics-prometheus, observability-tracing-openobserve) so coverage is tracked per-module.

.github/workflows/pr.yaml (modified): Adds new unit-test job that:
1. Iterates over changed module directories (same pattern as existing docker-build job)
2. For each module with module.yaml + images + go.mod, runs go test -coverprofile
3. Uploads all coverage files to Codecov 

Module READMEs (modified): Added Codecov badges to the three Go module READMEs, using the same badge URL format as openchoreo/openchoreo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added code coverage tracking and reporting to Codecov.
  * Integrated automated coverage tests into pull request workflows.
  * Added coverage badges to observability module documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->