### PR TITLE
fix: update helm chart path in observability-logs-moesif module README and enable code coverage publishing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -105,6 +105,7 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
+          use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
           files: ./*-coverage.out
           fail_ci_if_error: false
 

--- a/observability-logs-moesif/README.md
+++ b/observability-logs-moesif/README.md
@@ -30,7 +30,7 @@ Install this module in your OpenChoreo cluster:
 
 ```bash
 helm upgrade --install observability-logs-moesif \
-  oci://ghcr.io/openchoreo/charts/observability-logs-moesif \
+  oci://ghcr.io/openchoreo/helm-charts/observability-logs-moesif \
   --create-namespace \
   --namespace openchoreo-observability-plane \
   --version 0.1.0
@@ -72,7 +72,7 @@ Then install with:
 
 ```bash
 helm upgrade --install observability-logs-moesif \
-  oci://ghcr.io/openchoreo/charts/observability-logs-moesif \
+  oci://ghcr.io/openchoreo/helm-charts/observability-logs-moesif \
   --create-namespace \
   --namespace openchoreo-observability-plane \
   --version 0.1.0 \


### PR DESCRIPTION
## Purpose
1. https://github.com/openchoreo/openchoreo/issues/2501
Update the helm chart path in the Moesif logs module README

2. https://github.com/openchoreo/openchoreo/issues/2755
Add use_oidc field for code coverage publishing

## Goals
1. Fix helm commands in Moesif logs module README
2. Publish code coverage reports when PRs are merged to main

## Approach
1. Changed the helm chart path from `oci://ghcr.io/openchoreo/charts` to `oci://ghcr.io/openchoreo/helm-charts`
2. Added use_oidc flag

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Helm chart repository paths in installation instructions to ensure users deploy from the correct registry location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->