### PR TITLE
fix: update SQL query in OpenObserve alert rule creation

### DIFF
--- a/observability-logs-openobserve/README.md
+++ b/observability-logs-openobserve/README.md
@@ -31,7 +31,7 @@ helm upgrade --install observability-logs-openobserve \
   oci://ghcr.io/openchoreo/helm-charts/observability-logs-openobserve \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.3.7
+  --version 0.3.8
 ```
 
 ## Enable log collection
@@ -42,7 +42,7 @@ Enable Fluent Bit to start collecting logs from the cluster and publish to OpenO
 helm upgrade observability-logs-openobserve \
   oci://ghcr.io/openchoreo/helm-charts/observability-logs-openobserve \
   --namespace openchoreo-observability-plane \
-  --version 0.3.7 \
+  --version 0.3.8 \
   --reuse-values \
   --set fluent-bit.enabled=true
 ```

--- a/observability-logs-openobserve/helm/Chart.yaml
+++ b/observability-logs-openobserve/helm/Chart.yaml
@@ -5,8 +5,8 @@ apiVersion: v2
 name: observability-logs-openobserve
 description: A Helm chart for OpenChoreo Logs Module for OpenObserve
 type: application
-version: 0.3.7
-appVersion: "0.3.7"
+version: 0.3.8
+appVersion: "0.3.8"
 keywords:
   - openobserve
   - openchoreo

--- a/observability-logs-openobserve/internal/openobserve/queries.go
+++ b/observability-logs-openobserve/internal/openobserve/queries.go
@@ -122,8 +122,7 @@ func parseDurationMinutes(duration string) (int, error) {
 // generateAlertConfig generates an OpenObserve alert configuration as JSON
 func generateAlertConfig(params LogAlertParams, streamName string, logger *slog.Logger) ([]byte, error) {
 	query := fmt.Sprintf(
-		"SELECT count(*) as %s FROM %s WHERE str_match(log, '%s')",
-		"match_count",
+		"SELECT _timestamp FROM %s WHERE str_match(log, '%s')",
 		quoteIdentifier(streamName),
 		escapeSQLString(params.SearchPattern),
 	)


### PR DESCRIPTION
## Purpose
https://github.com/openchoreo/openchoreo/issues/2587
The SQL query added to alert rules were performing a count of matching rows and returning the number of matches. This prevented the alert rule from being triggered. This PR adds a fix for it.

## Goals
Fix issue where log based alerts were not being triggered in OpenObserve

## Approach
Updated SQL query to return matching records instead of doing a count of matching records


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Released version 0.3.8 with updated chart metadata and documentation

* **Bug Fixes**
  * Modified alert configuration query behavior to return updated data format
<!-- end of auto-generated comment: release notes by coderabbit.ai -->