### PR TITLE
test: add unit tests for observability-tracing-openobserve module and ignore generated code from code coverage calculation

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -16,6 +16,7 @@ coverage:
 ignore:
   - "**/testdata/**"
   - "**/*_test.go"
+  - "**/*.gen.go"
 
 component_management:
   default_rules:

--- a/observability-tracing-openobserve/internal/config_test.go
+++ b/observability-tracing-openobserve/internal/config_test.go
@@ -1,0 +1,184 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package app
+
+import (
+	"log/slog"
+	"os"
+	"testing"
+)
+
+// setEnvVars sets multiple environment variables and returns a cleanup function.
+func setEnvVars(t *testing.T, vars map[string]string) {
+	t.Helper()
+	for k, v := range vars {
+		t.Setenv(k, v)
+	}
+}
+
+// validEnvVars returns the minimal set of environment variables required for LoadConfig.
+func validEnvVars() map[string]string {
+	return map[string]string{
+		"OPENOBSERVE_URL":      "http://localhost:5080",
+		"OPENOBSERVE_USER":     "admin",
+		"OPENOBSERVE_PASSWORD": "fakeOpenObservePassword",
+	}
+}
+
+func TestLoadConfig_Success(t *testing.T) {
+	setEnvVars(t, validEnvVars())
+
+	cfg, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.ServerPort != "9100" {
+		t.Errorf("expected default ServerPort 9100, got %s", cfg.ServerPort)
+	}
+	if cfg.OpenObserveURL != "http://localhost:5080" {
+		t.Errorf("unexpected OpenObserveURL: %s", cfg.OpenObserveURL)
+	}
+	if cfg.OpenObserveOrg != "default" {
+		t.Errorf("expected default OpenObserveOrg, got %s", cfg.OpenObserveOrg)
+	}
+	if cfg.OpenObserveStream != "default" {
+		t.Errorf("expected default OpenObserveStream, got %s", cfg.OpenObserveStream)
+	}
+	if cfg.OpenObserveUser != "admin" {
+		t.Errorf("unexpected OpenObserveUser: %s", cfg.OpenObserveUser)
+	}
+	if cfg.OpenObservePassword != "fakeOpenObservePassword" {
+		t.Errorf("unexpected OpenObservePassword: %s", cfg.OpenObservePassword)
+	}
+	if cfg.LogLevel != slog.LevelInfo {
+		t.Errorf("expected default LogLevel Info, got %v", cfg.LogLevel)
+	}
+}
+
+func TestLoadConfig_CustomValues(t *testing.T) {
+	vars := validEnvVars()
+	vars["SERVER_PORT"] = "3000"
+	vars["OPENOBSERVE_ORG"] = "myorg"
+	vars["OPENOBSERVE_STREAM"] = "mystream"
+	setEnvVars(t, vars)
+
+	cfg, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.ServerPort != "3000" {
+		t.Errorf("expected ServerPort 3000, got %s", cfg.ServerPort)
+	}
+	if cfg.OpenObserveOrg != "myorg" {
+		t.Errorf("expected OpenObserveOrg myorg, got %s", cfg.OpenObserveOrg)
+	}
+	if cfg.OpenObserveStream != "mystream" {
+		t.Errorf("expected OpenObserveStream mystream, got %s", cfg.OpenObserveStream)
+	}
+}
+
+func TestLoadConfig_LogLevels(t *testing.T) {
+	tests := []struct {
+		level    string
+		expected slog.Level
+	}{
+		{"DEBUG", slog.LevelDebug},
+		{"INFO", slog.LevelInfo},
+		{"WARN", slog.LevelWarn},
+		{"WARNING", slog.LevelWarn},
+		{"ERROR", slog.LevelError},
+		{"debug", slog.LevelDebug},
+		{"info", slog.LevelInfo},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.level, func(t *testing.T) {
+			vars := validEnvVars()
+			vars["LOG_LEVEL"] = tt.level
+			setEnvVars(t, vars)
+
+			cfg, err := LoadConfig()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if cfg.LogLevel != tt.expected {
+				t.Errorf("for LOG_LEVEL=%s expected %v, got %v", tt.level, tt.expected, cfg.LogLevel)
+			}
+		})
+	}
+}
+
+func TestLoadConfig_MissingRequired(t *testing.T) {
+	tests := []struct {
+		name  string
+		unset string
+	}{
+		{"missing OPENOBSERVE_URL", "OPENOBSERVE_URL"},
+		{"missing OPENOBSERVE_USER", "OPENOBSERVE_USER"},
+		{"missing OPENOBSERVE_PASSWORD", "OPENOBSERVE_PASSWORD"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vars := validEnvVars()
+			delete(vars, tt.unset)
+			setEnvVars(t, vars)
+			// Ensure the unset variable is actually cleared
+			os.Unsetenv(tt.unset)
+
+			_, err := LoadConfig()
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+		})
+	}
+}
+
+func TestLoadConfig_InvalidServerPort(t *testing.T) {
+	vars := validEnvVars()
+	vars["SERVER_PORT"] = "not-a-number"
+	setEnvVars(t, vars)
+
+	_, err := LoadConfig()
+	if err == nil {
+		t.Fatal("expected error for invalid SERVER_PORT, got nil")
+	}
+}
+
+func TestLoadConfig_ServerPortOutOfRange(t *testing.T) {
+	tests := []struct {
+		name string
+		port string
+	}{
+		{"port zero", "0"},
+		{"port too high", "65536"},
+		{"negative port", "-1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vars := validEnvVars()
+			vars["SERVER_PORT"] = tt.port
+			setEnvVars(t, vars)
+
+			_, err := LoadConfig()
+			if err == nil {
+				t.Fatalf("expected error for SERVER_PORT=%s, got nil", tt.port)
+			}
+		})
+	}
+}
+
+func TestGetEnv(t *testing.T) {
+	t.Setenv("TEST_GET_ENV_EXISTS", "value")
+
+	if got := getEnv("TEST_GET_ENV_EXISTS", "default"); got != "value" {
+		t.Errorf("expected 'value', got %q", got)
+	}
+	if got := getEnv("TEST_GET_ENV_MISSING", "default"); got != "default" {
+		t.Errorf("expected 'default', got %q", got)
+	}
+}

--- a/observability-tracing-openobserve/internal/handlers_test.go
+++ b/observability-tracing-openobserve/internal/handlers_test.go
@@ -1,0 +1,645 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package app
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/openchoreo/community-modules/observability-tracing-openobserve/internal/api/gen"
+	"github.com/openchoreo/community-modules/observability-tracing-openobserve/internal/openobserve"
+)
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+}
+
+func TestHealth(t *testing.T) {
+	handler := NewTracingHandler(nil, testLogger())
+	resp, err := handler.Health(context.Background(), gen.HealthRequestObject{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	healthResp, ok := resp.(gen.Health200JSONResponse)
+	if !ok {
+		t.Fatalf("unexpected response type: %T", resp)
+	}
+	if healthResp.Status == nil || *healthResp.Status != "healthy" {
+		t.Errorf("expected status 'healthy', got %v", healthResp.Status)
+	}
+}
+
+func TestQueryTraces_NilBody(t *testing.T) {
+	handler := NewTracingHandler(nil, testLogger())
+	resp, err := handler.QueryTraces(context.Background(), gen.QueryTracesRequestObject{Body: nil})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := resp.(gen.QueryTraces400JSONResponse); !ok {
+		t.Fatalf("expected 400 response, got %T", resp)
+	}
+}
+
+func TestQueryTraces_EmptyNamespace(t *testing.T) {
+	handler := NewTracingHandler(nil, testLogger())
+	resp, err := handler.QueryTraces(context.Background(), gen.QueryTracesRequestObject{
+		Body: &gen.TracesQueryRequest{
+			StartTime: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+			EndTime:   time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC),
+			SearchScope: gen.ComponentSearchScope{
+				Namespace: "  ",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := resp.(gen.QueryTraces400JSONResponse); !ok {
+		t.Fatalf("expected 400 response, got %T", resp)
+	}
+}
+
+func TestQueryTraces_EndTimeBeforeStartTime(t *testing.T) {
+	handler := NewTracingHandler(nil, testLogger())
+	resp, err := handler.QueryTraces(context.Background(), gen.QueryTracesRequestObject{
+		Body: &gen.TracesQueryRequest{
+			StartTime: time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC),
+			EndTime:   time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+			SearchScope: gen.ComponentSearchScope{
+				Namespace: "test-ns",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := resp.(gen.QueryTraces400JSONResponse); !ok {
+		t.Fatalf("expected 400 response, got %T", resp)
+	}
+}
+
+func TestQuerySpansForTrace_NilBody(t *testing.T) {
+	handler := NewTracingHandler(nil, testLogger())
+	resp, err := handler.QuerySpansForTrace(context.Background(), gen.QuerySpansForTraceRequestObject{
+		TraceId: "abc123",
+		Body:    nil,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := resp.(gen.QuerySpansForTrace400JSONResponse); !ok {
+		t.Fatalf("expected 400 response, got %T", resp)
+	}
+}
+
+func TestQuerySpansForTrace_EmptyNamespace(t *testing.T) {
+	handler := NewTracingHandler(nil, testLogger())
+	resp, err := handler.QuerySpansForTrace(context.Background(), gen.QuerySpansForTraceRequestObject{
+		TraceId: "abc123",
+		Body: &gen.TracesQueryRequest{
+			StartTime: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+			EndTime:   time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC),
+			SearchScope: gen.ComponentSearchScope{
+				Namespace: "",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := resp.(gen.QuerySpansForTrace400JSONResponse); !ok {
+		t.Fatalf("expected 400 response, got %T", resp)
+	}
+}
+
+func TestQuerySpansForTrace_EndTimeBeforeStartTime(t *testing.T) {
+	handler := NewTracingHandler(nil, testLogger())
+	resp, err := handler.QuerySpansForTrace(context.Background(), gen.QuerySpansForTraceRequestObject{
+		TraceId: "abc123",
+		Body: &gen.TracesQueryRequest{
+			StartTime: time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC),
+			EndTime:   time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+			SearchScope: gen.ComponentSearchScope{
+				Namespace: "test-ns",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := resp.(gen.QuerySpansForTrace400JSONResponse); !ok {
+		t.Fatalf("expected 400 response, got %T", resp)
+	}
+}
+
+func TestToTracesQueryParams(t *testing.T) {
+	startTime := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	endTime := time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC)
+	limit := 50
+	sortOrder := gen.TracesQueryRequestSortOrder("asc")
+	projectID := "proj-1"
+	envID := "env-1"
+	compID := "comp-1"
+
+	req := &gen.TracesQueryRequest{
+		StartTime: startTime,
+		EndTime:   endTime,
+		Limit:     &limit,
+		SortOrder: &sortOrder,
+		SearchScope: gen.ComponentSearchScope{
+			Namespace:   "test-ns",
+			Project:     &projectID,
+			Environment: &envID,
+			Component:   &compID,
+		},
+	}
+
+	params := toTracesQueryParams(req)
+
+	if params.Scope.Namespace != "test-ns" {
+		t.Errorf("expected namespace 'test-ns', got %q", params.Scope.Namespace)
+	}
+	if params.Scope.ProjectID != "proj-1" {
+		t.Errorf("expected projectID 'proj-1', got %q", params.Scope.ProjectID)
+	}
+	if params.Scope.EnvironmentID != "env-1" {
+		t.Errorf("expected environmentID 'env-1', got %q", params.Scope.EnvironmentID)
+	}
+	if params.Scope.ComponentID != "comp-1" {
+		t.Errorf("expected componentID 'comp-1', got %q", params.Scope.ComponentID)
+	}
+	if params.Limit != 50 {
+		t.Errorf("expected limit 50, got %d", params.Limit)
+	}
+	if params.SortOrder != "asc" {
+		t.Errorf("expected sortOrder 'asc', got %q", params.SortOrder)
+	}
+	if !params.StartTime.Equal(startTime) {
+		t.Errorf("expected startTime %v, got %v", startTime, params.StartTime)
+	}
+	if !params.EndTime.Equal(endTime) {
+		t.Errorf("expected endTime %v, got %v", endTime, params.EndTime)
+	}
+}
+
+func TestToTracesQueryParams_Defaults(t *testing.T) {
+	req := &gen.TracesQueryRequest{
+		StartTime: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+		EndTime:   time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC),
+		SearchScope: gen.ComponentSearchScope{
+			Namespace: "test-ns",
+		},
+	}
+
+	params := toTracesQueryParams(req)
+
+	if params.Limit != 0 {
+		t.Errorf("expected default limit 0, got %d", params.Limit)
+	}
+	if params.SortOrder != "" {
+		t.Errorf("expected empty sortOrder, got %q", params.SortOrder)
+	}
+	if params.Scope.ProjectID != "" {
+		t.Errorf("expected empty projectID, got %q", params.Scope.ProjectID)
+	}
+	if params.Scope.EnvironmentID != "" {
+		t.Errorf("expected empty environmentID, got %q", params.Scope.EnvironmentID)
+	}
+	if params.Scope.ComponentID != "" {
+		t.Errorf("expected empty componentID, got %q", params.Scope.ComponentID)
+	}
+}
+
+func TestToTracesListResponse(t *testing.T) {
+	startTime := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+	endTime := time.Date(2025, 1, 1, 12, 1, 0, 0, time.UTC)
+
+	result := &openobserve.TracesResult{
+		Total:  1,
+		TookMs: 15,
+		Traces: []openobserve.TraceEntry{
+			{
+				TraceID:      "trace-1",
+				TraceName:    "GET /api/v1/users",
+				SpanCount:    5,
+				RootSpanID:   "span-root",
+				RootSpanName: "GET /api/v1/users",
+				RootSpanKind: "SERVER",
+				StartTime:    startTime,
+				EndTime:      endTime,
+				DurationNs:   60000000000,
+			},
+		},
+	}
+
+	resp := toTracesListResponse(result)
+
+	if resp.Total == nil || *resp.Total != 1 {
+		t.Errorf("expected total 1, got %v", resp.Total)
+	}
+	if resp.TookMs == nil || *resp.TookMs != 15 {
+		t.Errorf("expected tookMs 15, got %v", resp.TookMs)
+	}
+	if resp.Traces == nil || len(*resp.Traces) != 1 {
+		t.Fatalf("expected 1 trace, got %v", resp.Traces)
+	}
+
+	trace := (*resp.Traces)[0]
+	if trace.TraceId == nil || *trace.TraceId != "trace-1" {
+		t.Errorf("expected traceId 'trace-1', got %v", trace.TraceId)
+	}
+	if trace.TraceName == nil || *trace.TraceName != "GET /api/v1/users" {
+		t.Errorf("expected traceName 'GET /api/v1/users', got %v", trace.TraceName)
+	}
+	if trace.SpanCount == nil || *trace.SpanCount != 5 {
+		t.Errorf("expected spanCount 5, got %v", trace.SpanCount)
+	}
+	if trace.RootSpanId == nil || *trace.RootSpanId != "span-root" {
+		t.Errorf("expected rootSpanId 'span-root', got %v", trace.RootSpanId)
+	}
+	if trace.RootSpanName == nil || *trace.RootSpanName != "GET /api/v1/users" {
+		t.Errorf("expected rootSpanName 'GET /api/v1/users', got %v", trace.RootSpanName)
+	}
+	if trace.RootSpanKind == nil || *trace.RootSpanKind != "SERVER" {
+		t.Errorf("expected rootSpanKind 'SERVER', got %v", trace.RootSpanKind)
+	}
+	if trace.DurationNs == nil || *trace.DurationNs != 60000000000 {
+		t.Errorf("expected durationNs 60000000000, got %v", trace.DurationNs)
+	}
+}
+
+func TestToTracesListResponse_Empty(t *testing.T) {
+	result := &openobserve.TracesResult{
+		Total:  0,
+		TookMs: 5,
+		Traces: []openobserve.TraceEntry{},
+	}
+
+	resp := toTracesListResponse(result)
+
+	if resp.Total == nil || *resp.Total != 0 {
+		t.Errorf("expected total 0, got %v", resp.Total)
+	}
+	if resp.Traces == nil || len(*resp.Traces) != 0 {
+		t.Errorf("expected 0 traces, got %v", resp.Traces)
+	}
+}
+
+func TestToSpansListResponse(t *testing.T) {
+	startTime := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+	endTime := time.Date(2025, 1, 1, 12, 0, 1, 0, time.UTC)
+
+	result := &openobserve.SpansResult{
+		Total:  1,
+		TookMs: 10,
+		Spans: []openobserve.SpanEntry{
+			{
+				SpanID:       "span-1",
+				SpanName:     "db.query",
+				SpanKind:     "CLIENT",
+				StartTime:    startTime,
+				EndTime:      endTime,
+				DurationNs:   1000000000,
+				ParentSpanID: "span-root",
+			},
+		},
+	}
+
+	resp := toSpansListResponse(result)
+
+	if resp.Total == nil || *resp.Total != 1 {
+		t.Errorf("expected total 1, got %v", resp.Total)
+	}
+	if resp.TookMs == nil || *resp.TookMs != 10 {
+		t.Errorf("expected tookMs 10, got %v", resp.TookMs)
+	}
+	if resp.Spans == nil || len(*resp.Spans) != 1 {
+		t.Fatalf("expected 1 span, got %v", resp.Spans)
+	}
+
+	span := (*resp.Spans)[0]
+	if span.SpanId == nil || *span.SpanId != "span-1" {
+		t.Errorf("expected spanId 'span-1', got %v", span.SpanId)
+	}
+	if span.SpanName == nil || *span.SpanName != "db.query" {
+		t.Errorf("expected spanName 'db.query', got %v", span.SpanName)
+	}
+	if span.SpanKind == nil || *span.SpanKind != "CLIENT" {
+		t.Errorf("expected spanKind 'CLIENT', got %v", span.SpanKind)
+	}
+	if span.ParentSpanId == nil || *span.ParentSpanId != "span-root" {
+		t.Errorf("expected parentSpanId 'span-root', got %v", span.ParentSpanId)
+	}
+	if span.DurationNs == nil || *span.DurationNs != 1000000000 {
+		t.Errorf("expected durationNs 1000000000, got %v", span.DurationNs)
+	}
+}
+
+func TestToSpanDetailsResponse(t *testing.T) {
+	startTime := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+	endTime := time.Date(2025, 1, 1, 12, 0, 1, 0, time.UTC)
+
+	span := &openobserve.SpanDetail{
+		SpanID:       "span-1",
+		SpanName:     "db.query",
+		SpanKind:     "CLIENT",
+		StartTime:    startTime,
+		EndTime:      endTime,
+		DurationNs:   1000000000,
+		ParentSpanID: "span-root",
+		Attributes: []openobserve.SpanAttribute{
+			{Key: "http.method", Value: "GET"},
+			{Key: "http.status_code", Value: "200"},
+		},
+		ResourceAttributes: []openobserve.SpanAttribute{
+			{Key: "service.name", Value: "my-service"},
+		},
+	}
+
+	resp := toSpanDetailsResponse(span)
+
+	if resp.SpanId == nil || *resp.SpanId != "span-1" {
+		t.Errorf("expected spanId 'span-1', got %v", resp.SpanId)
+	}
+	if resp.SpanName == nil || *resp.SpanName != "db.query" {
+		t.Errorf("expected spanName 'db.query', got %v", resp.SpanName)
+	}
+	if resp.SpanKind == nil || *resp.SpanKind != "CLIENT" {
+		t.Errorf("expected spanKind 'CLIENT', got %v", resp.SpanKind)
+	}
+	if resp.ParentSpanId == nil || *resp.ParentSpanId != "span-root" {
+		t.Errorf("expected parentSpanId 'span-root', got %v", resp.ParentSpanId)
+	}
+	if resp.DurationNs == nil || *resp.DurationNs != 1000000000 {
+		t.Errorf("expected durationNs 1000000000, got %v", resp.DurationNs)
+	}
+	if resp.Attributes == nil || len(*resp.Attributes) != 2 {
+		t.Fatalf("expected 2 attributes, got %v", resp.Attributes)
+	}
+	attr0 := (*resp.Attributes)[0]
+	if attr0.Key == nil || *attr0.Key != "http.method" {
+		t.Errorf("expected attribute key 'http.method', got %v", attr0.Key)
+	}
+	if attr0.Value == nil || *attr0.Value != "GET" {
+		t.Errorf("expected attribute value 'GET', got %v", attr0.Value)
+	}
+	if resp.ResourceAttributes == nil || len(*resp.ResourceAttributes) != 1 {
+		t.Fatalf("expected 1 resource attribute, got %v", resp.ResourceAttributes)
+	}
+	resAttr0 := (*resp.ResourceAttributes)[0]
+	if resAttr0.Key == nil || *resAttr0.Key != "service.name" {
+		t.Errorf("expected resource attribute key 'service.name', got %v", resAttr0.Key)
+	}
+}
+
+func TestToSpanDetailsResponse_EmptyAttributes(t *testing.T) {
+	span := &openobserve.SpanDetail{
+		SpanID:             "span-1",
+		SpanName:           "test",
+		Attributes:         []openobserve.SpanAttribute{},
+		ResourceAttributes: []openobserve.SpanAttribute{},
+	}
+
+	resp := toSpanDetailsResponse(span)
+
+	if resp.Attributes == nil || len(*resp.Attributes) != 0 {
+		t.Errorf("expected 0 attributes, got %v", resp.Attributes)
+	}
+	if resp.ResourceAttributes == nil || len(*resp.ResourceAttributes) != 0 {
+		t.Errorf("expected 0 resource attributes, got %v", resp.ResourceAttributes)
+	}
+}
+
+func TestPtr(t *testing.T) {
+	v := ptr(42)
+	if v == nil || *v != 42 {
+		t.Errorf("expected pointer to 42, got %v", v)
+	}
+
+	s := ptr("hello")
+	if s == nil || *s != "hello" {
+		t.Errorf("expected pointer to 'hello', got %v", s)
+	}
+}
+
+func TestQueryTraces_Success(t *testing.T) {
+	startNs := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC).UnixNano()
+	endNs := time.Date(2025, 1, 1, 12, 1, 0, 0, time.UTC).UnixNano()
+
+	ooServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := openobserve.OpenObserveResponse{
+			Took:  5,
+			Total: 2,
+			Hits: []map[string]interface{}{
+				{
+					"trace_id":                    "trace-1",
+					"span_id":                     "span-root",
+					"operation_name":              "GET /api/v1/users",
+					"span_kind":                   "SERVER",
+					"start_time":                  json.Number(fmt.Sprintf("%d", startNs)),
+					"end_time":                    json.Number(fmt.Sprintf("%d", endNs)),
+					"reference_parent_span_id":    "",
+					"service_openchoreo_dev_namespace": "test-ns",
+				},
+				{
+					"trace_id":                 "trace-1",
+					"span_id":                  "span-child",
+					"operation_name":           "db.query",
+					"span_kind":                "CLIENT",
+					"start_time":               json.Number(fmt.Sprintf("%d", startNs+1000)),
+					"end_time":                 json.Number(fmt.Sprintf("%d", endNs-1000)),
+					"reference_parent_span_id": "span-root",
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		// Use json.Number-compatible encoding
+		data, _ := json.Marshal(resp)
+		w.Write(data)
+	}))
+	defer ooServer.Close()
+
+	client := openobserve.NewClient(ooServer.URL, "default", "default", "admin", "pass", testLogger())
+	handler := NewTracingHandler(client, testLogger())
+
+	resp, err := handler.QueryTraces(context.Background(), gen.QueryTracesRequestObject{
+		Body: &gen.TracesQueryRequest{
+			StartTime: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+			EndTime:   time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC),
+			SearchScope: gen.ComponentSearchScope{
+				Namespace: "test-ns",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, ok := resp.(gen.QueryTraces200JSONResponse); !ok {
+		t.Fatalf("expected 200 response, got %T", resp)
+	}
+}
+
+func TestQuerySpansForTrace_Success(t *testing.T) {
+	startNs := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC).UnixNano()
+	endNs := time.Date(2025, 1, 1, 12, 0, 1, 0, time.UTC).UnixNano()
+
+	ooServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := openobserve.OpenObserveResponse{
+			Took:  3,
+			Total: 1,
+			Hits: []map[string]interface{}{
+				{
+					"span_id":                  "span-1",
+					"operation_name":           "db.query",
+					"span_kind":                "CLIENT",
+					"start_time":               json.Number(fmt.Sprintf("%d", startNs)),
+					"end_time":                 json.Number(fmt.Sprintf("%d", endNs)),
+					"duration":                 json.Number(fmt.Sprintf("%d", endNs-startNs)),
+					"reference_parent_span_id": "span-root",
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		data, _ := json.Marshal(resp)
+		w.Write(data)
+	}))
+	defer ooServer.Close()
+
+	client := openobserve.NewClient(ooServer.URL, "default", "default", "admin", "pass", testLogger())
+	handler := NewTracingHandler(client, testLogger())
+
+	resp, err := handler.QuerySpansForTrace(context.Background(), gen.QuerySpansForTraceRequestObject{
+		TraceId: "trace-1",
+		Body: &gen.TracesQueryRequest{
+			StartTime: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+			EndTime:   time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC),
+			SearchScope: gen.ComponentSearchScope{
+				Namespace: "test-ns",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, ok := resp.(gen.QuerySpansForTrace200JSONResponse); !ok {
+		t.Fatalf("expected 200 response, got %T", resp)
+	}
+}
+
+func TestGetSpanDetailsForTrace_Success(t *testing.T) {
+	startNs := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC).UnixNano()
+	endNs := time.Date(2025, 1, 1, 12, 0, 1, 0, time.UTC).UnixNano()
+
+	ooServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := openobserve.OpenObserveResponse{
+			Took:  2,
+			Total: 1,
+			Hits: []map[string]interface{}{
+				{
+					"span_id":                  "span-1",
+					"operation_name":           "db.query",
+					"span_kind":                "CLIENT",
+					"start_time":               json.Number(fmt.Sprintf("%d", startNs)),
+					"end_time":                 json.Number(fmt.Sprintf("%d", endNs)),
+					"duration":                 json.Number(fmt.Sprintf("%d", endNs-startNs)),
+					"reference_parent_span_id": "span-root",
+					"http.method":              "GET",
+					"service.name":             "my-service",
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		data, _ := json.Marshal(resp)
+		w.Write(data)
+	}))
+	defer ooServer.Close()
+
+	client := openobserve.NewClient(ooServer.URL, "default", "default", "admin", "pass", testLogger())
+	handler := NewTracingHandler(client, testLogger())
+
+	resp, err := handler.GetSpanDetailsForTrace(context.Background(), gen.GetSpanDetailsForTraceRequestObject{
+		TraceId: "trace-1",
+		SpanId:  "span-1",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	detailResp, ok := resp.(gen.GetSpanDetailsForTrace200JSONResponse)
+	if !ok {
+		t.Fatalf("expected 200 response, got %T", resp)
+	}
+	if detailResp.SpanId == nil || *detailResp.SpanId != "span-1" {
+		t.Errorf("expected spanId 'span-1', got %v", detailResp.SpanId)
+	}
+	if detailResp.SpanName == nil || *detailResp.SpanName != "db.query" {
+		t.Errorf("expected spanName 'db.query', got %v", detailResp.SpanName)
+	}
+}
+
+func TestGetSpanDetailsForTrace_NotFound(t *testing.T) {
+	ooServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := openobserve.OpenObserveResponse{
+			Took:  1,
+			Total: 0,
+			Hits:  []map[string]interface{}{},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		data, _ := json.Marshal(resp)
+		w.Write(data)
+	}))
+	defer ooServer.Close()
+
+	client := openobserve.NewClient(ooServer.URL, "default", "default", "admin", "pass", testLogger())
+	handler := NewTracingHandler(client, testLogger())
+
+	resp, err := handler.GetSpanDetailsForTrace(context.Background(), gen.GetSpanDetailsForTraceRequestObject{
+		TraceId: "trace-1",
+		SpanId:  "nonexistent",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, ok := resp.(gen.GetSpanDetailsForTrace500JSONResponse); !ok {
+		t.Fatalf("expected 500 response, got %T", resp)
+	}
+}
+
+func TestQueryTraces_ServerError(t *testing.T) {
+	ooServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("internal error"))
+	}))
+	defer ooServer.Close()
+
+	client := openobserve.NewClient(ooServer.URL, "default", "default", "admin", "pass", testLogger())
+	handler := NewTracingHandler(client, testLogger())
+
+	resp, err := handler.QueryTraces(context.Background(), gen.QueryTracesRequestObject{
+		Body: &gen.TracesQueryRequest{
+			StartTime: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+			EndTime:   time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC),
+			SearchScope: gen.ComponentSearchScope{
+				Namespace: "test-ns",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, ok := resp.(gen.QueryTraces500JSONResponse); !ok {
+		t.Fatalf("expected 500 response, got %T", resp)
+	}
+}

--- a/observability-tracing-openobserve/internal/openobserve/client_test.go
+++ b/observability-tracing-openobserve/internal/openobserve/client_test.go
@@ -1,0 +1,548 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package openobserve
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+)
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+}
+
+func newTestClient(serverURL string) *Client {
+	return NewClient(serverURL, "default", "default", "admin", "token", testLogger())
+}
+
+func TestNewClient(t *testing.T) {
+	c := NewClient("http://localhost:5080/", "myorg", "mystream", "user", "pass", testLogger())
+
+	if c.baseURL != "http://localhost:5080" {
+		t.Errorf("expected trailing slash removed, got %q", c.baseURL)
+	}
+	if c.org != "myorg" {
+		t.Errorf("unexpected org: %q", c.org)
+	}
+	if c.stream != "mystream" {
+		t.Errorf("unexpected stream: %q", c.stream)
+	}
+	if c.user != "user" {
+		t.Errorf("unexpected user: %q", c.user)
+	}
+	if c.token != "pass" {
+		t.Errorf("unexpected token: %q", c.token)
+	}
+}
+
+func TestGetTraces(t *testing.T) {
+	startNs := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC).UnixNano()
+	endNs := time.Date(2025, 1, 1, 12, 1, 0, 0, time.UTC).UnixNano()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/default/_search" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Method != "POST" {
+			t.Errorf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Query().Get("type") != "traces" {
+			t.Errorf("expected type=traces query param, got %s", r.URL.Query().Get("type"))
+		}
+
+		user, pass, ok := r.BasicAuth()
+		if !ok || user != "admin" || pass != "token" {
+			t.Error("missing or incorrect basic auth")
+		}
+
+		resp := OpenObserveResponse{
+			Took:  42,
+			Total: 3,
+			Hits: []map[string]interface{}{
+				{
+					"trace_id":                 "trace-1",
+					"span_id":                  "span-root",
+					"operation_name":           "GET /api/users",
+					"span_kind":                "SERVER",
+					"start_time":               json.Number(fmt.Sprintf("%d", startNs)),
+					"end_time":                 json.Number(fmt.Sprintf("%d", endNs)),
+					"reference_parent_span_id": "",
+				},
+				{
+					"trace_id":                 "trace-1",
+					"span_id":                  "span-child",
+					"operation_name":           "db.query",
+					"span_kind":                "CLIENT",
+					"start_time":               json.Number(fmt.Sprintf("%d", startNs+1000)),
+					"end_time":                 json.Number(fmt.Sprintf("%d", endNs-1000)),
+					"reference_parent_span_id": "span-root",
+				},
+				{
+					"trace_id":                 "trace-2",
+					"span_id":                  "span-2-root",
+					"operation_name":           "POST /api/orders",
+					"span_kind":                "SERVER",
+					"start_time":               json.Number(fmt.Sprintf("%d", startNs+5000)),
+					"end_time":                 json.Number(fmt.Sprintf("%d", endNs+5000)),
+					"reference_parent_span_id": "",
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		data, _ := json.Marshal(resp)
+		w.Write(data)
+	}))
+	defer server.Close()
+
+	client := newTestClient(server.URL)
+	result, err := client.GetTraces(context.Background(), TracesQueryParams{
+		StartTime: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+		EndTime:   time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC),
+		Scope: Scope{
+			Namespace: "test-ns",
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Total != 2 {
+		t.Errorf("expected 2 traces, got %d", result.Total)
+	}
+	if result.TookMs != 42 {
+		t.Errorf("expected took 42, got %d", result.TookMs)
+	}
+	if len(result.Traces) != 2 {
+		t.Fatalf("expected 2 traces, got %d", len(result.Traces))
+	}
+
+	// First trace should have 2 spans grouped
+	trace0 := result.Traces[0]
+	if trace0.TraceID != "trace-1" {
+		t.Errorf("expected traceID 'trace-1', got %q", trace0.TraceID)
+	}
+	if trace0.SpanCount != 2 {
+		t.Errorf("expected spanCount 2, got %d", trace0.SpanCount)
+	}
+	if trace0.RootSpanID != "span-root" {
+		t.Errorf("expected rootSpanID 'span-root', got %q", trace0.RootSpanID)
+	}
+	if trace0.RootSpanName != "GET /api/users" {
+		t.Errorf("expected rootSpanName 'GET /api/users', got %q", trace0.RootSpanName)
+	}
+	if trace0.RootSpanKind != "SERVER" {
+		t.Errorf("expected rootSpanKind 'SERVER', got %q", trace0.RootSpanKind)
+	}
+	if trace0.TraceName != "GET /api/users" {
+		t.Errorf("expected traceName to equal rootSpanName, got %q", trace0.TraceName)
+	}
+
+	// Second trace should have 1 span
+	trace1 := result.Traces[1]
+	if trace1.TraceID != "trace-2" {
+		t.Errorf("expected traceID 'trace-2', got %q", trace1.TraceID)
+	}
+	if trace1.SpanCount != 1 {
+		t.Errorf("expected spanCount 1, got %d", trace1.SpanCount)
+	}
+}
+
+func TestGetTraces_ServerError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("internal error"))
+	}))
+	defer server.Close()
+
+	client := newTestClient(server.URL)
+	_, err := client.GetTraces(context.Background(), TracesQueryParams{
+		Scope: Scope{
+			Namespace: "test-ns",
+		},
+		StartTime: time.Now().Add(-time.Hour),
+		EndTime:   time.Now(),
+	})
+	if err == nil {
+		t.Fatal("expected error for server error response")
+	}
+}
+
+func TestGetTraces_EmptyResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := OpenObserveResponse{
+			Took:  1,
+			Total: 0,
+			Hits:  []map[string]interface{}{},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := newTestClient(server.URL)
+	result, err := client.GetTraces(context.Background(), TracesQueryParams{
+		Scope: Scope{
+			Namespace: "test-ns",
+		},
+		StartTime: time.Now().Add(-time.Hour),
+		EndTime:   time.Now(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Total != 0 {
+		t.Errorf("expected 0 traces, got %d", result.Total)
+	}
+	if len(result.Traces) != 0 {
+		t.Errorf("expected empty traces, got %d", len(result.Traces))
+	}
+}
+
+func TestGetSpans(t *testing.T) {
+	startNs := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC).UnixNano()
+	endNs := time.Date(2025, 1, 1, 12, 0, 1, 0, time.UTC).UnixNano()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := OpenObserveResponse{
+			Took:  10,
+			Total: 2,
+			Hits: []map[string]interface{}{
+				{
+					"span_id":                  "span-1",
+					"operation_name":           "GET /api/users",
+					"span_kind":                "SERVER",
+					"start_time":               json.Number(fmt.Sprintf("%d", startNs)),
+					"end_time":                 json.Number(fmt.Sprintf("%d", endNs)),
+					"duration":                 json.Number(fmt.Sprintf("%d", endNs-startNs)),
+					"reference_parent_span_id": "",
+				},
+				{
+					"span_id":                  "span-2",
+					"operation_name":           "db.query",
+					"span_kind":                "CLIENT",
+					"start_time":               json.Number(fmt.Sprintf("%d", startNs+100)),
+					"end_time":                 json.Number(fmt.Sprintf("%d", endNs-100)),
+					"duration":                 json.Number(fmt.Sprintf("%d", endNs-startNs-200)),
+					"reference_parent_span_id": "span-1",
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		data, _ := json.Marshal(resp)
+		w.Write(data)
+	}))
+	defer server.Close()
+
+	client := newTestClient(server.URL)
+	result, err := client.GetSpans(context.Background(), TracesQueryParams{
+		TraceID:   "trace-1",
+		StartTime: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+		EndTime:   time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Total != 2 {
+		t.Errorf("expected total 2, got %d", result.Total)
+	}
+	if result.TookMs != 10 {
+		t.Errorf("expected took 10, got %d", result.TookMs)
+	}
+	if len(result.Spans) != 2 {
+		t.Fatalf("expected 2 spans, got %d", len(result.Spans))
+	}
+
+	span0 := result.Spans[0]
+	if span0.SpanID != "span-1" {
+		t.Errorf("unexpected spanID: %q", span0.SpanID)
+	}
+	if span0.SpanName != "GET /api/users" {
+		t.Errorf("unexpected spanName: %q", span0.SpanName)
+	}
+	if span0.SpanKind != "SERVER" {
+		t.Errorf("unexpected spanKind: %q", span0.SpanKind)
+	}
+	if span0.ParentSpanID != "" {
+		t.Errorf("expected empty parentSpanID for root span, got %q", span0.ParentSpanID)
+	}
+
+	span1 := result.Spans[1]
+	if span1.ParentSpanID != "span-1" {
+		t.Errorf("expected parentSpanID 'span-1', got %q", span1.ParentSpanID)
+	}
+}
+
+func TestGetSpans_ServerError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("internal error"))
+	}))
+	defer server.Close()
+
+	client := newTestClient(server.URL)
+	_, err := client.GetSpans(context.Background(), TracesQueryParams{
+		TraceID:   "trace-1",
+		StartTime: time.Now().Add(-time.Hour),
+		EndTime:   time.Now(),
+	})
+	if err == nil {
+		t.Fatal("expected error for server error response")
+	}
+}
+
+func TestGetSpanDetail(t *testing.T) {
+	startNs := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC).UnixNano()
+	endNs := time.Date(2025, 1, 1, 12, 0, 1, 0, time.UTC).UnixNano()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := OpenObserveResponse{
+			Took:  2,
+			Total: 1,
+			Hits: []map[string]interface{}{
+				{
+					"span_id":                  "span-1",
+					"operation_name":           "db.query",
+					"span_kind":                "CLIENT",
+					"start_time":               json.Number(fmt.Sprintf("%d", startNs)),
+					"end_time":                 json.Number(fmt.Sprintf("%d", endNs)),
+					"duration":                 json.Number(fmt.Sprintf("%d", endNs-startNs)),
+					"reference_parent_span_id": "span-root",
+					"http.method":              "GET",
+					"http.status_code":         "200",
+					"service.name":             "my-service",
+					"resource.version":         "v1",
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		data, _ := json.Marshal(resp)
+		w.Write(data)
+	}))
+	defer server.Close()
+
+	client := newTestClient(server.URL)
+	result, err := client.GetSpanDetail(context.Background(), TracesQueryParams{
+		TraceID: "trace-1",
+		SpanID:  "span-1",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	span := result.Span
+	if span.SpanID != "span-1" {
+		t.Errorf("expected spanID 'span-1', got %q", span.SpanID)
+	}
+	if span.SpanName != "db.query" {
+		t.Errorf("expected spanName 'db.query', got %q", span.SpanName)
+	}
+	if span.SpanKind != "CLIENT" {
+		t.Errorf("expected spanKind 'CLIENT', got %q", span.SpanKind)
+	}
+	if span.ParentSpanID != "span-root" {
+		t.Errorf("expected parentSpanID 'span-root', got %q", span.ParentSpanID)
+	}
+	if span.StartTime != time.Unix(0, startNs) {
+		t.Errorf("unexpected startTime: %v", span.StartTime)
+	}
+	if span.EndTime != time.Unix(0, endNs) {
+		t.Errorf("unexpected endTime: %v", span.EndTime)
+	}
+
+	// Check that attributes are populated (http.method, http.status_code)
+	foundHTTPMethod := false
+	for _, attr := range span.Attributes {
+		if attr.Key == "http.method" && attr.Value == "GET" {
+			foundHTTPMethod = true
+		}
+	}
+	if !foundHTTPMethod {
+		t.Error("expected http.method attribute in span attributes")
+	}
+
+	// Check that resource attributes are populated (service.name, resource.version)
+	foundServiceName := false
+	for _, attr := range span.ResourceAttributes {
+		if attr.Key == "service.name" && attr.Value == "my-service" {
+			foundServiceName = true
+		}
+	}
+	if !foundServiceName {
+		t.Error("expected service.name in resource attributes")
+	}
+}
+
+func TestGetSpanDetail_NotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := OpenObserveResponse{
+			Took:  1,
+			Total: 0,
+			Hits:  []map[string]interface{}{},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := newTestClient(server.URL)
+	_, err := client.GetSpanDetail(context.Background(), TracesQueryParams{
+		TraceID: "trace-1",
+		SpanID:  "nonexistent",
+	})
+	if err == nil {
+		t.Fatal("expected error for not found span")
+	}
+}
+
+func TestParseSpanEntry(t *testing.T) {
+	startNs := time.Date(2025, 6, 15, 10, 30, 0, 0, time.UTC).UnixNano()
+	endNs := time.Date(2025, 6, 15, 10, 30, 1, 0, time.UTC).UnixNano()
+
+	hit := map[string]interface{}{
+		"span_id":                  "span-1",
+		"operation_name":           "db.query",
+		"span_kind":                "CLIENT",
+		"start_time":               json.Number(fmt.Sprintf("%d", startNs)),
+		"end_time":                 json.Number(fmt.Sprintf("%d", endNs)),
+		"duration":                 json.Number(fmt.Sprintf("%d", endNs-startNs)),
+		"reference_parent_span_id": "span-root",
+	}
+
+	entry := parseSpanEntry(hit)
+
+	if entry.SpanID != "span-1" {
+		t.Errorf("expected spanID 'span-1', got %q", entry.SpanID)
+	}
+	if entry.SpanName != "db.query" {
+		t.Errorf("expected spanName 'db.query', got %q", entry.SpanName)
+	}
+	if entry.SpanKind != "CLIENT" {
+		t.Errorf("expected spanKind 'CLIENT', got %q", entry.SpanKind)
+	}
+	if entry.ParentSpanID != "span-root" {
+		t.Errorf("expected parentSpanID 'span-root', got %q", entry.ParentSpanID)
+	}
+	if entry.StartTime != time.Unix(0, startNs) {
+		t.Errorf("unexpected startTime: %v", entry.StartTime)
+	}
+	if entry.EndTime != time.Unix(0, endNs) {
+		t.Errorf("unexpected endTime: %v", entry.EndTime)
+	}
+	if entry.DurationNs != endNs-startNs {
+		t.Errorf("expected durationNs %d, got %d", endNs-startNs, entry.DurationNs)
+	}
+}
+
+func TestParseSpanEntry_MissingFields(t *testing.T) {
+	hit := map[string]interface{}{}
+
+	entry := parseSpanEntry(hit)
+
+	if entry.SpanID != "" {
+		t.Errorf("expected empty spanID, got %q", entry.SpanID)
+	}
+	if entry.SpanName != "" {
+		t.Errorf("expected empty spanName, got %q", entry.SpanName)
+	}
+	if entry.DurationNs != 0 {
+		t.Errorf("expected zero durationNs, got %d", entry.DurationNs)
+	}
+}
+
+func TestParseSpanDetail(t *testing.T) {
+	startNs := time.Date(2025, 6, 15, 10, 30, 0, 0, time.UTC).UnixNano()
+	endNs := time.Date(2025, 6, 15, 10, 30, 1, 0, time.UTC).UnixNano()
+
+	hit := map[string]interface{}{
+		"span_id":                  "span-1",
+		"operation_name":           "db.query",
+		"span_kind":                "CLIENT",
+		"start_time":               json.Number(fmt.Sprintf("%d", startNs)),
+		"end_time":                 json.Number(fmt.Sprintf("%d", endNs)),
+		"duration":                 json.Number(fmt.Sprintf("%d", endNs-startNs)),
+		"reference_parent_span_id": "span-root",
+		"trace_id":                 "trace-1",
+		"_timestamp":               json.Number("1234567890"),
+		"http.method":              "GET",
+		"http.status_code":         "200",
+		"service.name":             "my-service",
+		"resource.version":         "v1",
+	}
+
+	detail := parseSpanDetail(hit)
+
+	if detail.SpanID != "span-1" {
+		t.Errorf("expected spanID 'span-1', got %q", detail.SpanID)
+	}
+	if detail.SpanName != "db.query" {
+		t.Errorf("expected spanName 'db.query', got %q", detail.SpanName)
+	}
+	if detail.ParentSpanID != "span-root" {
+		t.Errorf("expected parentSpanID 'span-root', got %q", detail.ParentSpanID)
+	}
+
+	// Internal fields should be excluded from attributes
+	for _, attr := range detail.Attributes {
+		for _, internal := range internalFields {
+			if attr.Key == internal {
+				t.Errorf("internal field %q should not appear in attributes", internal)
+			}
+		}
+	}
+
+	// http.method and http.status_code should be in attributes (not resource)
+	attrMap := make(map[string]string)
+	for _, attr := range detail.Attributes {
+		attrMap[attr.Key] = attr.Value
+	}
+	if attrMap["http.method"] != "GET" {
+		t.Errorf("expected http.method=GET in attributes, got %q", attrMap["http.method"])
+	}
+	if attrMap["http.status_code"] != "200" {
+		t.Errorf("expected http.status_code=200 in attributes, got %q", attrMap["http.status_code"])
+	}
+
+	// service.name and resource.version should be in resource attributes
+	resAttrMap := make(map[string]string)
+	for _, attr := range detail.ResourceAttributes {
+		resAttrMap[attr.Key] = attr.Value
+	}
+	if resAttrMap["service.name"] != "my-service" {
+		t.Errorf("expected service.name=my-service in resource attributes, got %q", resAttrMap["service.name"])
+	}
+	if resAttrMap["resource.version"] != "v1" {
+		t.Errorf("expected resource.version=v1 in resource attributes, got %q", resAttrMap["resource.version"])
+	}
+}
+
+func TestParseSpanDetail_NoExtraAttributes(t *testing.T) {
+	hit := map[string]interface{}{
+		"span_id":                  "span-1",
+		"operation_name":           "test",
+		"span_kind":                "SERVER",
+		"start_time":               json.Number("1000"),
+		"end_time":                 json.Number("2000"),
+		"duration":                 json.Number("1000"),
+		"reference_parent_span_id": "",
+		"trace_id":                 "trace-1",
+		"_timestamp":               json.Number("1234"),
+	}
+
+	detail := parseSpanDetail(hit)
+
+	if len(detail.Attributes) != 0 {
+		t.Errorf("expected 0 attributes, got %d: %v", len(detail.Attributes), detail.Attributes)
+	}
+	if len(detail.ResourceAttributes) != 0 {
+		t.Errorf("expected 0 resource attributes, got %d: %v", len(detail.ResourceAttributes), detail.ResourceAttributes)
+	}
+}

--- a/observability-tracing-openobserve/internal/openobserve/queries_test.go
+++ b/observability-tracing-openobserve/internal/openobserve/queries_test.go
@@ -1,0 +1,446 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package openobserve
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestValidateSQLIdentifier(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{"valid simple", "mystream", false},
+		{"valid with dots", "org.stream", false},
+		{"valid with hyphens", "my-stream", false},
+		{"valid with underscores", "my_stream", false},
+		{"valid alphanumeric", "stream123", false},
+		{"empty string", "", true},
+		{"contains space", "my stream", true},
+		{"contains semicolon", "stream;DROP", true},
+		{"contains single quote", "stream'bad", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := validateSQLIdentifier(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateSQLIdentifier(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && got != tt.input {
+				t.Errorf("validateSQLIdentifier(%q) = %q, want %q", tt.input, got, tt.input)
+			}
+		})
+	}
+}
+
+func TestEscapeSQLString(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"simple", "simple"},
+		{"it's", "it''s"},
+		{`back\slash`, `back\\slash`},
+		{`it's a back\slash`, `it''s a back\\slash`},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		got := escapeSQLString(tt.input)
+		if got != tt.expected {
+			t.Errorf("escapeSQLString(%q) = %q, want %q", tt.input, got, tt.expected)
+		}
+	}
+}
+
+func TestBuildFilterConditions(t *testing.T) {
+	t.Run("all filters", func(t *testing.T) {
+		params := TracesQueryParams{
+			Scope: Scope{
+				Namespace:     "test-ns",
+				ProjectID:     "proj-1",
+				EnvironmentID: "env-1",
+				ComponentID:   "comp-1",
+			},
+		}
+
+		conditions := buildFilterConditions(params)
+
+		if len(conditions) != 4 {
+			t.Fatalf("expected 4 conditions, got %d", len(conditions))
+		}
+
+		joined := strings.Join(conditions, " AND ")
+		checks := []string{
+			"service_openchoreo_dev_namespace = 'test-ns'",
+			"service_openchoreo_dev_project_uid = 'proj-1'",
+			"service_openchoreo_dev_environment_uid = 'env-1'",
+			"service_openchoreo_dev_component_uid = 'comp-1'",
+		}
+		for _, check := range checks {
+			if !strings.Contains(joined, check) {
+				t.Errorf("expected condition %q in: %s", check, joined)
+			}
+		}
+	})
+
+	t.Run("namespace only", func(t *testing.T) {
+		params := TracesQueryParams{
+			Scope: Scope{
+				Namespace: "test-ns",
+			},
+		}
+
+		conditions := buildFilterConditions(params)
+
+		if len(conditions) != 1 {
+			t.Fatalf("expected 1 condition, got %d", len(conditions))
+		}
+		if !strings.Contains(conditions[0], "service_openchoreo_dev_namespace = 'test-ns'") {
+			t.Errorf("unexpected condition: %s", conditions[0])
+		}
+	})
+
+	t.Run("empty scope", func(t *testing.T) {
+		params := TracesQueryParams{}
+
+		conditions := buildFilterConditions(params)
+
+		if len(conditions) != 0 {
+			t.Errorf("expected 0 conditions, got %d", len(conditions))
+		}
+	})
+
+	t.Run("SQL injection prevention", func(t *testing.T) {
+		params := TracesQueryParams{
+			Scope: Scope{
+				Namespace: "test'; DROP TABLE spans;--",
+			},
+		}
+
+		conditions := buildFilterConditions(params)
+
+		if len(conditions) != 1 {
+			t.Fatalf("expected 1 condition, got %d", len(conditions))
+		}
+		// Single quotes should be escaped (doubled)
+		if strings.Contains(conditions[0], "test'; DROP") {
+			t.Errorf("SQL contains unescaped single quotes: %s", conditions[0])
+		}
+		if !strings.Contains(conditions[0], "test''; DROP") {
+			t.Errorf("SQL should contain escaped single quotes: %s", conditions[0])
+		}
+	})
+}
+
+func TestGenerateTracesListQuery(t *testing.T) {
+	startTime := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	endTime := time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC)
+
+	t.Run("basic query with namespace", func(t *testing.T) {
+		params := TracesQueryParams{
+			Scope: Scope{
+				Namespace: "test-ns",
+			},
+			StartTime: startTime,
+			EndTime:   endTime,
+		}
+
+		result, err := generateTracesListQuery(params, "mystream", testLogger())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		var query map[string]interface{}
+		if err := json.Unmarshal(result, &query); err != nil {
+			t.Fatalf("invalid JSON: %v", err)
+		}
+
+		q := query["query"].(map[string]interface{})
+		sql := q["sql"].(string)
+		if !strings.Contains(sql, "service_openchoreo_dev_namespace = 'test-ns'") {
+			t.Errorf("expected namespace filter in SQL: %s", sql)
+		}
+		if !strings.Contains(sql, "FROM mystream") {
+			t.Errorf("expected stream name in SQL: %s", sql)
+		}
+		if !strings.Contains(sql, "ORDER BY start_time DESC") {
+			t.Errorf("expected default DESC order in SQL: %s", sql)
+		}
+		if q["size"].(float64) != 100 {
+			t.Errorf("expected default limit 100, got %v", q["size"])
+		}
+	})
+
+	t.Run("with all filters and custom limit", func(t *testing.T) {
+		params := TracesQueryParams{
+			Scope: Scope{
+				Namespace:     "test-ns",
+				ProjectID:     "proj-1",
+				EnvironmentID: "env-1",
+				ComponentID:   "comp-1",
+			},
+			Limit:     50,
+			SortOrder: "asc",
+			StartTime: startTime,
+			EndTime:   endTime,
+		}
+
+		result, err := generateTracesListQuery(params, "mystream", testLogger())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		var query map[string]interface{}
+		json.Unmarshal(result, &query)
+		q := query["query"].(map[string]interface{})
+		sql := q["sql"].(string)
+
+		checks := []string{
+			"service_openchoreo_dev_namespace = 'test-ns'",
+			"service_openchoreo_dev_project_uid = 'proj-1'",
+			"service_openchoreo_dev_environment_uid = 'env-1'",
+			"service_openchoreo_dev_component_uid = 'comp-1'",
+			"ORDER BY start_time ASC",
+		}
+		for _, check := range checks {
+			if !strings.Contains(sql, check) {
+				t.Errorf("expected SQL to contain %q, got: %s", check, sql)
+			}
+		}
+		if q["size"].(float64) != 50 {
+			t.Errorf("expected limit 50, got %v", q["size"])
+		}
+	})
+
+	t.Run("limit capped at MaxQueryLimit", func(t *testing.T) {
+		params := TracesQueryParams{
+			Scope: Scope{
+				Namespace: "test-ns",
+			},
+			Limit:     5000,
+			StartTime: startTime,
+			EndTime:   endTime,
+		}
+
+		result, err := generateTracesListQuery(params, "mystream", testLogger())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		var query map[string]interface{}
+		json.Unmarshal(result, &query)
+		q := query["query"].(map[string]interface{})
+		if q["size"].(float64) != float64(MaxQueryLimit) {
+			t.Errorf("expected limit capped at %d, got %v", MaxQueryLimit, q["size"])
+		}
+	})
+
+	t.Run("invalid stream identifier", func(t *testing.T) {
+		params := TracesQueryParams{
+			Scope: Scope{
+				Namespace: "test-ns",
+			},
+			StartTime: startTime,
+			EndTime:   endTime,
+		}
+
+		_, err := generateTracesListQuery(params, "bad;stream", testLogger())
+		if err == nil {
+			t.Fatal("expected error for invalid stream identifier")
+		}
+	})
+
+	t.Run("SQL injection prevention in namespace", func(t *testing.T) {
+		params := TracesQueryParams{
+			Scope: Scope{
+				Namespace: "test'; DROP TABLE spans;--",
+			},
+			StartTime: startTime,
+			EndTime:   endTime,
+		}
+
+		result, err := generateTracesListQuery(params, "mystream", testLogger())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		var query map[string]interface{}
+		json.Unmarshal(result, &query)
+		q := query["query"].(map[string]interface{})
+		sql := q["sql"].(string)
+
+		if strings.Contains(sql, "test'; DROP") {
+			t.Errorf("SQL contains unescaped single quotes: %s", sql)
+		}
+		if !strings.Contains(sql, "test''; DROP") {
+			t.Errorf("SQL should contain escaped single quotes: %s", sql)
+		}
+	})
+}
+
+func TestGenerateSpansListQuery(t *testing.T) {
+	startTime := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	endTime := time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC)
+
+	t.Run("basic query", func(t *testing.T) {
+		params := TracesQueryParams{
+			TraceID:   "abc123",
+			StartTime: startTime,
+			EndTime:   endTime,
+		}
+
+		result, err := generateSpansListQuery(params, "mystream", testLogger())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		var query map[string]interface{}
+		if err := json.Unmarshal(result, &query); err != nil {
+			t.Fatalf("invalid JSON: %v", err)
+		}
+
+		q := query["query"].(map[string]interface{})
+		sql := q["sql"].(string)
+		if !strings.Contains(sql, "trace_id = 'abc123'") {
+			t.Errorf("expected trace_id filter in SQL: %s", sql)
+		}
+		if !strings.Contains(sql, "FROM mystream") {
+			t.Errorf("expected stream name in SQL: %s", sql)
+		}
+		if !strings.Contains(sql, "ORDER BY start_time DESC") {
+			t.Errorf("expected default DESC order in SQL: %s", sql)
+		}
+	})
+
+	t.Run("with ASC sort order", func(t *testing.T) {
+		params := TracesQueryParams{
+			TraceID:   "abc123",
+			SortOrder: "asc",
+			StartTime: startTime,
+			EndTime:   endTime,
+		}
+
+		result, err := generateSpansListQuery(params, "mystream", testLogger())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		var query map[string]interface{}
+		json.Unmarshal(result, &query)
+		q := query["query"].(map[string]interface{})
+		sql := q["sql"].(string)
+		if !strings.Contains(sql, "ORDER BY start_time ASC") {
+			t.Errorf("expected ASC order in SQL: %s", sql)
+		}
+	})
+
+	t.Run("SQL injection in traceID", func(t *testing.T) {
+		params := TracesQueryParams{
+			TraceID:   "abc'; DROP TABLE spans;--",
+			StartTime: startTime,
+			EndTime:   endTime,
+		}
+
+		result, err := generateSpansListQuery(params, "mystream", testLogger())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		var query map[string]interface{}
+		json.Unmarshal(result, &query)
+		q := query["query"].(map[string]interface{})
+		sql := q["sql"].(string)
+		if strings.Contains(sql, "abc'; DROP") {
+			t.Errorf("SQL contains unescaped single quotes: %s", sql)
+		}
+	})
+
+	t.Run("invalid stream identifier", func(t *testing.T) {
+		params := TracesQueryParams{
+			TraceID:   "abc123",
+			StartTime: startTime,
+			EndTime:   endTime,
+		}
+
+		_, err := generateSpansListQuery(params, "bad;stream", testLogger())
+		if err == nil {
+			t.Fatal("expected error for invalid stream identifier")
+		}
+	})
+}
+
+func TestGenerateSpanDetailQuery(t *testing.T) {
+	t.Run("basic query", func(t *testing.T) {
+		params := TracesQueryParams{
+			TraceID: "trace-1",
+			SpanID:  "span-1",
+		}
+
+		result, err := generateSpanDetailQuery(params, "mystream", testLogger())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		var query map[string]interface{}
+		if err := json.Unmarshal(result, &query); err != nil {
+			t.Fatalf("invalid JSON: %v", err)
+		}
+
+		q := query["query"].(map[string]interface{})
+		sql := q["sql"].(string)
+		if !strings.Contains(sql, "trace_id = 'trace-1'") {
+			t.Errorf("expected trace_id filter in SQL: %s", sql)
+		}
+		if !strings.Contains(sql, "span_id = 'span-1'") {
+			t.Errorf("expected span_id filter in SQL: %s", sql)
+		}
+		if !strings.Contains(sql, "SELECT * FROM mystream") {
+			t.Errorf("expected SELECT * FROM in SQL: %s", sql)
+		}
+		if q["size"].(float64) != 1 {
+			t.Errorf("expected size 1, got %v", q["size"])
+		}
+	})
+
+	t.Run("SQL injection in traceID and spanID", func(t *testing.T) {
+		params := TracesQueryParams{
+			TraceID: "trace'; DROP TABLE spans;--",
+			SpanID:  "span'; DROP TABLE spans;--",
+		}
+
+		result, err := generateSpanDetailQuery(params, "mystream", testLogger())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		var query map[string]interface{}
+		json.Unmarshal(result, &query)
+		q := query["query"].(map[string]interface{})
+		sql := q["sql"].(string)
+		if strings.Contains(sql, "trace'; DROP") {
+			t.Errorf("SQL contains unescaped traceID single quotes: %s", sql)
+		}
+		if strings.Contains(sql, "span'; DROP") {
+			t.Errorf("SQL contains unescaped spanID single quotes: %s", sql)
+		}
+	})
+
+	t.Run("invalid stream identifier", func(t *testing.T) {
+		params := TracesQueryParams{
+			TraceID: "trace-1",
+			SpanID:  "span-1",
+		}
+
+		_, err := generateSpanDetailQuery(params, "bad;stream", testLogger())
+		if err == nil {
+			t.Fatal("expected error for invalid stream identifier")
+		}
+	})
+}


### PR DESCRIPTION
## Purpose
1. Implement unit tests for observability-tracing-openobserve module
2. Ignore OAPI-codegen generated code from code coverage calculations

## Goals
Improve test coverage

## Approach
1. Added Go unit tests to the observability-tracing-openobserve module
2. Excluded files with `.gen.go` extension  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for configuration loading and environment variable handling.
  * Added extensive test coverage for tracing HTTP handler endpoints and error scenarios.
  * Added test suite for OpenObserve client operations including trace and span retrieval.
  * Added test coverage for SQL query generation and validation.

* **Chores**
  * Updated code coverage configuration to exclude generated files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->