### PR TITLE
test: implement unit tests for observability-metrics-prometheus module

### DIFF
--- a/observability-metrics-prometheus/internal/config_test.go
+++ b/observability-metrics-prometheus/internal/config_test.go
@@ -1,0 +1,149 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package app
+
+import (
+	"log/slog"
+	"testing"
+)
+
+// setEnvVars sets multiple environment variables for the test.
+func setEnvVars(t *testing.T, vars map[string]string) {
+	t.Helper()
+	for k, v := range vars {
+		t.Setenv(k, v)
+	}
+}
+
+// validEnvVars returns the minimal set of environment variables required for LoadConfig.
+func validEnvVars() map[string]string {
+	return map[string]string{
+		"OBSERVER_API_INTERNAL_URL": "http://localhost:8080",
+	}
+}
+
+func TestLoadConfig_Success(t *testing.T) {
+	setEnvVars(t, validEnvVars())
+
+	cfg, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.ServerPort != "9098" {
+		t.Errorf("expected default ServerPort 9098, got %s", cfg.ServerPort)
+	}
+	if cfg.ObserverAPIInternalURL != "http://localhost:8080" {
+		t.Errorf("unexpected ObserverAPIInternalURL: %s", cfg.ObserverAPIInternalURL)
+	}
+	if cfg.LogLevel != slog.LevelInfo {
+		t.Errorf("expected default LogLevel Info, got %v", cfg.LogLevel)
+	}
+}
+
+func TestLoadConfig_CustomValues(t *testing.T) {
+	vars := validEnvVars()
+	vars["SERVER_PORT"] = "3000"
+	vars["LOG_LEVEL"] = "DEBUG"
+	setEnvVars(t, vars)
+
+	cfg, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.ServerPort != "3000" {
+		t.Errorf("expected ServerPort 3000, got %s", cfg.ServerPort)
+	}
+	if cfg.LogLevel != slog.LevelDebug {
+		t.Errorf("expected LogLevel Debug, got %v", cfg.LogLevel)
+	}
+}
+
+func TestLoadConfig_LogLevels(t *testing.T) {
+	tests := []struct {
+		level    string
+		expected slog.Level
+	}{
+		{"DEBUG", slog.LevelDebug},
+		{"INFO", slog.LevelInfo},
+		{"WARN", slog.LevelWarn},
+		{"WARNING", slog.LevelWarn},
+		{"ERROR", slog.LevelError},
+		{"debug", slog.LevelDebug},
+		{"info", slog.LevelInfo},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.level, func(t *testing.T) {
+			vars := validEnvVars()
+			vars["LOG_LEVEL"] = tt.level
+			setEnvVars(t, vars)
+
+			cfg, err := LoadConfig()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if cfg.LogLevel != tt.expected {
+				t.Errorf("for LOG_LEVEL=%s expected %v, got %v", tt.level, tt.expected, cfg.LogLevel)
+			}
+		})
+	}
+}
+
+func TestLoadConfig_MissingObserverURL(t *testing.T) {
+	// Explicitly set OBSERVER_API_INTERNAL_URL to empty to ensure it's treated as missing
+	t.Setenv("OBSERVER_API_INTERNAL_URL", "")
+
+	_, err := LoadConfig()
+	if err == nil {
+		t.Fatal("expected error for missing OBSERVER_API_INTERNAL_URL, got nil")
+	}
+}
+
+func TestLoadConfig_InvalidObserverURL(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+	}{
+		{"no scheme", "localhost:8080"},
+		{"no host", "http://"},
+		{"empty after trim", "   "},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setEnvVars(t, map[string]string{
+				"OBSERVER_API_INTERNAL_URL": tt.url,
+			})
+
+			_, err := LoadConfig()
+			if err == nil {
+				t.Fatalf("expected error for OBSERVER_API_INTERNAL_URL=%q, got nil", tt.url)
+			}
+		})
+	}
+}
+
+func TestLoadConfig_InvalidServerPort(t *testing.T) {
+	vars := validEnvVars()
+	vars["SERVER_PORT"] = "not-a-number"
+	setEnvVars(t, vars)
+
+	_, err := LoadConfig()
+	if err == nil {
+		t.Fatal("expected error for invalid SERVER_PORT, got nil")
+	}
+}
+
+func TestGetEnv(t *testing.T) {
+	t.Setenv("TEST_GET_ENV_EXISTS", "value")
+
+	if got := getEnv("TEST_GET_ENV_EXISTS", "default"); got != "value" {
+		t.Errorf("expected 'value', got %q", got)
+	}
+	if got := getEnv("TEST_GET_ENV_MISSING", "default"); got != "default" {
+		t.Errorf("expected 'default', got %q", got)
+	}
+}

--- a/observability-metrics-prometheus/internal/handlers_test.go
+++ b/observability-metrics-prometheus/internal/handlers_test.go
@@ -1,0 +1,264 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package app
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/openchoreo/community-modules/observability-metrics-prometheus/internal/api/gen"
+	"github.com/openchoreo/community-modules/observability-metrics-prometheus/internal/observer"
+)
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+}
+
+func TestHealth(t *testing.T) {
+	handler := NewMetricsHandler(nil, testLogger())
+	resp, err := handler.Health(context.Background(), gen.HealthRequestObject{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	healthResp, ok := resp.(gen.Health200JSONResponse)
+	if !ok {
+		t.Fatalf("unexpected response type: %T", resp)
+	}
+	if healthResp.Status != "healthy" {
+		t.Errorf("expected status 'healthy', got %q", healthResp.Status)
+	}
+}
+
+func TestHandleAlertmanagerWebhook_NilBody(t *testing.T) {
+	handler := NewMetricsHandler(nil, testLogger())
+	resp, err := handler.HandleAlertmanagerWebhook(context.Background(), gen.HandleAlertmanagerWebhookRequestObject{Body: nil})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := resp.(gen.HandleAlertmanagerWebhook400JSONResponse); !ok {
+		t.Fatalf("expected 400 response, got %T", resp)
+	}
+}
+
+func TestHandleAlertmanagerWebhook_NoAlerts(t *testing.T) {
+	handler := NewMetricsHandler(nil, testLogger())
+	resp, err := handler.HandleAlertmanagerWebhook(context.Background(), gen.HandleAlertmanagerWebhookRequestObject{
+		Body: &gen.AlertmanagerWebhookPayload{
+			Alerts: []gen.AlertmanagerAlert{},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := resp.(gen.HandleAlertmanagerWebhook400JSONResponse); !ok {
+		t.Fatalf("expected 400 response, got %T", resp)
+	}
+}
+
+func TestHandleAlertmanagerWebhook_MultipleAlerts(t *testing.T) {
+	handler := NewMetricsHandler(nil, testLogger())
+	resp, err := handler.HandleAlertmanagerWebhook(context.Background(), gen.HandleAlertmanagerWebhookRequestObject{
+		Body: &gen.AlertmanagerWebhookPayload{
+			Alerts: []gen.AlertmanagerAlert{
+				{Status: "firing", Annotations: gen.AlertmanagerAlert_Annotations{RuleName: "r1", RuleNamespace: "ns1", AlertValue: "1.0"}},
+				{Status: "firing", Annotations: gen.AlertmanagerAlert_Annotations{RuleName: "r2", RuleNamespace: "ns2", AlertValue: "2.0"}},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := resp.(gen.HandleAlertmanagerWebhook400JSONResponse); !ok {
+		t.Fatalf("expected 400 response, got %T", resp)
+	}
+}
+
+func TestHandleAlertmanagerWebhook_NonFiringStatus(t *testing.T) {
+	handler := NewMetricsHandler(nil, testLogger())
+	resp, err := handler.HandleAlertmanagerWebhook(context.Background(), gen.HandleAlertmanagerWebhookRequestObject{
+		Body: &gen.AlertmanagerWebhookPayload{
+			Alerts: []gen.AlertmanagerAlert{
+				{
+					Status:      "resolved",
+					Annotations: gen.AlertmanagerAlert_Annotations{RuleName: "r1", RuleNamespace: "ns1", AlertValue: "1.0"},
+					StartsAt:    time.Now(),
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := resp.(gen.HandleAlertmanagerWebhook400JSONResponse); !ok {
+		t.Fatalf("expected 400 response, got %T", resp)
+	}
+}
+
+func TestHandleAlertmanagerWebhook_MissingAnnotations(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations gen.AlertmanagerAlert_Annotations
+	}{
+		{"missing rule_name", gen.AlertmanagerAlert_Annotations{RuleName: "", RuleNamespace: "ns1", AlertValue: "1.0"}},
+		{"missing rule_namespace", gen.AlertmanagerAlert_Annotations{RuleName: "r1", RuleNamespace: "", AlertValue: "1.0"}},
+		{"missing alert_value", gen.AlertmanagerAlert_Annotations{RuleName: "r1", RuleNamespace: "ns1", AlertValue: ""}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := NewMetricsHandler(nil, testLogger())
+			resp, err := handler.HandleAlertmanagerWebhook(context.Background(), gen.HandleAlertmanagerWebhookRequestObject{
+				Body: &gen.AlertmanagerWebhookPayload{
+					Alerts: []gen.AlertmanagerAlert{
+						{
+							Status:      "firing",
+							Annotations: tt.annotations,
+							StartsAt:    time.Now(),
+						},
+					},
+				},
+			})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if _, ok := resp.(gen.HandleAlertmanagerWebhook400JSONResponse); !ok {
+				t.Fatalf("expected 400 response, got %T", resp)
+			}
+		})
+	}
+}
+
+func TestHandleAlertmanagerWebhook_InvalidAlertValue(t *testing.T) {
+	handler := NewMetricsHandler(nil, testLogger())
+	resp, err := handler.HandleAlertmanagerWebhook(context.Background(), gen.HandleAlertmanagerWebhookRequestObject{
+		Body: &gen.AlertmanagerWebhookPayload{
+			Alerts: []gen.AlertmanagerAlert{
+				{
+					Status: "firing",
+					Annotations: gen.AlertmanagerAlert_Annotations{
+						RuleName:      "r1",
+						RuleNamespace: "ns1",
+						AlertValue:    "not-a-number",
+					},
+					StartsAt: time.Now(),
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := resp.(gen.HandleAlertmanagerWebhook400JSONResponse); !ok {
+		t.Fatalf("expected 400 response, got %T", resp)
+	}
+}
+
+func TestHandleAlertmanagerWebhook_Success(t *testing.T) {
+	alertTime := time.Date(2025, 6, 15, 10, 30, 0, 0, time.UTC)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := observer.NewClient(server.URL)
+	handler := NewMetricsHandler(client, testLogger())
+
+	resp, err := handler.HandleAlertmanagerWebhook(context.Background(), gen.HandleAlertmanagerWebhookRequestObject{
+		Body: &gen.AlertmanagerWebhookPayload{
+			Alerts: []gen.AlertmanagerAlert{
+				{
+					Status: "firing",
+					Annotations: gen.AlertmanagerAlert_Annotations{
+						RuleName:      "high-cpu",
+						RuleNamespace: "production",
+						AlertValue:    "95.5",
+					},
+					StartsAt: alertTime,
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	successResp, ok := resp.(gen.HandleAlertmanagerWebhook200JSONResponse)
+	if !ok {
+		t.Fatalf("expected 200 response, got %T", resp)
+	}
+	if successResp.Status != gen.Success {
+		t.Errorf("expected status 'success', got %q", successResp.Status)
+	}
+}
+
+func TestHandleAlertmanagerWebhook_FiringCaseInsensitive(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := observer.NewClient(server.URL)
+	handler := NewMetricsHandler(client, testLogger())
+
+	resp, err := handler.HandleAlertmanagerWebhook(context.Background(), gen.HandleAlertmanagerWebhookRequestObject{
+		Body: &gen.AlertmanagerWebhookPayload{
+			Alerts: []gen.AlertmanagerAlert{
+				{
+					Status: "FIRING",
+					Annotations: gen.AlertmanagerAlert_Annotations{
+						RuleName:      "rule1",
+						RuleNamespace: "ns1",
+						AlertValue:    "1.0",
+					},
+					StartsAt: time.Now(),
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := resp.(gen.HandleAlertmanagerWebhook200JSONResponse); !ok {
+		t.Fatalf("expected 200 response, got %T", resp)
+	}
+}
+
+func TestHandleAlertmanagerWebhook_ForwardError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("internal error"))
+	}))
+	defer server.Close()
+
+	client := observer.NewClient(server.URL)
+	handler := NewMetricsHandler(client, testLogger())
+
+	resp, err := handler.HandleAlertmanagerWebhook(context.Background(), gen.HandleAlertmanagerWebhookRequestObject{
+		Body: &gen.AlertmanagerWebhookPayload{
+			Alerts: []gen.AlertmanagerAlert{
+				{
+					Status: "firing",
+					Annotations: gen.AlertmanagerAlert_Annotations{
+						RuleName:      "rule1",
+						RuleNamespace: "ns1",
+						AlertValue:    "1.0",
+					},
+					StartsAt: time.Now(),
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := resp.(gen.HandleAlertmanagerWebhook500JSONResponse); !ok {
+		t.Fatalf("expected 500 response, got %T", resp)
+	}
+}

--- a/observability-metrics-prometheus/internal/observer/client_test.go
+++ b/observability-metrics-prometheus/internal/observer/client_test.go
@@ -1,0 +1,104 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package observer
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestNewClient(t *testing.T) {
+	c := NewClient("http://localhost:8080/")
+	if c.baseURL != "http://localhost:8080" {
+		t.Errorf("expected trailing slash removed, got %q", c.baseURL)
+	}
+}
+
+func TestNewClient_NoTrailingSlash(t *testing.T) {
+	c := NewClient("http://localhost:8080")
+	if c.baseURL != "http://localhost:8080" {
+		t.Errorf("expected baseURL unchanged, got %q", c.baseURL)
+	}
+}
+
+func TestForwardAlert_Success(t *testing.T) {
+	alertTime := time.Date(2025, 6, 15, 10, 30, 0, 0, time.UTC)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1alpha1/alerts/webhook" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Method != http.MethodPost {
+			t.Errorf("unexpected method: %s", r.Method)
+		}
+		if r.Header.Get("Content-Type") != "application/json" {
+			t.Errorf("unexpected content-type: %s", r.Header.Get("Content-Type"))
+		}
+
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("failed to read body: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte("failed to read body"))
+			return
+		}
+
+		var payload alertWebhookRequest
+		if err := json.Unmarshal(body, &payload); err != nil {
+			t.Errorf("failed to unmarshal body: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte("failed to unmarshal body"))
+			return
+		}
+
+		if payload.RuleName != "my-rule" {
+			t.Errorf("expected ruleName 'my-rule', got %q", payload.RuleName)
+		}
+		if payload.RuleNamespace != "test-ns" {
+			t.Errorf("expected ruleNamespace 'test-ns', got %q", payload.RuleNamespace)
+		}
+		if payload.AlertValue != 42.5 {
+			t.Errorf("expected alertValue 42.5, got %v", payload.AlertValue)
+		}
+		if !payload.AlertTimestamp.Equal(alertTime) {
+			t.Errorf("expected alertTimestamp %v, got %v", alertTime, payload.AlertTimestamp)
+		}
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL)
+	err := client.ForwardAlert(context.Background(), "my-rule", "test-ns", 42.5, alertTime)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestForwardAlert_ServerError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("internal error"))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL)
+	err := client.ForwardAlert(context.Background(), "my-rule", "test-ns", 1, time.Now())
+	if err == nil {
+		t.Fatal("expected error for server error response")
+	}
+}
+
+func TestForwardAlert_ConnectionError(t *testing.T) {
+	client := NewClient("http://localhost:1") // unreachable port
+	err := client.ForwardAlert(context.Background(), "my-rule", "test-ns", 1, time.Now())
+	if err == nil {
+		t.Fatal("expected error for connection failure")
+	}
+}


### PR DESCRIPTION
## Purpose
Add unit tests for observability-metrics-prometheus module
https://github.com/openchoreo/openchoreo/issues/2755

## Goals
Increase test coverage

## Approach
Implemented Go unit tests for the observability-metrics-prometheus module

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests for configuration loading, covering defaults, custom values, log-level mappings, validation errors, and environment handling.
  * Added exhaustive API/handler tests validating health and webhook behaviors across success and multiple error scenarios.
  * Added client/network tests to verify request formatting, payload fields, header usage, and error handling for server and connection failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->