### PR TITLE
test: add unit tests for observability modules

### DIFF
--- a/observability-logs-openobserve/internal/handlers.go
+++ b/observability-logs-openobserve/internal/handlers.go
@@ -265,8 +265,8 @@ func (h *LogsHandler) UpdateAlertRule(ctx context.Context, request gen.UpdateAle
 			slog.Any("error", err),
 		)
 		if strings.Contains(err.Error(), "not found") {
-			return gen.UpdateAlertRule500JSONResponse{
-				Title:   ptr(gen.InternalServerError),
+			return gen.UpdateAlertRule400JSONResponse{
+				Title:   ptr(gen.BadRequest),
 				Message: ptr("alert rule not found"),
 			}, nil
 		}

--- a/observability-logs-openobserve/internal/handlers_test.go
+++ b/observability-logs-openobserve/internal/handlers_test.go
@@ -717,6 +717,608 @@ func TestGetAlertRule_NotFound(t *testing.T) {
 	}
 }
 
+func TestUpdateAlertRule_Success(t *testing.T) {
+	ooServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "GET" && r.URL.Path == "/api/v2/default/alerts":
+			resp := map[string]interface{}{
+				"list": []map[string]string{
+					{"alert_id": "alert-upd-1", "name": "test-alert"},
+				},
+			}
+			json.NewEncoder(w).Encode(resp)
+		case r.Method == "PUT" && r.URL.Path == "/api/v2/default/alerts/alert-upd-1":
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer ooServer.Close()
+
+	client := openobserve.NewClient(ooServer.URL, "default", "default", "admin", "pass", testLogger())
+	handler := NewLogsHandler(client, nil, testLogger())
+
+	enabled := true
+	operator := gen.AlertRuleRequestConditionOperator("gt")
+	threshold := float32(5)
+	window := "5m"
+	interval := "1m"
+
+	resp, err := handler.UpdateAlertRule(context.Background(), gen.UpdateAlertRuleRequestObject{
+		RuleName: "test-alert",
+		Body: &gen.AlertRuleRequest{
+			Metadata: &struct {
+				ComponentUid   *openapi_types.UUID `json:"componentUid,omitempty"`
+				EnvironmentUid *openapi_types.UUID `json:"environmentUid,omitempty"`
+				Name           *string             `json:"name,omitempty"`
+				Namespace      *string             `json:"namespace,omitempty"`
+				ProjectUid     *openapi_types.UUID `json:"projectUid,omitempty"`
+			}{
+				Name:      ptr("test-alert"),
+				Namespace: ptr("ns-1"),
+			},
+			Source: &struct {
+				Metric *gen.AlertRuleRequestSourceMetric `json:"metric,omitempty"`
+				Query  *string                           `json:"query,omitempty"`
+			}{
+				Query: ptr("error"),
+			},
+			Condition: &struct {
+				Enabled   *bool                                 `json:"enabled,omitempty"`
+				Interval  *string                               `json:"interval,omitempty"`
+				Operator  *gen.AlertRuleRequestConditionOperator `json:"operator,omitempty"`
+				Threshold *float32                              `json:"threshold,omitempty"`
+				Window    *string                               `json:"window,omitempty"`
+			}{
+				Enabled:   &enabled,
+				Operator:  &operator,
+				Threshold: &threshold,
+				Window:    &window,
+				Interval:  &interval,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	updateResp, ok := resp.(gen.UpdateAlertRule200JSONResponse)
+	if !ok {
+		t.Fatalf("expected 200 response, got %T", resp)
+	}
+	if updateResp.RuleBackendId == nil || *updateResp.RuleBackendId != "alert-upd-1" {
+		t.Errorf("expected ruleBackendId 'alert-upd-1', got %v", updateResp.RuleBackendId)
+	}
+}
+
+func TestUpdateAlertRule_NotFound(t *testing.T) {
+	ooServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := map[string]interface{}{
+			"list": []map[string]string{},
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer ooServer.Close()
+
+	client := openobserve.NewClient(ooServer.URL, "default", "default", "admin", "pass", testLogger())
+	handler := NewLogsHandler(client, nil, testLogger())
+
+	enabled := true
+	operator := gen.AlertRuleRequestConditionOperator("gt")
+	threshold := float32(5)
+
+	resp, err := handler.UpdateAlertRule(context.Background(), gen.UpdateAlertRuleRequestObject{
+		RuleName: "nonexistent",
+		Body: &gen.AlertRuleRequest{
+			Condition: &struct {
+				Enabled   *bool                                 `json:"enabled,omitempty"`
+				Interval  *string                               `json:"interval,omitempty"`
+				Operator  *gen.AlertRuleRequestConditionOperator `json:"operator,omitempty"`
+				Threshold *float32                              `json:"threshold,omitempty"`
+				Window    *string                               `json:"window,omitempty"`
+			}{
+				Enabled:   &enabled,
+				Operator:  &operator,
+				Threshold: &threshold,
+				Window:    ptr("5m"),
+				Interval:  ptr("1m"),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, ok := resp.(gen.UpdateAlertRule400JSONResponse); !ok {
+		t.Fatalf("expected 400 response for not found, got %T", resp)
+	}
+}
+
+func TestUpdateAlertRule_InvalidError(t *testing.T) {
+	ooServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "GET" && r.URL.Path == "/api/v2/default/alerts":
+			resp := map[string]interface{}{
+				"list": []map[string]string{
+					{"alert_id": "alert-inv-1", "name": "test-alert"},
+				},
+			}
+			json.NewEncoder(w).Encode(resp)
+		case r.Method == "PUT":
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte("invalid alert config"))
+		}
+	}))
+	defer ooServer.Close()
+
+	client := openobserve.NewClient(ooServer.URL, "default", "default", "admin", "pass", testLogger())
+	handler := NewLogsHandler(client, nil, testLogger())
+
+	enabled := true
+	operator := gen.AlertRuleRequestConditionOperator("gt")
+	threshold := float32(5)
+
+	resp, err := handler.UpdateAlertRule(context.Background(), gen.UpdateAlertRuleRequestObject{
+		RuleName: "test-alert",
+		Body: &gen.AlertRuleRequest{
+			Condition: &struct {
+				Enabled   *bool                                 `json:"enabled,omitempty"`
+				Interval  *string                               `json:"interval,omitempty"`
+				Operator  *gen.AlertRuleRequestConditionOperator `json:"operator,omitempty"`
+				Threshold *float32                              `json:"threshold,omitempty"`
+				Window    *string                               `json:"window,omitempty"`
+			}{
+				Enabled:   &enabled,
+				Operator:  &operator,
+				Threshold: &threshold,
+				Window:    ptr("5m"),
+				Interval:  ptr("1m"),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, ok := resp.(gen.UpdateAlertRule400JSONResponse); !ok {
+		t.Fatalf("expected 400 response for invalid error, got %T", resp)
+	}
+}
+
+func TestUpdateAlertRule_GenericError(t *testing.T) {
+	ooServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "GET" && r.URL.Path == "/api/v2/default/alerts":
+			resp := map[string]interface{}{
+				"list": []map[string]string{
+					{"alert_id": "alert-gen-1", "name": "test-alert"},
+				},
+			}
+			json.NewEncoder(w).Encode(resp)
+		case r.Method == "PUT":
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte("something went wrong"))
+		}
+	}))
+	defer ooServer.Close()
+
+	client := openobserve.NewClient(ooServer.URL, "default", "default", "admin", "pass", testLogger())
+	handler := NewLogsHandler(client, nil, testLogger())
+
+	enabled := true
+	operator := gen.AlertRuleRequestConditionOperator("gt")
+	threshold := float32(5)
+
+	resp, err := handler.UpdateAlertRule(context.Background(), gen.UpdateAlertRuleRequestObject{
+		RuleName: "test-alert",
+		Body: &gen.AlertRuleRequest{
+			Condition: &struct {
+				Enabled   *bool                                 `json:"enabled,omitempty"`
+				Interval  *string                               `json:"interval,omitempty"`
+				Operator  *gen.AlertRuleRequestConditionOperator `json:"operator,omitempty"`
+				Threshold *float32                              `json:"threshold,omitempty"`
+				Window    *string                               `json:"window,omitempty"`
+			}{
+				Enabled:   &enabled,
+				Operator:  &operator,
+				Threshold: &threshold,
+				Window:    ptr("5m"),
+				Interval:  ptr("1m"),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, ok := resp.(gen.UpdateAlertRule500JSONResponse); !ok {
+		t.Fatalf("expected 500 response for generic error, got %T", resp)
+	}
+}
+
+func TestQueryLogs_WorkflowScope_Success(t *testing.T) {
+	ooServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := openobserve.OpenObserveResponse{
+			Took:  3,
+			Total: 1,
+			Hits: []map[string]interface{}{
+				{
+					"_timestamp": float64(time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC).UnixMicro()),
+					"log":        "workflow step done",
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer ooServer.Close()
+
+	client := openobserve.NewClient(ooServer.URL, "default", "default", "admin", "pass", testLogger())
+	handler := NewLogsHandler(client, nil, testLogger())
+
+	scope := gen.LogsQueryRequest_SearchScope{}
+	workflowRunName := "run-1"
+	_ = scope.FromWorkflowSearchScope(gen.WorkflowSearchScope{
+		Namespace:       "test-ns",
+		WorkflowRunName: &workflowRunName,
+	})
+
+	resp, err := handler.QueryLogs(context.Background(), gen.QueryLogsRequestObject{
+		Body: &gen.LogsQueryRequest{
+			StartTime:   time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+			EndTime:     time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC),
+			SearchScope: scope,
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, ok := resp.(gen.QueryLogs200JSONResponse); !ok {
+		t.Fatalf("expected 200 response, got %T", resp)
+	}
+}
+
+func TestQueryLogs_WorkflowScope_Error(t *testing.T) {
+	ooServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("server error"))
+	}))
+	defer ooServer.Close()
+
+	client := openobserve.NewClient(ooServer.URL, "default", "default", "admin", "pass", testLogger())
+	handler := NewLogsHandler(client, nil, testLogger())
+
+	scope := gen.LogsQueryRequest_SearchScope{}
+	workflowRunName := "run-1"
+	_ = scope.FromWorkflowSearchScope(gen.WorkflowSearchScope{
+		Namespace:       "test-ns",
+		WorkflowRunName: &workflowRunName,
+	})
+
+	resp, err := handler.QueryLogs(context.Background(), gen.QueryLogsRequestObject{
+		Body: &gen.LogsQueryRequest{
+			StartTime:   time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+			EndTime:     time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC),
+			SearchScope: scope,
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, ok := resp.(gen.QueryLogs500JSONResponse); !ok {
+		t.Fatalf("expected 500 response, got %T", resp)
+	}
+}
+
+func TestQueryLogs_WorkflowScope_EmptyNamespace(t *testing.T) {
+	handler := NewLogsHandler(nil, nil, testLogger())
+
+	scope := gen.LogsQueryRequest_SearchScope{}
+	workflowRunName := "run-1"
+	_ = scope.FromWorkflowSearchScope(gen.WorkflowSearchScope{
+		Namespace:       "  ",
+		WorkflowRunName: &workflowRunName,
+	})
+
+	resp, err := handler.QueryLogs(context.Background(), gen.QueryLogsRequestObject{
+		Body: &gen.LogsQueryRequest{
+			StartTime:   time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+			EndTime:     time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC),
+			SearchScope: scope,
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, ok := resp.(gen.QueryLogs400JSONResponse); !ok {
+		t.Fatalf("expected 400 response, got %T", resp)
+	}
+}
+
+func TestQueryLogs_ComponentScope_Error(t *testing.T) {
+	ooServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("server error"))
+	}))
+	defer ooServer.Close()
+
+	client := openobserve.NewClient(ooServer.URL, "default", "default", "admin", "pass", testLogger())
+	handler := NewLogsHandler(client, nil, testLogger())
+
+	scope := gen.LogsQueryRequest_SearchScope{}
+	_ = scope.FromComponentSearchScope(gen.ComponentSearchScope{
+		Namespace: "test-ns",
+	})
+
+	resp, err := handler.QueryLogs(context.Background(), gen.QueryLogsRequestObject{
+		Body: &gen.LogsQueryRequest{
+			StartTime:   time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+			EndTime:     time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC),
+			SearchScope: scope,
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, ok := resp.(gen.QueryLogs500JSONResponse); !ok {
+		t.Fatalf("expected 500 response, got %T", resp)
+	}
+}
+
+func TestDeleteAlertRule_Error(t *testing.T) {
+	ooServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := map[string]interface{}{
+			"list": []map[string]string{},
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer ooServer.Close()
+
+	client := openobserve.NewClient(ooServer.URL, "default", "default", "admin", "pass", testLogger())
+	handler := NewLogsHandler(client, nil, testLogger())
+
+	resp, err := handler.DeleteAlertRule(context.Background(), gen.DeleteAlertRuleRequestObject{
+		RuleName: "nonexistent",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, ok := resp.(gen.DeleteAlertRule500JSONResponse); !ok {
+		t.Fatalf("expected 500 response, got %T", resp)
+	}
+}
+
+func TestCreateAlertRule_Error(t *testing.T) {
+	ooServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte("bad request"))
+	}))
+	defer ooServer.Close()
+
+	client := openobserve.NewClient(ooServer.URL, "default", "default", "admin", "pass", testLogger())
+	handler := NewLogsHandler(client, nil, testLogger())
+
+	enabled := true
+	operator := gen.AlertRuleRequestConditionOperator("gt")
+	threshold := float32(5)
+
+	resp, err := handler.CreateAlertRule(context.Background(), gen.CreateAlertRuleRequestObject{
+		Body: &gen.AlertRuleRequest{
+			Metadata: &struct {
+				ComponentUid   *openapi_types.UUID `json:"componentUid,omitempty"`
+				EnvironmentUid *openapi_types.UUID `json:"environmentUid,omitempty"`
+				Name           *string             `json:"name,omitempty"`
+				Namespace      *string             `json:"namespace,omitempty"`
+				ProjectUid     *openapi_types.UUID `json:"projectUid,omitempty"`
+			}{
+				Name:      ptr("test-alert"),
+				Namespace: ptr("ns-1"),
+			},
+			Source: &struct {
+				Metric *gen.AlertRuleRequestSourceMetric `json:"metric,omitempty"`
+				Query  *string                           `json:"query,omitempty"`
+			}{
+				Query: ptr("error"),
+			},
+			Condition: &struct {
+				Enabled   *bool                                 `json:"enabled,omitempty"`
+				Interval  *string                               `json:"interval,omitempty"`
+				Operator  *gen.AlertRuleRequestConditionOperator `json:"operator,omitempty"`
+				Threshold *float32                              `json:"threshold,omitempty"`
+				Window    *string                               `json:"window,omitempty"`
+			}{
+				Enabled:   &enabled,
+				Operator:  &operator,
+				Threshold: &threshold,
+				Window:    ptr("5m"),
+				Interval:  ptr("1m"),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, ok := resp.(gen.CreateAlertRule500JSONResponse); !ok {
+		t.Fatalf("expected 500 response, got %T", resp)
+	}
+}
+
+func TestGetAlertRule_InvalidUUIDs(t *testing.T) {
+	ooServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/default/alerts":
+			resp := map[string]interface{}{
+				"list": []map[string]string{
+					{"alert_id": "alert-uuid-test", "name": "test-alert"},
+				},
+			}
+			json.NewEncoder(w).Encode(resp)
+		case "/api/v2/default/alerts/alert-uuid-test":
+			resp := map[string]interface{}{
+				"name":    "test-alert",
+				"enabled": true,
+				"query_condition": map[string]interface{}{
+					"sql": "SELECT count(*) FROM \"default\" WHERE str_match(log, 'error')",
+				},
+				"trigger_condition": map[string]interface{}{
+					"operator":       ">",
+					"threshold":      float64(10),
+					"period":         float64(5),
+					"frequency":      float64(1),
+					"frequency_type": "minutes",
+				},
+				"context_attributes": map[string]interface{}{
+					"namespace":      "test-ns",
+					"projectUid":     "not-a-valid-uuid",
+					"environmentUid": "also-not-valid",
+					"componentUid":   "invalid-too",
+				},
+			}
+			json.NewEncoder(w).Encode(resp)
+		}
+	}))
+	defer ooServer.Close()
+
+	client := openobserve.NewClient(ooServer.URL, "default", "default", "admin", "pass", testLogger())
+	handler := NewLogsHandler(client, nil, testLogger())
+
+	resp, err := handler.GetAlertRule(context.Background(), gen.GetAlertRuleRequestObject{
+		RuleName: "test-alert",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	getResp, ok := resp.(gen.GetAlertRule200JSONResponse)
+	if !ok {
+		t.Fatalf("expected 200 response, got %T", resp)
+	}
+	// Invalid UUIDs should result in nil UID fields
+	if getResp.Metadata.ProjectUid != nil {
+		t.Error("expected projectUid to be nil for invalid UUID")
+	}
+	if getResp.Metadata.EnvironmentUid != nil {
+		t.Error("expected environmentUid to be nil for invalid UUID")
+	}
+	if getResp.Metadata.ComponentUid != nil {
+		t.Error("expected componentUid to be nil for invalid UUID")
+	}
+}
+
+func TestGetAlertRule_ServerError(t *testing.T) {
+	ooServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/default/alerts":
+			resp := map[string]interface{}{
+				"list": []map[string]string{
+					{"alert_id": "alert-err", "name": "test-alert"},
+				},
+			}
+			json.NewEncoder(w).Encode(resp)
+		case "/api/v2/default/alerts/alert-err":
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte("internal error"))
+		}
+	}))
+	defer ooServer.Close()
+
+	client := openobserve.NewClient(ooServer.URL, "default", "default", "admin", "pass", testLogger())
+	handler := NewLogsHandler(client, nil, testLogger())
+
+	resp, err := handler.GetAlertRule(context.Background(), gen.GetAlertRuleRequestObject{
+		RuleName: "test-alert",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, ok := resp.(gen.GetAlertRule500JSONResponse); !ok {
+		t.Fatalf("expected 500 response, got %T", resp)
+	}
+}
+
+func TestToWorkflowLogsParams_AllOptions(t *testing.T) {
+	startTime := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	endTime := time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC)
+	workflowRunName := "run-1"
+	limit := 50
+	sortOrder := gen.LogsQueryRequestSortOrder("ASC")
+	search := "error"
+	logLevels := []gen.LogsQueryRequestLogLevels{"ERROR", "WARN"}
+
+	req := &gen.LogsQueryRequest{
+		StartTime:    startTime,
+		EndTime:      endTime,
+		Limit:        &limit,
+		SortOrder:    &sortOrder,
+		SearchPhrase: &search,
+		LogLevels:    &logLevels,
+	}
+	scope := &gen.WorkflowSearchScope{
+		Namespace:       "test-ns",
+		WorkflowRunName: &workflowRunName,
+	}
+
+	params := toWorkflowLogsParams(req, scope)
+
+	if params.Namespace != "test-ns" {
+		t.Errorf("expected namespace 'test-ns', got %q", params.Namespace)
+	}
+	if params.WorkflowRunName != "run-1" {
+		t.Errorf("expected workflowRunName 'run-1', got %q", params.WorkflowRunName)
+	}
+	if params.Limit != 50 {
+		t.Errorf("expected limit 50, got %d", params.Limit)
+	}
+	if params.SortOrder != "ASC" {
+		t.Errorf("expected sortOrder 'ASC', got %q", params.SortOrder)
+	}
+	if params.SearchPhrase != "error" {
+		t.Errorf("expected searchPhrase 'error', got %q", params.SearchPhrase)
+	}
+	if len(params.LogLevels) != 2 {
+		t.Errorf("expected 2 logLevels, got %d", len(params.LogLevels))
+	}
+}
+
+func TestToWorkflowLogsParams_NilOptionals(t *testing.T) {
+	startTime := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	endTime := time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC)
+
+	req := &gen.LogsQueryRequest{
+		StartTime: startTime,
+		EndTime:   endTime,
+	}
+	scope := &gen.WorkflowSearchScope{
+		Namespace: "test-ns",
+	}
+
+	params := toWorkflowLogsParams(req, scope)
+
+	if params.Namespace != "test-ns" {
+		t.Errorf("expected namespace 'test-ns', got %q", params.Namespace)
+	}
+	if params.WorkflowRunName != "" {
+		t.Errorf("expected empty workflowRunName, got %q", params.WorkflowRunName)
+	}
+	if params.Limit != 0 {
+		t.Errorf("expected limit 0, got %d", params.Limit)
+	}
+	if params.SortOrder != "" {
+		t.Errorf("expected empty sortOrder, got %q", params.SortOrder)
+	}
+	if params.SearchPhrase != "" {
+		t.Errorf("expected empty searchPhrase, got %q", params.SearchPhrase)
+	}
+	if params.LogLevels != nil {
+		t.Errorf("expected nil logLevels, got %v", params.LogLevels)
+	}
+}
+
 func TestHandleAlertWebhook_ValidBody(t *testing.T) {
 	// Mock OpenObserve for GetAlert call
 	ooServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/observability-logs-openobserve/internal/observer/client_test.go
+++ b/observability-logs-openobserve/internal/observer/client_test.go
@@ -89,3 +89,45 @@ func TestForwardAlert_ConnectionError(t *testing.T) {
 		t.Fatal("expected error for connection failure")
 	}
 }
+
+func TestForwardAlert_ContextCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL)
+	err := client.ForwardAlert(ctx, "my-rule", "test-ns", 1, time.Now())
+	if err == nil {
+		t.Fatal("expected error for cancelled context")
+	}
+}
+
+func TestForwardAlert_NonSuccessStatusCodes(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+	}{
+		{"400 Bad Request", http.StatusBadRequest},
+		{"404 Not Found", http.StatusNotFound},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.statusCode)
+				w.Write([]byte("error response"))
+			}))
+			defer server.Close()
+
+			client := NewClient(server.URL)
+			err := client.ForwardAlert(context.Background(), "my-rule", "test-ns", 1, time.Now())
+			if err == nil {
+				t.Fatalf("expected error for status %d", tt.statusCode)
+			}
+		})
+	}
+}

--- a/observability-logs-openobserve/internal/openobserve/client_test.go
+++ b/observability-logs-openobserve/internal/openobserve/client_test.go
@@ -400,6 +400,226 @@ func TestGetAlert(t *testing.T) {
 	}
 }
 
+func TestUpdateAlert_LookupFailure(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := map[string]interface{}{
+			"list": []map[string]string{},
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := newTestClient(server.URL)
+	enabled := true
+	_, err := client.UpdateAlert(context.Background(), "nonexistent", LogAlertParams{
+		Operator: "gt",
+		Window:   "5m",
+		Interval: "1m",
+		Enabled:  &enabled,
+	})
+	if err == nil {
+		t.Fatal("expected error for nonexistent alert")
+	}
+}
+
+func TestUpdateAlert_HTTPError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "GET" && r.URL.Path == "/api/v2/default/alerts":
+			resp := map[string]interface{}{
+				"list": []map[string]string{
+					{"alert_id": "alert-upd-err", "name": "my-alert"},
+				},
+			}
+			json.NewEncoder(w).Encode(resp)
+		case r.Method == "PUT":
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte("bad request"))
+		}
+	}))
+	defer server.Close()
+
+	client := newTestClient(server.URL)
+	enabled := true
+	_, err := client.UpdateAlert(context.Background(), "my-alert", LogAlertParams{
+		Operator: "gt",
+		Window:   "5m",
+		Interval: "1m",
+		Enabled:  &enabled,
+	})
+	if err == nil {
+		t.Fatal("expected error for bad request response")
+	}
+}
+
+func TestUpdateAlert_ConfigError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := map[string]interface{}{
+			"list": []map[string]string{
+				{"alert_id": "alert-cfg", "name": "my-alert"},
+			},
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := newTestClient(server.URL)
+	enabled := true
+	// Invalid operator will cause generateAlertConfig to fail
+	_, err := client.UpdateAlert(context.Background(), "my-alert", LogAlertParams{
+		Operator: "invalid_op",
+		Window:   "5m",
+		Interval: "1m",
+		Enabled:  &enabled,
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid alert config")
+	}
+}
+
+func TestDeleteAlert_HTTPError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "GET" && r.URL.Path == "/api/v2/default/alerts":
+			resp := map[string]interface{}{
+				"list": []map[string]string{
+					{"alert_id": "alert-del-err", "name": "my-alert"},
+				},
+			}
+			json.NewEncoder(w).Encode(resp)
+		case r.Method == "DELETE":
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte("server error"))
+		}
+	}))
+	defer server.Close()
+
+	client := newTestClient(server.URL)
+	_, err := client.DeleteAlert(context.Background(), "my-alert")
+	if err == nil {
+		t.Fatal("expected error for delete failure")
+	}
+}
+
+func TestCreateAlert_ConfigError(t *testing.T) {
+	client := newTestClient("http://localhost:1")
+	enabled := true
+	name := "test"
+	// Invalid operator causes config generation to fail
+	_, err := client.CreateAlert(context.Background(), LogAlertParams{
+		Name:     &name,
+		Operator: "invalid_op",
+		Window:   "5m",
+		Interval: "1m",
+		Enabled:  &enabled,
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid config")
+	}
+}
+
+func TestCreateAlert_MissingResponseID(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		// Response without "id" field
+		w.Write([]byte(`{"status": "ok"}`))
+	}))
+	defer server.Close()
+
+	client := newTestClient(server.URL)
+	enabled := true
+	name := "test-alert"
+	_, err := client.CreateAlert(context.Background(), LogAlertParams{
+		Name:     &name,
+		Operator: "gt",
+		Window:   "5m",
+		Interval: "1m",
+		Enabled:  &enabled,
+	})
+	if err == nil {
+		t.Fatal("expected error for missing response ID")
+	}
+}
+
+func TestCreateAlert_ConnectionError(t *testing.T) {
+	client := newTestClient("http://localhost:1")
+	enabled := true
+	name := "test-alert"
+	_, err := client.CreateAlert(context.Background(), LogAlertParams{
+		Name:     &name,
+		Operator: "gt",
+		Window:   "5m",
+		Interval: "1m",
+		Enabled:  &enabled,
+	})
+	if err == nil {
+		t.Fatal("expected error for connection failure")
+	}
+}
+
+func TestExecuteSearchQuery_NonOKStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte("bad query"))
+	}))
+	defer server.Close()
+
+	client := newTestClient(server.URL)
+	_, err := client.GetWorkflowLogs(context.Background(), WorkflowLogsParams{
+		Namespace:       "test-ns",
+		WorkflowRunName: "run-1",
+		StartTime:       time.Now().Add(-time.Hour),
+		EndTime:         time.Now(),
+	})
+	if err == nil {
+		t.Fatal("expected error for non-OK status")
+	}
+}
+
+func TestExecuteSearchQuery_MalformedJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("not valid json{{{"))
+	}))
+	defer server.Close()
+
+	client := newTestClient(server.URL)
+	_, err := client.GetComponentLogs(context.Background(), ComponentLogsParams{
+		Namespace: "test-ns",
+		StartTime: time.Now().Add(-time.Hour),
+		EndTime:   time.Now(),
+	})
+	if err == nil {
+		t.Fatal("expected error for malformed JSON response")
+	}
+}
+
+func TestGetAlert_ServerError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/api/v2/default/alerts" && r.Method == "GET":
+			resp := map[string]interface{}{
+				"list": []map[string]string{
+					{"alert_id": "alert-err", "name": "my-alert"},
+				},
+			}
+			json.NewEncoder(w).Encode(resp)
+		case r.URL.Path == "/api/v2/default/alerts/alert-err":
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte("server error"))
+		}
+	}))
+	defer server.Close()
+
+	client := newTestClient(server.URL)
+	_, err := client.GetAlert(context.Background(), "my-alert")
+	if err == nil {
+		t.Fatal("expected error for server error response")
+	}
+}
+
 func TestExtractLogLevel(t *testing.T) {
 	tests := []struct {
 		log      string

--- a/observability-metrics-prometheus/internal/config_test.go
+++ b/observability-metrics-prometheus/internal/config_test.go
@@ -137,6 +137,34 @@ func TestLoadConfig_InvalidServerPort(t *testing.T) {
 	}
 }
 
+func TestLoadConfig_UnknownLogLevel(t *testing.T) {
+	vars := validEnvVars()
+	vars["LOG_LEVEL"] = "TRACE"
+	setEnvVars(t, vars)
+
+	cfg, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.LogLevel != slog.LevelInfo {
+		t.Errorf("expected default LogLevel Info for unknown level, got %v", cfg.LogLevel)
+	}
+}
+
+func TestLoadConfig_EmptyLogLevel(t *testing.T) {
+	vars := validEnvVars()
+	vars["LOG_LEVEL"] = ""
+	setEnvVars(t, vars)
+
+	cfg, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.LogLevel != slog.LevelInfo {
+		t.Errorf("expected default LogLevel Info for empty level, got %v", cfg.LogLevel)
+	}
+}
+
 func TestGetEnv(t *testing.T) {
 	t.Setenv("TEST_GET_ENV_EXISTS", "value")
 

--- a/observability-metrics-prometheus/internal/handlers_test.go
+++ b/observability-metrics-prometheus/internal/handlers_test.go
@@ -230,6 +230,73 @@ func TestHandleAlertmanagerWebhook_FiringCaseInsensitive(t *testing.T) {
 	}
 }
 
+func TestExtractAlertFields_EdgeCases(t *testing.T) {
+	tests := []struct {
+		name              string
+		ruleName          string
+		ruleNamespace     string
+		alertValue        string
+		expectedRuleName  string
+		expectedNamespace string
+		expectedValue     float32
+	}{
+		{
+			name:              "whitespace trimming",
+			ruleName:          "  high-cpu  ",
+			ruleNamespace:     "  production  ",
+			alertValue:        "  95.5  ",
+			expectedRuleName:  "high-cpu",
+			expectedNamespace: "production",
+			expectedValue:     95.5,
+		},
+		{
+			name:              "negative number",
+			ruleName:          "low-temp",
+			ruleNamespace:     "monitoring",
+			alertValue:        "-42.5",
+			expectedRuleName:  "low-temp",
+			expectedNamespace: "monitoring",
+			expectedValue:     -42.5,
+		},
+		{
+			name:              "zero value",
+			ruleName:          "zero-check",
+			ruleNamespace:     "default",
+			alertValue:        "0",
+			expectedRuleName:  "zero-check",
+			expectedNamespace: "default",
+			expectedValue:     0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			alert := gen.AlertmanagerAlert{
+				Status: "firing",
+				Annotations: gen.AlertmanagerAlert_Annotations{
+					RuleName:      tt.ruleName,
+					RuleNamespace: tt.ruleNamespace,
+					AlertValue:    tt.alertValue,
+				},
+			}
+
+			ruleName, ruleNamespace, alertValue, err := extractAlertFields(alert)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if ruleName != tt.expectedRuleName {
+				t.Errorf("expected ruleName %q, got %q", tt.expectedRuleName, ruleName)
+			}
+			if ruleNamespace != tt.expectedNamespace {
+				t.Errorf("expected ruleNamespace %q, got %q", tt.expectedNamespace, ruleNamespace)
+			}
+			if alertValue != tt.expectedValue {
+				t.Errorf("expected alertValue %v, got %v", tt.expectedValue, alertValue)
+			}
+		})
+	}
+}
+
 func TestHandleAlertmanagerWebhook_ForwardError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)

--- a/observability-metrics-prometheus/internal/observer/client_test.go
+++ b/observability-metrics-prometheus/internal/observer/client_test.go
@@ -102,3 +102,59 @@ func TestForwardAlert_ConnectionError(t *testing.T) {
 		t.Fatal("expected error for connection failure")
 	}
 }
+
+func TestForwardAlert_ContextCancelled(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := client.ForwardAlert(ctx, "my-rule", "test-ns", 1, time.Now())
+	if err == nil {
+		t.Fatal("expected error for cancelled context")
+	}
+}
+
+func TestForwardAlert_NonSuccessStatusCodes(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		body       string
+	}{
+		{"bad request", http.StatusBadRequest, "bad request"},
+		{"not found", http.StatusNotFound, "not found"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.statusCode)
+				w.Write([]byte(tt.body))
+			}))
+			defer server.Close()
+
+			client := NewClient(server.URL)
+			err := client.ForwardAlert(context.Background(), "my-rule", "test-ns", 1, time.Now())
+			if err == nil {
+				t.Fatalf("expected error for status %d", tt.statusCode)
+			}
+		})
+	}
+}
+
+func TestForwardAlert_EmptyResponseBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL)
+	err := client.ForwardAlert(context.Background(), "my-rule", "test-ns", 1, time.Now())
+	if err == nil {
+		t.Fatal("expected error for 500 with empty body")
+	}
+}

--- a/observability-tracing-openobserve/internal/handlers_test.go
+++ b/observability-tracing-openobserve/internal/handlers_test.go
@@ -616,6 +616,35 @@ func TestGetSpanDetailsForTrace_NotFound(t *testing.T) {
 	}
 }
 
+func TestQuerySpansForTrace_ServerError(t *testing.T) {
+	ooServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("internal error"))
+	}))
+	defer ooServer.Close()
+
+	client := openobserve.NewClient(ooServer.URL, "default", "default", "admin", "pass", testLogger())
+	handler := NewTracingHandler(client, testLogger())
+
+	resp, err := handler.QuerySpansForTrace(context.Background(), gen.QuerySpansForTraceRequestObject{
+		TraceId: "trace-1",
+		Body: &gen.TracesQueryRequest{
+			StartTime: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+			EndTime:   time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC),
+			SearchScope: gen.ComponentSearchScope{
+				Namespace: "test-ns",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, ok := resp.(gen.QuerySpansForTrace500JSONResponse); !ok {
+		t.Fatalf("expected 500 response, got %T", resp)
+	}
+}
+
 func TestQueryTraces_ServerError(t *testing.T) {
 	ooServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)

--- a/observability-tracing-openobserve/internal/openobserve/client_test.go
+++ b/observability-tracing-openobserve/internal/openobserve/client_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 	"time"
 )
@@ -521,6 +522,50 @@ func TestParseSpanDetail(t *testing.T) {
 	}
 	if resAttrMap["resource.version"] != "v1" {
 		t.Errorf("expected resource.version=v1 in resource attributes, got %q", resAttrMap["resource.version"])
+	}
+}
+
+func TestExecuteSearchQuery_InvalidJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("this is not valid json"))
+	}))
+	defer server.Close()
+
+	client := newTestClient(server.URL)
+	_, err := client.GetTraces(context.Background(), TracesQueryParams{
+		Scope: Scope{
+			Namespace: "test-ns",
+		},
+		StartTime: time.Now().Add(-time.Hour),
+		EndTime:   time.Now(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid JSON response")
+	}
+	if !strings.Contains(err.Error(), "unmarshal") {
+		t.Errorf("expected unmarshal error, got: %v", err)
+	}
+}
+
+func TestGetSpanDetail_InvalidStream(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	// Create client with invalid stream name containing semicolon
+	client := NewClient(server.URL, "default", "bad;stream", "admin", "token", testLogger())
+	_, err := client.GetSpanDetail(context.Background(), TracesQueryParams{
+		TraceID: "trace-1",
+		SpanID:  "span-1",
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid stream identifier")
+	}
+	if !strings.Contains(err.Error(), "invalid stream identifier") {
+		t.Errorf("expected 'invalid stream identifier' error, got: %v", err)
 	}
 }
 

--- a/observability-tracing-openobserve/internal/openobserve/queries_test.go
+++ b/observability-tracing-openobserve/internal/openobserve/queries_test.go
@@ -5,6 +5,9 @@ package openobserve
 
 import (
 	"encoding/json"
+	"io"
+	"log/slog"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -443,4 +446,137 @@ func TestGenerateSpanDetailQuery(t *testing.T) {
 			t.Fatal("expected error for invalid stream identifier")
 		}
 	})
+}
+
+// captureStdout runs fn and returns whatever it wrote to os.Stdout.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	origStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create pipe: %v", err)
+	}
+	os.Stdout = w
+
+	fn()
+
+	w.Close()
+	os.Stdout = origStdout
+
+	captured, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("failed to read captured output: %v", err)
+	}
+	return string(captured)
+}
+
+func debugLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
+}
+
+func TestGenerateTracesListQuery_DebugLogging(t *testing.T) {
+	startTime := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	endTime := time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC)
+
+	params := TracesQueryParams{
+		Scope: Scope{
+			Namespace: "test-ns",
+		},
+		StartTime: startTime,
+		EndTime:   endTime,
+	}
+
+	var result []byte
+	output := captureStdout(t, func() {
+		var err error
+		result, err = generateTracesListQuery(params, "mystream", debugLogger())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	var query map[string]interface{}
+	if err := json.Unmarshal(result, &query); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	q := query["query"].(map[string]interface{})
+	sql := q["sql"].(string)
+	if !strings.Contains(sql, "FROM mystream") {
+		t.Errorf("expected stream name in SQL: %s", sql)
+	}
+
+	if !strings.Contains(output, "FROM mystream") {
+		t.Errorf("expected debug output to contain SQL with stream name, got: %s", output)
+	}
+}
+
+func TestGenerateSpansListQuery_DebugLogging(t *testing.T) {
+	startTime := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	endTime := time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC)
+
+	params := TracesQueryParams{
+		TraceID:   "abc123",
+		StartTime: startTime,
+		EndTime:   endTime,
+	}
+
+	var result []byte
+	output := captureStdout(t, func() {
+		var err error
+		result, err = generateSpansListQuery(params, "mystream", debugLogger())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	var query map[string]interface{}
+	if err := json.Unmarshal(result, &query); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	q := query["query"].(map[string]interface{})
+	sql := q["sql"].(string)
+	if !strings.Contains(sql, "trace_id = 'abc123'") {
+		t.Errorf("expected trace_id filter in SQL: %s", sql)
+	}
+
+	if !strings.Contains(output, "trace_id = 'abc123'") {
+		t.Errorf("expected debug output to contain trace_id filter, got: %s", output)
+	}
+}
+
+func TestGenerateSpanDetailQuery_DebugLogging(t *testing.T) {
+	params := TracesQueryParams{
+		TraceID: "trace-1",
+		SpanID:  "span-1",
+	}
+
+	var result []byte
+	output := captureStdout(t, func() {
+		var err error
+		result, err = generateSpanDetailQuery(params, "mystream", debugLogger())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	var query map[string]interface{}
+	if err := json.Unmarshal(result, &query); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	q := query["query"].(map[string]interface{})
+	sql := q["sql"].(string)
+	if !strings.Contains(sql, "trace_id = 'trace-1'") {
+		t.Errorf("expected trace_id filter in SQL: %s", sql)
+	}
+	if !strings.Contains(sql, "span_id = 'span-1'") {
+		t.Errorf("expected span_id filter in SQL: %s", sql)
+	}
+
+	if !strings.Contains(output, "trace_id = 'trace-1'") {
+		t.Errorf("expected debug output to contain trace_id filter, got: %s", output)
+	}
 }


### PR DESCRIPTION
## Purpose
Add more unit tests for observability modules
https://github.com/openchoreo/openchoreo/issues/2755

## Goals
Increase test coverage

## Approach
Added Go unit tests for observability-logs-openobserve, observability-metrics-prometheus and observability-tracing-openobserve modules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Update alert rule now returns a 400 Bad Request (with "alert rule not found") when the target rule is missing instead of a 500 error.

* **Tests**
  * Added broad tests covering alert rule create/update/delete success and error paths.
  * Added tests for context cancellation, non-success HTTP responses, malformed responses, invalid inputs, and debug logging for query generation.
  * Expanded webhook and forwarding validation to ensure correct payloads and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->