### PR TITLE
chore: move coverage report copying logic to makefile target

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -77,10 +77,6 @@ jobs:
 
             echo "::group::Testing ${module}"
             make -C "${module}" unit-test
-            # Copy coverage output to repo root for Codecov upload
-            if [ -f "${module}/coverage.out" ]; then
-              cp "${module}/coverage.out" "${module}-coverage.out"
-            fi
             echo "::endgroup::"
 
             TEST_COUNT=$((TEST_COUNT + 1))
@@ -98,9 +94,6 @@ jobs:
           else
             echo "Successfully tested ${TEST_COUNT} module(s). ✓"
           fi
-
-      - name: Clean up in-module coverage files
-        run: find . -mindepth 2 -name 'coverage.out' -delete
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -223,10 +223,6 @@ jobs:
 
             echo "::group::Testing ${module}"
             make -C "${module}" unit-test
-            # Copy coverage output to repo root for Codecov upload
-            if [ -f "${module}/coverage.out" ]; then
-              cp "${module}/coverage.out" "${module}-coverage.out"
-            fi
             echo "::endgroup::"
 
             TEST_COUNT=$((TEST_COUNT + 1))
@@ -244,9 +240,6 @@ jobs:
           else
             echo "Successfully tested ${TEST_COUNT} module(s). ✓"
           fi
-
-      - name: Clean up in-module coverage files
-        run: find . -mindepth 2 -name 'coverage.out' -delete
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2

--- a/observability-logs-openobserve/Makefile
+++ b/observability-logs-openobserve/Makefile
@@ -12,5 +12,8 @@ openapi-codegen: oapi-codegen-install
 	cd $(CFG_DIR) && $(shell go env GOPATH)/bin/oapi-codegen --config cfg-server.yaml $(SPEC)
 	cd $(CFG_DIR) && $(shell go env GOPATH)/bin/oapi-codegen --config cfg-client.yaml $(SPEC)
 
+MODULE_NAME := $(notdir $(CURDIR))
+
 unit-test:
 	go test -coverprofile=coverage.out ./...
+	mv coverage.out ../$(MODULE_NAME)-coverage.out

--- a/observability-logs-openobserve/README.md
+++ b/observability-logs-openobserve/README.md
@@ -31,7 +31,7 @@ helm upgrade --install observability-logs-openobserve \
   oci://ghcr.io/openchoreo/helm-charts/observability-logs-openobserve \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.3.9
+  --version 0.3.10
 ```
 
 ## Enable log collection
@@ -45,7 +45,7 @@ to start collecting logs from the cluster and publish them to OpenObserve:
 helm upgrade observability-logs-openobserve \
   oci://ghcr.io/openchoreo/helm-charts/observability-logs-openobserve \
   --namespace openchoreo-observability-plane \
-  --version 0.3.9 \
+  --version 0.3.10 \
   --reuse-values \
   --set fluent-bit.enabled=true
 ```
@@ -60,7 +60,7 @@ helm upgrade --install observability-logs-openobserve \
   oci://ghcr.io/openchoreo/helm-charts/observability-logs-openobserve \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.3.9 \
+  --version 0.3.10 \
   --set fluent-bit.enabled=true \
   --set openObserve.enabled=false \
   --set openObserveSetup.enabled=false \

--- a/observability-logs-openobserve/helm/Chart.yaml
+++ b/observability-logs-openobserve/helm/Chart.yaml
@@ -5,8 +5,8 @@ apiVersion: v2
 name: observability-logs-openobserve
 description: A Helm chart for OpenChoreo Logs Module for OpenObserve
 type: application
-version: 0.3.9
-appVersion: "0.3.9"
+version: 0.3.10
+appVersion: "0.3.10"
 keywords:
   - openobserve
   - openchoreo

--- a/observability-metrics-prometheus/Makefile
+++ b/observability-metrics-prometheus/Makefile
@@ -12,5 +12,8 @@ openapi-codegen: oapi-codegen-install
 	cd $(CFG_DIR) && $(OAPI_CODEGEN_BIN) --config cfg-models.yaml ../../$(SPEC)
 	cd $(CFG_DIR) && $(OAPI_CODEGEN_BIN) --config cfg-server.yaml ../../$(SPEC)
 
+MODULE_NAME := $(notdir $(CURDIR))
+
 unit-test:
 	go test -coverprofile=coverage.out ./...
+	mv coverage.out ../$(MODULE_NAME)-coverage.out

--- a/observability-metrics-prometheus/README.md
+++ b/observability-metrics-prometheus/README.md
@@ -19,5 +19,5 @@ helm install observability-metrics-prometheus \
   oci://ghcr.io/openchoreo/helm-charts/observability-metrics-prometheus \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.2.4
+  --version 0.2.5
 ```

--- a/observability-metrics-prometheus/helm/Chart.yaml
+++ b/observability-metrics-prometheus/helm/Chart.yaml
@@ -5,8 +5,8 @@ apiVersion: v2
 name: observability-metrics-prometheus
 description: A Helm chart for OpenChoreo Observability Metrics module based on Prometheus
 type: application
-version: 0.2.4
-appVersion: "0.2.4"
+version: 0.2.5
+appVersion: "0.2.5"
 keywords:
   - prometheus
   - observability

--- a/observability-tracing-openobserve/Makefile
+++ b/observability-tracing-openobserve/Makefile
@@ -12,5 +12,8 @@ openapi-codegen: oapi-codegen-install
 	cd $(CFG_DIR) && $(shell go env GOPATH)/bin/oapi-codegen --config cfg-server.yaml $(SPEC)
 	cd $(CFG_DIR) && $(shell go env GOPATH)/bin/oapi-codegen --config cfg-client.yaml $(SPEC)
 
+MODULE_NAME := $(notdir $(CURDIR))
+
 unit-test:
 	go test -coverprofile=coverage.out ./...
+	mv coverage.out ../$(MODULE_NAME)-coverage.out

--- a/observability-tracing-openobserve/README.md
+++ b/observability-tracing-openobserve/README.md
@@ -30,7 +30,7 @@ helm upgrade --install observability-tracing-openobserve \
   oci://ghcr.io/openchoreo/helm-charts/observability-tracing-openobserve \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.1.4
+  --version 0.1.5
 ```
 
 > **Note:** If OpenObserve is already installed by another module (e.g., `observability-logs-openobserve`), disable it to avoid conflicts:
@@ -40,6 +40,6 @@ helm upgrade --install observability-tracing-openobserve \
 >  oci://ghcr.io/openchoreo/helm-charts/observability-tracing-openobserve \
 >  --create-namespace \
 >  --namespace openchoreo-observability-plane \
->  --version 0.1.4 \
+>  --version 0.1.5 \
 >  --set openObserve.enabled=false
 >```

--- a/observability-tracing-openobserve/helm/Chart.yaml
+++ b/observability-tracing-openobserve/helm/Chart.yaml
@@ -5,8 +5,8 @@ apiVersion: v2
 name: observability-tracing-openobserve
 description: A Helm chart for OpenChoreo Tracing Module for OpenObserve
 type: application
-version: 0.1.4
-appVersion: "0.1.4"
+version: 0.1.5
+appVersion: "0.1.5"
 keywords:
   - openobserve
   - openchoreo


### PR DESCRIPTION
## Purpose
https://github.com/openchoreo/openchoreo/issues/2755
Update the unit-test target it the Makefile to copy the generated code coverage report to the repository root

## Goals
Make the code coverage publishing workflow generic so it just needs to run `make unit-test`

## Approach
Updated the Makefiles' unit-test target to copy the coverage report to the repository root

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Helm chart versions across observability modules
  * Simplified CI/PR workflow coverage handling
  * Enhanced build configuration for improved artifact management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->