### PR TITLE
fix: add componentUid and projectUid filters for alert rule SQL and update required fields in request body

### DIFF
--- a/observability-logs-openobserve/README.md
+++ b/observability-logs-openobserve/README.md
@@ -38,7 +38,7 @@ helm upgrade --install observability-logs-openobserve \
   oci://ghcr.io/openchoreo/helm-charts/observability-logs-openobserve \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.4.0
+  --version 0.4.1
 ```
 
 To switch to HA mode, disable the standalone chart and enable the distributed chart:
@@ -47,7 +47,7 @@ To switch to HA mode, disable the standalone chart and enable the distributed ch
 helm upgrade --install observability-logs-openobserve \
   oci://ghcr.io/openchoreo/helm-charts/observability-logs-openobserve \
   --namespace openchoreo-observability-plane \
-  --version 0.4.0 \
+  --version 0.4.1 \
   --reuse-values \
   --set openobserve-standalone.enabled=false \
   --set openobserve.enabled=true
@@ -66,7 +66,7 @@ to start collecting logs from the cluster and publish them to OpenObserve:
 helm upgrade observability-logs-openobserve \
   oci://ghcr.io/openchoreo/helm-charts/observability-logs-openobserve \
   --namespace openchoreo-observability-plane \
-  --version 0.4.0 \
+  --version 0.4.1 \
   --reuse-values \
   --set fluent-bit.enabled=true
 ```
@@ -81,7 +81,7 @@ helm upgrade --install observability-logs-openobserve \
   oci://ghcr.io/openchoreo/helm-charts/observability-logs-openobserve \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.4.0 \
+  --version 0.4.1 \
   --set fluent-bit.enabled=true \
   --set openobserve-standalone.enabled=false \
   --set openObserveSetup.enabled=false \

--- a/observability-logs-openobserve/helm/Chart.yaml
+++ b/observability-logs-openobserve/helm/Chart.yaml
@@ -5,8 +5,8 @@ apiVersion: v2
 name: observability-logs-openobserve
 description: A Helm chart for OpenChoreo Logs Module for OpenObserve
 type: application
-version: 0.4.0
-appVersion: "0.4.0"
+version: 0.4.1
+appVersion: "0.4.1"
 keywords:
   - openobserve
   - openchoreo

--- a/observability-logs-openobserve/internal/api/gen/models.gen.go
+++ b/observability-logs-openobserve/internal/api/gen/models.gen.go
@@ -11,10 +11,6 @@ import (
 	openapi_types "github.com/oapi-codegen/runtime/types"
 )
 
-const (
-	BearerAuthScopes = "BearerAuth.Scopes"
-)
-
 // Defines values for AlertRuleRequestConditionOperator.
 const (
 	AlertRuleRequestConditionOperatorEq  AlertRuleRequestConditionOperator = "eq"
@@ -23,12 +19,6 @@ const (
 	AlertRuleRequestConditionOperatorLt  AlertRuleRequestConditionOperator = "lt"
 	AlertRuleRequestConditionOperatorLte AlertRuleRequestConditionOperator = "lte"
 	AlertRuleRequestConditionOperatorNeq AlertRuleRequestConditionOperator = "neq"
-)
-
-// Defines values for AlertRuleRequestSourceMetric.
-const (
-	AlertRuleRequestSourceMetricCpuUsage    AlertRuleRequestSourceMetric = "cpu_usage"
-	AlertRuleRequestSourceMetricMemoryUsage AlertRuleRequestSourceMetric = "memory_usage"
 )
 
 // Defines values for AlertRuleResponseConditionOperator.
@@ -43,8 +33,8 @@ const (
 
 // Defines values for AlertRuleResponseSourceMetric.
 const (
-	AlertRuleResponseSourceMetricCpuUsage    AlertRuleResponseSourceMetric = "cpu_usage"
-	AlertRuleResponseSourceMetricMemoryUsage AlertRuleResponseSourceMetric = "memory_usage"
+	CpuUsage    AlertRuleResponseSourceMetric = "cpu_usage"
+	MemoryUsage AlertRuleResponseSourceMetric = "memory_usage"
 )
 
 // Defines values for AlertWebhookResponseStatus.
@@ -93,52 +83,46 @@ const (
 
 // AlertRuleRequest defines model for AlertRuleRequest.
 type AlertRuleRequest struct {
-	Condition *struct {
+	Condition struct {
 		// Enabled Whether the alert rule is enabled
-		Enabled *bool `json:"enabled,omitempty"`
+		Enabled bool `json:"enabled"`
 
 		// Interval The interval of time to query for the alert rule
-		Interval *string `json:"interval,omitempty"`
+		Interval string `json:"interval"`
 
 		// Operator The operator to use for the alert rule
-		Operator *AlertRuleRequestConditionOperator `json:"operator,omitempty"`
+		Operator AlertRuleRequestConditionOperator `json:"operator"`
 
 		// Threshold The threshold value to use for the alert rule
-		Threshold *float32 `json:"threshold,omitempty"`
+		Threshold float32 `json:"threshold"`
 
 		// Window The window of time to query for the alert rule
-		Window *string `json:"window,omitempty"`
-	} `json:"condition,omitempty"`
-	Metadata *struct {
+		Window string `json:"window"`
+	} `json:"condition"`
+	Metadata struct {
 		// ComponentUid The OpenChoreo component UID to query
-		ComponentUid *openapi_types.UUID `json:"componentUid,omitempty"`
+		ComponentUid openapi_types.UUID `json:"componentUid"`
 
 		// EnvironmentUid The OpenChoreo environment UID to query
-		EnvironmentUid *openapi_types.UUID `json:"environmentUid,omitempty"`
+		EnvironmentUid openapi_types.UUID `json:"environmentUid"`
 
 		// Name The name of the alert rule
-		Name *string `json:"name,omitempty"`
+		Name string `json:"name"`
 
 		// Namespace The namespace of the alert rule CR
-		Namespace *string `json:"namespace,omitempty"`
+		Namespace string `json:"namespace"`
 
 		// ProjectUid The OpenChoreo project UID to query
-		ProjectUid *openapi_types.UUID `json:"projectUid,omitempty"`
-	} `json:"metadata,omitempty"`
-	Source *struct {
-		// Metric The metric to query for metric based alerts
-		Metric *AlertRuleRequestSourceMetric `json:"metric,omitempty"`
-
+		ProjectUid openapi_types.UUID `json:"projectUid"`
+	} `json:"metadata"`
+	Source struct {
 		// Query The query to execute for log based alerts
-		Query *string `json:"query,omitempty"`
-	} `json:"source,omitempty"`
+		Query string `json:"query"`
+	} `json:"source"`
 }
 
 // AlertRuleRequestConditionOperator The operator to use for the alert rule
 type AlertRuleRequestConditionOperator string
-
-// AlertRuleRequestSourceMetric The metric to query for metric based alerts
-type AlertRuleRequestSourceMetric string
 
 // AlertRuleResponse defines model for AlertRuleResponse.
 type AlertRuleResponse struct {

--- a/observability-logs-openobserve/internal/api/gen/server.gen.go
+++ b/observability-logs-openobserve/internal/api/gen/server.gen.go
@@ -59,12 +59,6 @@ type MiddlewareFunc func(http.Handler) http.Handler
 // QueryLogs operation middleware
 func (siw *ServerInterfaceWrapper) QueryLogs(w http.ResponseWriter, r *http.Request) {
 
-	ctx := r.Context()
-
-	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
-
-	r = r.WithContext(ctx)
-
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.QueryLogs(w, r)
 	}))
@@ -78,12 +72,6 @@ func (siw *ServerInterfaceWrapper) QueryLogs(w http.ResponseWriter, r *http.Requ
 
 // CreateAlertRule operation middleware
 func (siw *ServerInterfaceWrapper) CreateAlertRule(w http.ResponseWriter, r *http.Request) {
-
-	ctx := r.Context()
-
-	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
-
-	r = r.WithContext(ctx)
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.CreateAlertRule(w, r)
@@ -110,12 +98,6 @@ func (siw *ServerInterfaceWrapper) DeleteAlertRule(w http.ResponseWriter, r *htt
 		return
 	}
 
-	ctx := r.Context()
-
-	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
-
-	r = r.WithContext(ctx)
-
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.DeleteAlertRule(w, r, ruleName)
 	}))
@@ -141,12 +123,6 @@ func (siw *ServerInterfaceWrapper) GetAlertRule(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	ctx := r.Context()
-
-	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
-
-	r = r.WithContext(ctx)
-
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.GetAlertRule(w, r, ruleName)
 	}))
@@ -171,12 +147,6 @@ func (siw *ServerInterfaceWrapper) UpdateAlertRule(w http.ResponseWriter, r *htt
 		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "ruleName", Err: err})
 		return
 	}
-
-	ctx := r.Context()
-
-	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
-
-	r = r.WithContext(ctx)
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.UpdateAlertRule(w, r, ruleName)
@@ -893,49 +863,48 @@ func (sh *strictHandler) Health(w http.ResponseWriter, r *http.Request) {
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+waW2/buvmvENyAboBiO233cPzmpmmPu5ymJ2mXhzQYaPGzxBOKVEgqqRv4vw+8SJZt",
-	"yrHd9DIgL60jkt/9Tt7jVBalFCCMxsN7rNMcCuJ+jjgoc1ZxOIObCrSx30olS1CGgduRSkGZYVKsL4Eg",
-	"Ew7U/qSgU8VKvw9f5GByUMjkgIjFgFTFATGN6iMJNrMS8BBPpORABJ4nmAkD6pbwdXgfc0D1KpJTZFgB",
-	"yEh0U4GaoalcxbQAr41iIrPQLeHESBWHXq9aqJWGOEwQVYGHlzgzOMGZsZ+4cf+41RucYAE3+CqC3eQK",
-	"dC45jaNvltEt4RVspCLAFlUxAWVh3zFB5V0csF/bT2bz5ouc/AWpsbgKMIQSQ2J2EkzsE+tg8rQEcZRL",
-	"BRI1m9Gn8euGKpzgqVQFMXiIq4rRmBpB3DIlRbElotb2nVEJUkAcgV1xMn3Q6uxOXZJ0AyC3vA4NHZ3F",
-	"AJZKWl1sw3vYuiPfMa1rWSnPwrLOCzCKpXFC/NqyxYVvE6KBelZ1y63SsvpvpUlmBVlAIdUs/BlzKM9N",
-	"FLPHZySCL5BWxrsRl9kq3gcZj4miFTB1KYWGp4j5FDGfIuZTxHyKmJsi5gVMcimvu4NmAdpR3iEZt7is",
-	"8jsPMqZybYipdByWX+sCVUtWV2kK2slaKakiAu1klYnM5ofzmUi72SVpnSDWKfRryJBrEMj+6IqqqQJi",
-	"XGqoSlr/EmlOROZ+U+Bgv8asgRNtLIlAR6YjwrICtCFFWcvKHkF6JtKYyC1pr0h6DYKOOxxt4pfR+DX6",
-	"h/WwqZIFkhNtk9SEcWZm9ZZ/bhcq7PcTmbGU8C6c3C87nDZ0bAl5VwNaUYx2grWRgzAeVUDMeo7qEH8i",
-	"s2NhvLMumw2HW+CdnCK/HNO2zLpP1a4XOddOXtGA5VYbA5EZAkd40pXq3ndmiGiuc2nD5MSgDIStN4DW",
-	"mGLkfktG7ULyYNJLpTCECVDdvDVbdmWolYy3klw7ee+Paq8yYW/5NRl9Kw4X+X9H/kpJuxH8u5qAEmBA",
-	"o1LSPUHvUrWsINwBly9RtpJVXc7sys6eBdOeFhALhU3u2TY1tSJPg86mxAO7Fe8Wfs+BqDQ/T2UJDxft",
-	"W/jR5hL3AfGvE67gpmLKNpGXLUhXEY6ObenSXYO4yuZI0g5DcssolRTamRoUsv+x1OW7L6QouUV6+ur8",
-	"4D+HBycHz5/H80hHdfd7VRBxoIBQ2+UGnIuEtEDwB9OaiQzV3KMpA041eqYNUeYjK+AZIoKiZyCo+ytG",
-	"hmGGb+S2hTmk8gmh9WjUFlekMrlU7KvP7lJNGKUgbBsrzRtZCfs5lWLKWWoPuBZcEH7uJHe8Qyl5IjP9",
-	"py3LOwezgdEOdgT1/WtwkLVWZoNzJJizgoWqcEoqbvDwcDBIYhUA+cKKqkC+tbbImIFC21ZCgamUlUzY",
-	"42AMElwwEf5sEFspZb4z5zI7sUWM49DB8qx6Zbw+fvXpLU7w+P2bU5zgi9HZe5zg47Oz07P4DMF/IEqR",
-	"mVMfu6lg7KEaVYGt9Jyzf8gV0XF31MvRQAo4neLh5T3+u4IpHuK/9RfD9X6YrPejsWSebD50IdX1lMu7",
-	"pTNXrplU5lRRUEsqcerAMa3Y/UjaA6vqrwVJmpNRuTU+1VkBK7O3ea2EsAWupDHpZalfbXaPrvDGZaY7",
-	"i17tSGZAUej0phXnloOFfhvr20rRTc2+anZW61uBqtXfDcnagpHy+g/dnRZD29gMEUzNLxOoYJwzDakU",
-	"tNXNt7zPSNM1THRLLT9vyzACKxbS1hiMqWyvNuVnlAsxb11jaHOmvwsgzipR13P7p3sXqtJKMTM7txbl",
-	"CXgFRIEaVSa3f03cX29qjt9dfFyLH+8uPiIjrQlNpUI23YEwLCV2uYfGIuUVBSdEv4v5+cQo5EW3D+VA",
-	"bPAhGj3zBKDP1WDwInVH3E941rNe7gjFw0DYQvC5MSWez92IeyrDUN2Q1NRCtSXHogz9CKSwAl1VPdNo",
-	"9GGMdAkpmwYmEIUpE6Ad2RaqIqnxxSuxhpHZKoNQUhpQqKi0QcyWILae+yyMdFP1zJa46I6Z3EFpUXIa",
-	"iqQecpVyXTKlhHOHUbvUXEomjM2Sn4X3UudNtnwpiCBZe6qgffEVrNYRV89RSiVvGQWKJt7NC0krDr3P",
-	"NulylkKIikFco5KkOaDnvYHNhIoHKethv393d9cjbrknVdYPZ3X/ZHx0/P78+OB5b9DLTcFbJRRe47ke",
-	"4djIjEZBfqMPY5zgW1Daq+SwN+gNwt2CICXDQ/yiN+i9wAkuicmdyfZJyfq3h30rk34ztCyljsyp/lxI",
-	"rxFTpE71dxVMijGtD1kysfcu0OaVpLPaykA4RKQseTCZ/l/az+p8qH4okK+VbvNlPw6VhwqZyzH9fDD4",
-	"HvhDbnQELEvupDMHzhP8citqmuJ8qZXAuFXu71e2BxNrld7zZEvel1ueCN9jcUs4o0gtIL8cHD4StzVw",
-	"20kExl3IazG11EI8HlufVsC+HLx4JJ7OK5dgQgT/Mvvq4zfKiUZCohKUY1W6muOWwZ13RzlFzUwETaVM",
-	"0IcwK5gQlaCmbkIT8tUmkePWPInaDkCW9ndLcotu6/HE9qYN81/fYvWLBvi3JfG1GIg1g49p2B468uBR",
-	"gG8RVEVBbBRthUtLFrH18aWLBPjKbgyRl/AyJ4d9f+vTd0moOwIfuTsIRMTStbXYLhL7w82V+neKx2tv",
-	"nLaKx4ePiz92KxTR4mghxHC7s2dw/p7h8rcfh78lD8IVEDpD8IVpo7d32B/oX7UzLN0tBTcb+UvUBxyt",
-	"f2//s5Fz7n2Ng4l04a/d9z29zh9e9rrvVIrsafrh4vIXNP2XP8X0hTRo6qaLv6LV18a40eoTnEEkfbwF",
-	"s2LFXe3Omhm/BfPjbHjpxddmZSkwisHtk/n+n5ivM8EHbLckihRgQGk3GtzhfROzO2xvi+vnUbiO8Hi1",
-	"CGnXgquDoKsEl1XEgT65lx/xTPCQB/mzv2b59dNzUHhS88s58S/nP7UF7lX01C+vOvuL34mgHDQyimUZ",
-	"qOY12iJPkKDfTjP3INrP0L7B0tddP0BCE0lnKCUCTaw7ztC789P3yE9nE0Q0omw6BWX721WKNSrIDGkQ",
-	"tLWpJDMuCdU9vD7q/fH+s/p+r9N3gkJR7oT+5D5d7hNG9Xh4edV2pr3MPeptORDup/7Rwusoh/TaAfQb",
-	"V561rTYRvXWv8vC/0fCWr0sWz+4WF/+evNlWr0/XFHDuqUdMoxqOs4EX30CkfxC6RKMsQfgbyyFKpRDg",
-	"X3CG138b3xcugFTisVhdQNpoal7vqTWElhEFvV7NV84u3yVdXtmKJJy5X58t11Uw4Yv7jkUF5EZO8+S+",
-	"O/v6exA3DYycD4a+DqHNU+xgYG5+Nf9fAAAA//83VSsXFDcAAA==",
+	"H4sIAAAAAAAC/+waWXMUufmvqJRUbVLVnhkDedh5M8awTryYtSE8gCulaX3TrbVaaktqm8Hl/57S0deM",
+	"ei7MkQovMG5J331L9ziVRSkFCKPx9B7rNIeCuJ9HHJS5qDhcwE0F2thvpZIlKMPA7UiloMwwKVaXQJAZ",
+	"B2p/UtCpYqXfh9/nYHJQyOSAiMWAVMUBMY3qIwk2ixLwFM+k5EAEfkgwEwbULeGr8N7mgOpVJOfIsAKQ",
+	"keimArVAc7mMqQWvjWIis9At4cRIFYder1qolYY4TBBVgacfcGZwgjNjP3Hj/nGrNzjBAm7wVQS7yRXo",
+	"XHIaR98so1vCK1hLRYAtqmIGysK+Y4LKuzhgv7afzB4SrOCmYsqq+ANuVRcQdjTWEW+X11YScvYnpMZS",
+	"W4AhlBgSs7RgpO/YgJjOSxDHuVQgUbMZvTt90fCFEzyXqiAGT3FVMRozBBC3TElRbImos31nVIIUEEdg",
+	"V5xWNtqt3alLkq4B5JZXoaHjixjAUkmri214D1t35HvJbpwQunz0SFjRR9K3g5gJaVkpL4++AXn6okx5",
+	"qzcSwSdIK+Ndi8sMzYgG6oWmN7LiEayStLStMfGG1KQTRmMcdcKwLqXQ8DMO/4zDHSP8GUX/H6Po1oGv",
+	"AKNYGifEr/UtLnxbin21W6Vl9Z9Kk8wKsoBCqkX4M+ZQXyXmrobXeMR8D7NcyuvhoFmAdpQPSMYt9lV+",
+	"50HGVK4NMZWOw/JrQ6BqyeoqTUE7WSslVUSgg6wykdn8cLkQ6TC7JK0TxCqFfg0Zcg0C2R9DUTVVQIxL",
+	"DVVJ618izYnI3G8KHOzXmDVwoo0lEeiRGYiwrABtSFHWsrJHkF6INCZyS9pzkl6DoKcDjjbzy+j0Bfqb",
+	"9bC5kgWSM22T1IxxZhb1lr9vFyrs9zOZsZTwIZzcLzucNnRsCXlXA1pSjHaCtZGDMB5VQMx6jusQfyaz",
+	"E2G8s/bNhsMt8EFOkV+OaVtmw6dq14uc6yavaMByq42ByAyBIzwZSnWvBzNENNe5tGFyYlAGwtYbQGtM",
+	"MXK/JKMOIdmY9FIpDGEC1DBvzZZdGeok460k103e+6Paq0zYW35NRt+Kwzb/78hfKekwgn9VM1ACDGhU",
+	"Sron6F2qliWEO+DyJcpWsqrLmV3Z2bNg2tMCYqGwyT3bpqZO5GnQ2ZR4YLfi3cLvJRCV5pepLGFz0b6F",
+	"H60vcTeIf3PH7iHFetUTW7oM1yCusjmWdMCQ3DJKJYVupgaF7H/MtcrwiRQlt0jPn18e/Pvw4OzgyZN4",
+	"Hhmo7n6rCiIOFBBqu9yAs01ILYLfmdZMZKjmHs0ZcKrRL9oQZd6yAn5BRFD0Cwjq/oqRYZjha7ntYA6p",
+	"fEZoPXC1xRWpTC4V++yzu1QzRikI28ZK81JWwk9FxJyz1NRjN0H4pZPcyQ6l5JnM9B+2LB8c9wZGB9gR",
+	"1PevwUFWWpk1zpFgzgoWqsI5qbjB08PJJIlVAOQTK6oC+dbaImMGCm1bCQWmUlYyYY+DMUlwwUT4s0Fs",
+	"pZT5zpzL7MwWMY5DB8uz6pXx4uT5u1c4waevX57jBL8/uniNE3xycXF+EZ8h+A9EKbJw6mM3FZx6qEZV",
+	"YCs95+xvckV03B11PxpIAedzPP1wj/+qYI6n+C/jdmQ/DvP6cTSWPCTrD72X6nrO5V3vzJVrJpU5VxRU",
+	"TyVOHTimFbsfSXtgWf21IElzMiq3xqcGK2Bl9javpRDW4koak+5L/Wq9ewyFNy4zPVj0akcyA4pCpzev",
+	"OLcctPptrG8rRTc1+7LZWa1vBapW/zAkawtGyuvf9XBaDG1jM0QwNb9MoIJxzjSkUtBON9/xPiPN0DDR",
+	"LXX8vCvDCKxYSFthMKayvdqU71EuxLx1haH1mf4ugLioRF3P7Z/uH9w8eC7DBNqQ1NQU2Pzc1mxvgRQW",
+	"+7KcmEZHb06RLiFlc5YSN4SgMGcCtJOahapIanylR6wUM5uSCSWlAYWKShvEbL62xc9HYaQbQWe2HkR3",
+	"zOQOSoeS81BRjJArK+v6IiWcO4za5bFSMmFsSvkovEk707O5viCCZN0WXPtKJajYEVcPHUolbxkFimbe",
+	"JwpJKw6jjzZDcZZCCCFBXEclSXNAT0YTmzYUx1OcG1Pq6Xh8d3c3Im55JFU2Dmf1+Oz0+OT15cnBk9Fk",
+	"lJuCd+oNvMJzPe+wYQwdBfkdvTnFCb4Fpb1KDkeT0SQM4gUpGZ7ip6PJ6KntronJnYGNScnGt4djK5Nx",
+	"M+ErpY4Mdf5opdeIKVLU+cE+k+KU1ocsmdibImjzXNJFbWUgHCJSljyYzPhP7QdbPq5tinordc5D3+hD",
+	"mlYhzDumn0wmXwN/SCSOgL7kzgYTxkOCn21FTVPJ9upujDu18X41bjCxTp1qE/hWvPf7gwjfp+KWcEaR",
+	"aiE/mxw+Erc1cFt2B8aNvHbFdM1Ur95+PLbeLYF9Nnn6SDxdVi4ao4/VZPI0/bT47H4AyolGQqISlGNV",
+	"ugR9y+DOu6Oco2aAgOZSJuhNaKxnRCWoKTLQjHy2ifykM3yhtlyWpf3dkVzbmjye2F52Yf7jS6y+7RZ/",
+	"7Ymvw0Csc3pMw/bQkQePAnyLoCoKYqNoJ1xasogtJj+4SICv7MYQeQkvc3I49lckY5eEhiPwsRvYIyJ6",
+	"d7xiu0jsDzf3z18pHq88M9oqHh8+Lv7YFUpEi0etEMNVyJ7B+WuGy1+/Hf6OPAhXQOgCwSemjd7eYb+h",
+	"f9XO0LuICW525G8cNzja+N7+ZyPng/c1DibSsr5w3/f0On+473VfqRTZ0/TDLd8PaPrPvovpC2nQ3I3i",
+	"fkSrr41xrdUnOINI+ngFZsmKh9qdFTN+Bebb2XDvedR6ZSkwisHtT/P9HzFfZ4IbbLckihRgQGk3R9vh",
+	"MRCzO2xvi+u3RLiO8Hi5COnWgstTk6sEl1XEgd65ZxLxTLDJg/zZH7P8+u45KLw/+eGc+Ifzn9oC9yp6",
+	"6mdKg/3Fb0RQDhoZxbIMVPN0q80TJOh30Mw9iO6brS+w9FXXD5DQTNIFSolAM+uOC/TPy/PXyI8yE0Q0",
+	"omw+B2X722WKNSrIAmkQtLOpJAsuCdUjHJ2LfmP/WX7sNug7QaEod0L/6T4b3WcvA4/6Vw6Em9wSHS21",
+	"jnNIrx1Av3Hp1ddy2zBa9SMP/wtNrX+b0L5Ka+/FPXmLrR5nroj80lOPmEY1HKf1p19ApH8v2aNRliD8",
+	"hd4UpVII8A8cw+O4tc/vWiCVeCxWW0hLxuU1nVrVd8wmaPLKAQ0f71cHxHUpS3h7adGWMW5u9JDcD6dQ",
+	"f5nhRnqR88F2VyF0iY4dDNQ/XD38NwAA//8gQ0OrXDYAAA==",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/observability-logs-openobserve/internal/handlers.go
+++ b/observability-logs-openobserve/internal/handlers.go
@@ -473,43 +473,18 @@ func toComponentLogsParams(req *gen.LogsQueryRequest, scope *gen.ComponentSearch
 
 // toLogAlertParams converts the generated AlertRuleRequest to internal params.
 func toLogAlertParams(req *gen.AlertRuleRequest) openobserve.LogAlertParams {
-	params := openobserve.LogAlertParams{}
-	if req.Metadata != nil {
-		params.Name = req.Metadata.Name
-		if req.Metadata.Namespace != nil {
-			params.Namespace = *req.Metadata.Namespace
-		}
-		if req.Metadata.ProjectUid != nil {
-			params.ProjectUID = req.Metadata.ProjectUid.String()
-		}
-		if req.Metadata.EnvironmentUid != nil {
-			params.EnvironmentUID = req.Metadata.EnvironmentUid.String()
-		}
-		if req.Metadata.ComponentUid != nil {
-			params.ComponentUID = req.Metadata.ComponentUid.String()
-		}
-	}
-	if req.Source != nil {
-		if req.Source.Query != nil {
-			params.SearchPattern = *req.Source.Query
-		}
-	}
-	if req.Condition != nil {
-		if req.Condition.Enabled != nil {
-			params.Enabled = req.Condition.Enabled
-		}
-		if req.Condition.Operator != nil {
-			params.Operator = string(*req.Condition.Operator)
-		}
-		if req.Condition.Threshold != nil {
-			params.ThresholdValue = *req.Condition.Threshold
-		}
-		if req.Condition.Window != nil {
-			params.Window = *req.Condition.Window
-		}
-		if req.Condition.Interval != nil {
-			params.Interval = *req.Condition.Interval
-		}
+	params := openobserve.LogAlertParams{
+		Name:           &req.Metadata.Name,
+		Namespace:      req.Metadata.Namespace,
+		ProjectUID:     req.Metadata.ProjectUid.String(),
+		EnvironmentUID: req.Metadata.EnvironmentUid.String(),
+		ComponentUID:   req.Metadata.ComponentUid.String(),
+		SearchPattern:  req.Source.Query,
+		Operator:       string(req.Condition.Operator),
+		ThresholdValue: req.Condition.Threshold,
+		Window:         req.Condition.Window,
+		Interval:       req.Condition.Interval,
+		Enabled:        &req.Condition.Enabled,
 	}
 	return params
 }

--- a/observability-logs-openobserve/internal/handlers_test.go
+++ b/observability-logs-openobserve/internal/handlers_test.go
@@ -278,9 +278,9 @@ func TestToWorkflowLogsParams(t *testing.T) {
 
 func TestToLogAlertParams(t *testing.T) {
 	enabled := true
-	projUID := openapi_types.UUID{}
-	envUID := openapi_types.UUID{}
-	compUID := openapi_types.UUID{}
+	projUID, _ := parseUUID("550e8400-e29b-41d4-a716-446655440000")
+	envUID, _ := parseUUID("550e8400-e29b-41d4-a716-446655440001")
+	compUID, _ := parseUUID("550e8400-e29b-41d4-a716-446655440002")
 	operator := gen.AlertRuleRequestConditionOperator("gt")
 	threshold := float32(5)
 	window := "5m"
@@ -288,37 +288,36 @@ func TestToLogAlertParams(t *testing.T) {
 	query := "error pattern"
 
 	req := &gen.AlertRuleRequest{
-		Metadata: &struct {
-			ComponentUid   *openapi_types.UUID `json:"componentUid,omitempty"`
-			EnvironmentUid *openapi_types.UUID `json:"environmentUid,omitempty"`
-			Name           *string   `json:"name,omitempty"`
-			Namespace      *string   `json:"namespace,omitempty"`
-			ProjectUid     *openapi_types.UUID `json:"projectUid,omitempty"`
+		Metadata: struct {
+			ComponentUid   openapi_types.UUID `json:"componentUid"`
+			EnvironmentUid openapi_types.UUID `json:"environmentUid"`
+			Name           string             `json:"name"`
+			Namespace      string             `json:"namespace"`
+			ProjectUid     openapi_types.UUID `json:"projectUid"`
 		}{
-			Name:           ptr("my-alert"),
-			Namespace:      ptr("ns-1"),
-			ProjectUid:     &projUID,
-			EnvironmentUid: &envUID,
-			ComponentUid:   &compUID,
+			Name:           "my-alert",
+			Namespace:      "ns-1",
+			ProjectUid:     projUID,
+			EnvironmentUid: envUID,
+			ComponentUid:   compUID,
 		},
-		Source: &struct {
-			Metric *gen.AlertRuleRequestSourceMetric `json:"metric,omitempty"`
-			Query  *string                           `json:"query,omitempty"`
+		Source: struct {
+			Query string `json:"query"`
 		}{
-			Query: &query,
+			Query: query,
 		},
-		Condition: &struct {
-			Enabled   *bool                                     `json:"enabled,omitempty"`
-			Interval  *string                                   `json:"interval,omitempty"`
-			Operator  *gen.AlertRuleRequestConditionOperator     `json:"operator,omitempty"`
-			Threshold *float32                                  `json:"threshold,omitempty"`
-			Window    *string                                   `json:"window,omitempty"`
+		Condition: struct {
+			Enabled   bool                                 `json:"enabled"`
+			Interval  string                               `json:"interval"`
+			Operator  gen.AlertRuleRequestConditionOperator `json:"operator"`
+			Threshold float32                              `json:"threshold"`
+			Window    string                               `json:"window"`
 		}{
-			Enabled:   &enabled,
-			Operator:  &operator,
-			Threshold: &threshold,
-			Window:    &window,
-			Interval:  &interval,
+			Enabled:   enabled,
+			Operator:  operator,
+			Threshold: threshold,
+			Window:    window,
+			Interval:  interval,
 		},
 	}
 
@@ -557,36 +556,40 @@ func TestCreateAlertRule_Success(t *testing.T) {
 	window := "5m"
 	interval := "1m"
 
+	envUID, _ := parseUUID("550e8400-e29b-41d4-a716-446655440001")
+	compUID, _ := parseUUID("550e8400-e29b-41d4-a716-446655440002")
+
 	resp, err := handler.CreateAlertRule(context.Background(), gen.CreateAlertRuleRequestObject{
 		Body: &gen.AlertRuleRequest{
-			Metadata: &struct {
-				ComponentUid   *openapi_types.UUID `json:"componentUid,omitempty"`
-				EnvironmentUid *openapi_types.UUID `json:"environmentUid,omitempty"`
-				Name           *string   `json:"name,omitempty"`
-				Namespace      *string   `json:"namespace,omitempty"`
-				ProjectUid     *openapi_types.UUID `json:"projectUid,omitempty"`
+			Metadata: struct {
+				ComponentUid   openapi_types.UUID `json:"componentUid"`
+				EnvironmentUid openapi_types.UUID `json:"environmentUid"`
+				Name           string             `json:"name"`
+				Namespace      string             `json:"namespace"`
+				ProjectUid     openapi_types.UUID `json:"projectUid"`
 			}{
-				Name:      ptr("test-alert"),
-				Namespace: ptr("ns-1"),
+				Name:           "test-alert",
+				Namespace:      "ns-1",
+				EnvironmentUid: envUID,
+				ComponentUid:   compUID,
 			},
-			Source: &struct {
-				Metric *gen.AlertRuleRequestSourceMetric `json:"metric,omitempty"`
-				Query  *string                           `json:"query,omitempty"`
+			Source: struct {
+				Query string `json:"query"`
 			}{
-				Query: ptr("error"),
+				Query: "error",
 			},
-			Condition: &struct {
-				Enabled   *bool                                     `json:"enabled,omitempty"`
-				Interval  *string                                   `json:"interval,omitempty"`
-				Operator  *gen.AlertRuleRequestConditionOperator     `json:"operator,omitempty"`
-				Threshold *float32                                  `json:"threshold,omitempty"`
-				Window    *string                                   `json:"window,omitempty"`
+			Condition: struct {
+				Enabled   bool                                 `json:"enabled"`
+				Interval  string                               `json:"interval"`
+				Operator  gen.AlertRuleRequestConditionOperator `json:"operator"`
+				Threshold float32                              `json:"threshold"`
+				Window    string                               `json:"window"`
 			}{
-				Enabled:   &enabled,
-				Operator:  &operator,
-				Threshold: &threshold,
-				Window:    &window,
-				Interval:  &interval,
+				Enabled:   enabled,
+				Operator:  operator,
+				Threshold: threshold,
+				Window:    window,
+				Interval:  interval,
 			},
 		},
 	})
@@ -745,34 +748,33 @@ func TestUpdateAlertRule_Success(t *testing.T) {
 	resp, err := handler.UpdateAlertRule(context.Background(), gen.UpdateAlertRuleRequestObject{
 		RuleName: "test-alert",
 		Body: &gen.AlertRuleRequest{
-			Metadata: &struct {
-				ComponentUid   *openapi_types.UUID `json:"componentUid,omitempty"`
-				EnvironmentUid *openapi_types.UUID `json:"environmentUid,omitempty"`
-				Name           *string             `json:"name,omitempty"`
-				Namespace      *string             `json:"namespace,omitempty"`
-				ProjectUid     *openapi_types.UUID `json:"projectUid,omitempty"`
+			Metadata: struct {
+				ComponentUid   openapi_types.UUID `json:"componentUid"`
+				EnvironmentUid openapi_types.UUID `json:"environmentUid"`
+				Name           string             `json:"name"`
+				Namespace      string             `json:"namespace"`
+				ProjectUid     openapi_types.UUID `json:"projectUid"`
 			}{
-				Name:      ptr("test-alert"),
-				Namespace: ptr("ns-1"),
+				Name:      "test-alert",
+				Namespace: "ns-1",
 			},
-			Source: &struct {
-				Metric *gen.AlertRuleRequestSourceMetric `json:"metric,omitempty"`
-				Query  *string                           `json:"query,omitempty"`
+			Source: struct {
+				Query string `json:"query"`
 			}{
-				Query: ptr("error"),
+				Query: "error",
 			},
-			Condition: &struct {
-				Enabled   *bool                                 `json:"enabled,omitempty"`
-				Interval  *string                               `json:"interval,omitempty"`
-				Operator  *gen.AlertRuleRequestConditionOperator `json:"operator,omitempty"`
-				Threshold *float32                              `json:"threshold,omitempty"`
-				Window    *string                               `json:"window,omitempty"`
+			Condition: struct {
+				Enabled   bool                                 `json:"enabled"`
+				Interval  string                               `json:"interval"`
+				Operator  gen.AlertRuleRequestConditionOperator `json:"operator"`
+				Threshold float32                              `json:"threshold"`
+				Window    string                               `json:"window"`
 			}{
-				Enabled:   &enabled,
-				Operator:  &operator,
-				Threshold: &threshold,
-				Window:    &window,
-				Interval:  &interval,
+				Enabled:   enabled,
+				Operator:  operator,
+				Threshold: threshold,
+				Window:    window,
+				Interval:  interval,
 			},
 		},
 	})
@@ -808,18 +810,18 @@ func TestUpdateAlertRule_NotFound(t *testing.T) {
 	resp, err := handler.UpdateAlertRule(context.Background(), gen.UpdateAlertRuleRequestObject{
 		RuleName: "nonexistent",
 		Body: &gen.AlertRuleRequest{
-			Condition: &struct {
-				Enabled   *bool                                 `json:"enabled,omitempty"`
-				Interval  *string                               `json:"interval,omitempty"`
-				Operator  *gen.AlertRuleRequestConditionOperator `json:"operator,omitempty"`
-				Threshold *float32                              `json:"threshold,omitempty"`
-				Window    *string                               `json:"window,omitempty"`
+			Condition: struct {
+				Enabled   bool                                 `json:"enabled"`
+				Interval  string                               `json:"interval"`
+				Operator  gen.AlertRuleRequestConditionOperator `json:"operator"`
+				Threshold float32                              `json:"threshold"`
+				Window    string                               `json:"window"`
 			}{
-				Enabled:   &enabled,
-				Operator:  &operator,
-				Threshold: &threshold,
-				Window:    ptr("5m"),
-				Interval:  ptr("1m"),
+				Enabled:   enabled,
+				Operator:  operator,
+				Threshold: threshold,
+				Window:    "5m",
+				Interval:  "1m",
 			},
 		},
 	})
@@ -859,18 +861,18 @@ func TestUpdateAlertRule_InvalidError(t *testing.T) {
 	resp, err := handler.UpdateAlertRule(context.Background(), gen.UpdateAlertRuleRequestObject{
 		RuleName: "test-alert",
 		Body: &gen.AlertRuleRequest{
-			Condition: &struct {
-				Enabled   *bool                                 `json:"enabled,omitempty"`
-				Interval  *string                               `json:"interval,omitempty"`
-				Operator  *gen.AlertRuleRequestConditionOperator `json:"operator,omitempty"`
-				Threshold *float32                              `json:"threshold,omitempty"`
-				Window    *string                               `json:"window,omitempty"`
+			Condition: struct {
+				Enabled   bool                                 `json:"enabled"`
+				Interval  string                               `json:"interval"`
+				Operator  gen.AlertRuleRequestConditionOperator `json:"operator"`
+				Threshold float32                              `json:"threshold"`
+				Window    string                               `json:"window"`
 			}{
-				Enabled:   &enabled,
-				Operator:  &operator,
-				Threshold: &threshold,
-				Window:    ptr("5m"),
-				Interval:  ptr("1m"),
+				Enabled:   enabled,
+				Operator:  operator,
+				Threshold: threshold,
+				Window:    "5m",
+				Interval:  "1m",
 			},
 		},
 	})
@@ -910,18 +912,18 @@ func TestUpdateAlertRule_GenericError(t *testing.T) {
 	resp, err := handler.UpdateAlertRule(context.Background(), gen.UpdateAlertRuleRequestObject{
 		RuleName: "test-alert",
 		Body: &gen.AlertRuleRequest{
-			Condition: &struct {
-				Enabled   *bool                                 `json:"enabled,omitempty"`
-				Interval  *string                               `json:"interval,omitempty"`
-				Operator  *gen.AlertRuleRequestConditionOperator `json:"operator,omitempty"`
-				Threshold *float32                              `json:"threshold,omitempty"`
-				Window    *string                               `json:"window,omitempty"`
+			Condition: struct {
+				Enabled   bool                                 `json:"enabled"`
+				Interval  string                               `json:"interval"`
+				Operator  gen.AlertRuleRequestConditionOperator `json:"operator"`
+				Threshold float32                              `json:"threshold"`
+				Window    string                               `json:"window"`
 			}{
-				Enabled:   &enabled,
-				Operator:  &operator,
-				Threshold: &threshold,
-				Window:    ptr("5m"),
-				Interval:  ptr("1m"),
+				Enabled:   enabled,
+				Operator:  operator,
+				Threshold: threshold,
+				Window:    "5m",
+				Interval:  "1m",
 			},
 		},
 	})
@@ -1104,37 +1106,40 @@ func TestCreateAlertRule_Error(t *testing.T) {
 	enabled := true
 	operator := gen.AlertRuleRequestConditionOperator("gt")
 	threshold := float32(5)
+	envUID, _ := parseUUID("550e8400-e29b-41d4-a716-446655440001")
+	compUID, _ := parseUUID("550e8400-e29b-41d4-a716-446655440002")
 
 	resp, err := handler.CreateAlertRule(context.Background(), gen.CreateAlertRuleRequestObject{
 		Body: &gen.AlertRuleRequest{
-			Metadata: &struct {
-				ComponentUid   *openapi_types.UUID `json:"componentUid,omitempty"`
-				EnvironmentUid *openapi_types.UUID `json:"environmentUid,omitempty"`
-				Name           *string             `json:"name,omitempty"`
-				Namespace      *string             `json:"namespace,omitempty"`
-				ProjectUid     *openapi_types.UUID `json:"projectUid,omitempty"`
+			Metadata: struct {
+				ComponentUid   openapi_types.UUID `json:"componentUid"`
+				EnvironmentUid openapi_types.UUID `json:"environmentUid"`
+				Name           string             `json:"name"`
+				Namespace      string             `json:"namespace"`
+				ProjectUid     openapi_types.UUID `json:"projectUid"`
 			}{
-				Name:      ptr("test-alert"),
-				Namespace: ptr("ns-1"),
+				Name:           "test-alert",
+				Namespace:      "ns-1",
+				EnvironmentUid: envUID,
+				ComponentUid:   compUID,
 			},
-			Source: &struct {
-				Metric *gen.AlertRuleRequestSourceMetric `json:"metric,omitempty"`
-				Query  *string                           `json:"query,omitempty"`
+			Source: struct {
+				Query string `json:"query"`
 			}{
-				Query: ptr("error"),
+				Query: "error",
 			},
-			Condition: &struct {
-				Enabled   *bool                                 `json:"enabled,omitempty"`
-				Interval  *string                               `json:"interval,omitempty"`
-				Operator  *gen.AlertRuleRequestConditionOperator `json:"operator,omitempty"`
-				Threshold *float32                              `json:"threshold,omitempty"`
-				Window    *string                               `json:"window,omitempty"`
+			Condition: struct {
+				Enabled   bool                                 `json:"enabled"`
+				Interval  string                               `json:"interval"`
+				Operator  gen.AlertRuleRequestConditionOperator `json:"operator"`
+				Threshold float32                              `json:"threshold"`
+				Window    string                               `json:"window"`
 			}{
-				Enabled:   &enabled,
-				Operator:  &operator,
-				Threshold: &threshold,
-				Window:    ptr("5m"),
-				Interval:  ptr("1m"),
+				Enabled:   enabled,
+				Operator:  operator,
+				Threshold: threshold,
+				Window:    "5m",
+				Interval:  "1m",
 			},
 		},
 	})

--- a/observability-logs-openobserve/internal/openobserve/queries.go
+++ b/observability-logs-openobserve/internal/openobserve/queries.go
@@ -122,9 +122,11 @@ func parseDurationMinutes(duration string) (int, error) {
 // generateAlertConfig generates an OpenObserve alert configuration as JSON
 func generateAlertConfig(params LogAlertParams, streamName string, logger *slog.Logger) ([]byte, error) {
 	query := fmt.Sprintf(
-		"SELECT _timestamp FROM %s WHERE str_match(log, '%s')",
+		"SELECT _timestamp FROM %s WHERE str_match(log, '%s') AND kubernetes_labels_openchoreo_dev_environment_uid = '%s' AND kubernetes_labels_openchoreo_dev_component_uid = '%s'",
 		quoteIdentifier(streamName),
 		escapeSQLString(params.SearchPattern),
+		escapeSQLString(params.EnvironmentUID),
+		escapeSQLString(params.ComponentUID),
 	)
 
 	sqlOperator, err := mapOperator(params.Operator)

--- a/observability-logs-openobserve/internal/openobserve/queries_test.go
+++ b/observability-logs-openobserve/internal/openobserve/queries_test.go
@@ -415,6 +415,12 @@ func TestGenerateAlertConfig(t *testing.T) {
 		if !strings.Contains(sql, "str_match(log, 'error')") {
 			t.Errorf("expected str_match in SQL: %s", sql)
 		}
+		if !strings.Contains(sql, "kubernetes_labels_openchoreo_dev_environment_uid = 'env-uid'") {
+			t.Errorf("expected environment_uid filter in SQL: %s", sql)
+		}
+		if !strings.Contains(sql, "kubernetes_labels_openchoreo_dev_component_uid = 'comp-uid'") {
+			t.Errorf("expected component_uid filter in SQL: %s", sql)
+		}
 
 		tc := config["trigger_condition"].(map[string]interface{})
 		if tc["operator"] != ">" {


### PR DESCRIPTION
## Purpose
https://github.com/openchoreo/openchoreo/issues/2859

Log-based alerts created in the observability-logs-openobserve module match log entries from any component and environment because the generated OpenObserve SQL query only filters by the search pattern, without scoping to a specific environment or component.

## Goals
- Scope alert SQL queries by filtering on environmentUid and componentUid in the WHERE clause.
- Enforce all alert request fields as mandatory at the API spec level.
- Remove the inapplicable metric field from the log-based alert request schema.

## Approach
- Regenerated Go types via make openapi-codegen, making all fields value types with automatic rejection of incomplete requests.
- Updated generateAlertConfig to include kubernetes_labels_openchoreo_dev_environment_uid and kubernetes_labels_openchoreo_dev_component_uid filters in the SQL WHERE clause.
- Simplified handlers.go by removing manual nil-check validation and pointer dereferencing, since the generated code now enforces required fields.
- Updated tests to match the new non-pointer types and added assertions verifying the UID filters in the generated SQL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Version 0.4.1 now available for the observability logs component.

* **Improvements**
  * Enhanced log alert filtering to better isolate and scope alerts to specific environment and component contexts, improving alert accuracy and precision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->