### PR TITLE
refactor: look up OpenSearch admin password from credentials secret

### DIFF
--- a/observability-logs-opensearch/README.md
+++ b/observability-logs-opensearch/README.md
@@ -52,14 +52,14 @@ helm upgrade --install opensearch-operator opensearch-operator/opensearch-operat
 
 ## Deploy Helm chart
 
-> **Note:** If you wish to use the Kubernetes operator-based OpenSearch version, add `--set openSearch.enabled=false --set openSearchCluster.enabled=true` flags when installing the Helm chart
+> **Note:** If you wish to use the Kubernetes operator-based OpenSearch version, add `--set openSearch.enabled=false --set openSearchCluster.enabled=true --set openSearchCluster.credentialsSecretName="opensearch-admin-credentials"` flags when installing the Helm chart. The admin password will be read from the credentials secret at install time.
 
 ```bash
 helm upgrade --install observability-logs-opensearch \
   oci://ghcr.io/openchoreo/helm-charts/observability-logs-opensearch \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.3.9 \
+  --version 0.3.10 \
   --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials"
 ```
 
@@ -70,7 +70,7 @@ helm upgrade --install observability-logs-opensearch \
 >   oci://ghcr.io/openchoreo/helm-charts/observability-logs-opensearch \
 >   --create-namespace \
 >   --namespace openchoreo-observability-plane \
->   --version 0.3.9 \
+>   --version 0.3.10 \
 >   --set openSearch.enabled=false \
 >   --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials"
 > ```
@@ -87,7 +87,7 @@ helm upgrade observability-logs-opensearch \
   oci://ghcr.io/openchoreo/helm-charts/observability-logs-opensearch \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.3.9 \
+  --version 0.3.10 \
   --reuse-values \
   --set fluent-bit.enabled=true
 ```
@@ -102,7 +102,7 @@ helm upgrade --install observability-logs-opensearch \
   oci://ghcr.io/openchoreo/helm-charts/observability-logs-opensearch \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.3.9 \
+  --version 0.3.10 \
   --set fluent-bit.enabled=true \
   --set openSearch.enabled=false \
   --set openSearchCluster.enabled=false \

--- a/observability-logs-opensearch/helm/Chart.yaml
+++ b/observability-logs-opensearch/helm/Chart.yaml
@@ -5,8 +5,8 @@ apiVersion: v2
 name: observability-logs-opensearch
 description: A Helm chart for OpenChoreo Observability Logs module with Fluent Bit and OpenSearch
 type: application
-version: 0.3.9
-appVersion: "0.3.9"
+version: 0.3.10
+appVersion: "0.3.10"
 keywords:
   - opensearch
   - observability

--- a/observability-logs-opensearch/helm/templates/opensearch-cluster/secrets.yaml
+++ b/observability-logs-opensearch/helm/templates/opensearch-cluster/secrets.yaml
@@ -2,9 +2,11 @@
 {{- if not .Values.openSearchCluster.credentialsSecretName }}
 {{- fail "openSearchCluster.credentialsSecretName is required when openSearchCluster is enabled. Create a Secret with 'username' and 'password' keys, then set openSearchCluster.credentialsSecretName." }}
 {{- end }}
-{{- if not .Values.openSearchCluster.adminPassword }}
-{{- fail "openSearchCluster.adminPassword is required when openSearchCluster is enabled. This password is used to generate the internal_users.yml security configuration." }}
+{{- $secret := lookup "v1" "Secret" .Release.Namespace .Values.openSearchCluster.credentialsSecretName }}
+{{- if not $secret }}
+{{- fail (printf "Secret '%s' not found in namespace '%s'. Create the Secret with 'username' and 'password' keys before installing this chart." .Values.openSearchCluster.credentialsSecretName .Release.Namespace) }}
 {{- end }}
+{{- $password := index $secret.data "password" | required (printf "Secret '%s' in namespace '%s' is missing the 'password' key." .Values.openSearchCluster.credentialsSecretName .Release.Namespace) | b64dec }}
 ---
 apiVersion: v1
 kind: Secret
@@ -13,5 +15,5 @@ metadata:
   namespace: {{ .Release.Namespace }}
 type: Opaque
 data:
-  internal_users.yml: {{- (printf .Values.openSearchCluster.internalUsers (.Values.openSearchCluster.adminPassword | bcrypt)) | b64enc | nindent 4 }}
+  internal_users.yml: {{- (printf .Values.openSearchCluster.internalUsers ($password | bcrypt)) | b64enc | nindent 4 }}
 {{- end }}

--- a/observability-logs-opensearch/helm/templates/opensearch-setup-logs/job.yaml
+++ b/observability-logs-opensearch/helm/templates/opensearch-setup-logs/job.yaml
@@ -36,8 +36,6 @@ spec:
           value: "{{ .Values.openSearchSetup.alertingWebhookUrl }}"
         - name: CONTAINER_LOGS_MIN_INDEX_AGE
           value: "{{ .Values.openSearchSetup.dataRetentionTime.containerLogs }}"
-        - name: RCA_REPORTS_MIN_INDEX_AGE
-          value: "{{ .Values.openSearchSetup.dataRetentionTime.rcaReports }}"
         image: "{{ .Values.openSearchSetup.image.repository }}:{{ .Values.openSearchSetup.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.openSearchSetup.image.pullPolicy | default "IfNotPresent" }}
         resources:

--- a/observability-logs-opensearch/helm/values.yaml
+++ b/observability-logs-opensearch/helm/values.yaml
@@ -153,7 +153,6 @@ openSearchCluster:
           memory: 900Mi
 
   credentialsSecretName: ""
-  adminPassword: ""
 
   internalUsers: |
     # This is the internal user database
@@ -180,4 +179,3 @@ openSearchSetup:
 
   dataRetentionTime:
     containerLogs: "30d"
-    rcaReports: "90d"

--- a/observability-logs-opensearch/init/setup-opensearch.sh
+++ b/observability-logs-opensearch/init/setup-opensearch.sh
@@ -138,52 +138,10 @@ containerLogsIndexTemplate='
   }
 }'
 
-# Template for indices which hold RCA reports
-rcaReportsIndexTemplate='
-{
-  "index_patterns": [
-    "rca-reports-*"
-  ],
-  "template": {
-    "settings": {
-      "number_of_shards": 1,
-      "number_of_replicas": 1
-    },
-    "mappings": {
-      "dynamic": "false",
-      "properties": {
-        "@timestamp": {
-          "type": "date"
-        },
-        "reportId": {
-          "type": "keyword"
-        },
-        "alertId": {
-          "type": "keyword"
-        },
-        "status": {
-          "type": "keyword"
-        },
-        "resource": {
-          "properties": {
-            "openchoreo.dev/project-uid": {
-              "type": "keyword"
-            },
-            "openchoreo.dev/environment-uid": {
-              "type": "keyword"
-            }
-          }
-        }
-      }
-    }
-  }
-}'
-# TODO: "openchoreo.dev/organization-uid": should be removed or refactored
-
 # The following array holds pairs of index template names and their definitions. Define more templates above
 # and add them to this array.
 # Format: (templateName1 templateDefinition1 templateName2 templateDefinition2 ...)
-indexTemplates=("container-logs" "containerLogsIndexTemplate" "rca-reports" "rcaReportsIndexTemplate")
+indexTemplates=("container-logs" "containerLogsIndexTemplate")
 
 # Create index templates through a loop using the above array
 echo "Creating index templates..."
@@ -293,7 +251,6 @@ echo -e "\nManaging ISM Policies..."
 
 # Read retention periods from environment variables or use defaults
 containerLogsRetention="${CONTAINER_LOGS_MIN_INDEX_AGE:-30d}"
-rcaReportsRetention="${RCA_REPORTS_MIN_INDEX_AGE:-90d}"
 
 # container logs
 containerLogsIsmPolicy='{
@@ -332,46 +289,9 @@ containerLogsIsmPolicy='{
   }
 }'
 
-# RCA reports
-rcaReportsIsmPolicy='{
-  "policy": {
-    "description": "Delete RCA reports older than '"$rcaReportsRetention"'",
-    "default_state": "active",
-    "states": [
-      {
-        "name": "active",
-        "actions": [],
-        "transitions": [
-          {
-            "state_name": "delete",
-            "conditions": {
-              "min_index_age": "'"$rcaReportsRetention"'"
-            }
-          }
-        ]
-      },
-      {
-        "name": "delete",
-        "actions": [
-          {
-            "delete": {}
-          }
-        ],
-        "transitions": []
-      }
-    ],
-    "ism_template": [
-      {
-        "index_patterns": ["rca-reports-*"],
-        "priority": 100
-      }
-    ]
-  }
-}'
-
 # Array to hold policy names and their definitions
 # Format: (ismPolicyName1 ismPolicyDefinition1 ismPolicyName2 ismPolicyDefinition2 ...)
-ismPolicies=("container-logs" "containerLogsIsmPolicy" "rca-reports" "rcaReportsIsmPolicy")
+ismPolicies=("container-logs" "containerLogsIsmPolicy")
 
 # Function to normalize JSON for comparison (removes whitespace differences)
 normalize_json() {

--- a/observability-tracing-opensearch/README.md
+++ b/observability-tracing-opensearch/README.md
@@ -52,14 +52,14 @@ helm upgrade --install opensearch-operator opensearch-operator/opensearch-operat
 
 ### Deploy Helm chart
 
-> **Note:** If you wish to use the Kubernetes operator-based OpenSearch version, add `--set openSearch.enabled=false --set openSearchCluster.enabled=true` flags when installing the Helm chart
+> **Note:** If you wish to use the Kubernetes operator-based OpenSearch version, add `--set openSearch.enabled=false --set openSearchCluster.enabled=true --set openSearchCluster.credentialsSecretName="opensearch-admin-credentials"` flags when installing the Helm chart. The admin password will be read from the credentials secret at install time.
 
 ```bash
 helm upgrade --install observability-tracing-opensearch \
   oci://ghcr.io/openchoreo/helm-charts/observability-tracing-opensearch \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.3.7 \
+  --version 0.3.8 \
   --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials"
 ```
 
@@ -70,7 +70,7 @@ helm upgrade --install observability-tracing-opensearch \
 >   oci://ghcr.io/openchoreo/helm-charts/observability-tracing-opensearch \
 >   --create-namespace \
 >   --namespace openchoreo-observability-plane \
->   --version 0.3.7 \
+>   --version 0.3.8 \
 >   --set openSearch.enabled=false \
 >   --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials"
 > ```

--- a/observability-tracing-opensearch/helm/Chart.yaml
+++ b/observability-tracing-opensearch/helm/Chart.yaml
@@ -5,8 +5,8 @@ apiVersion: v2
 name: observability-tracing-opensearch
 description: A Helm chart for OpenChoreo Observability Tracing module with OpenTelemetry Collector and OpenSearch
 type: application
-version: 0.3.7
-appVersion: "0.3.7"
+version: 0.3.8
+appVersion: "0.3.8"
 keywords:
   - opensearch
   - observability

--- a/observability-tracing-opensearch/helm/templates/opensearch-cluster/secrets.yaml
+++ b/observability-tracing-opensearch/helm/templates/opensearch-cluster/secrets.yaml
@@ -2,9 +2,11 @@
 {{- if not .Values.openSearchCluster.credentialsSecretName }}
 {{- fail "openSearchCluster.credentialsSecretName is required when openSearchCluster is enabled. Create a Secret with 'username' and 'password' keys, then set openSearchCluster.credentialsSecretName." }}
 {{- end }}
-{{- if not .Values.openSearchCluster.adminPassword }}
-{{- fail "openSearchCluster.adminPassword is required when openSearchCluster is enabled. This password is used to generate the internal_users.yml security configuration." }}
+{{- $secret := lookup "v1" "Secret" .Release.Namespace .Values.openSearchCluster.credentialsSecretName }}
+{{- if not $secret }}
+{{- fail (printf "Secret '%s' not found in namespace '%s'. Create the Secret with 'username' and 'password' keys before installing this chart." .Values.openSearchCluster.credentialsSecretName .Release.Namespace) }}
 {{- end }}
+{{- $password := index $secret.data "password" | required (printf "Secret '%s' in namespace '%s' is missing the 'password' key." .Values.openSearchCluster.credentialsSecretName .Release.Namespace) | b64dec }}
 ---
 apiVersion: v1
 kind: Secret
@@ -13,5 +15,5 @@ metadata:
   namespace: {{ .Release.Namespace }}
 type: Opaque
 data:
-  internal_users.yml: {{- (printf .Values.openSearchCluster.internalUsers (.Values.openSearchCluster.adminPassword | bcrypt)) | b64enc | nindent 4 }}
+  internal_users.yml: {{- (printf .Values.openSearchCluster.internalUsers ($password | bcrypt)) | b64enc | nindent 4 }}
 {{- end }}

--- a/observability-tracing-opensearch/helm/values.yaml
+++ b/observability-tracing-opensearch/helm/values.yaml
@@ -112,8 +112,6 @@ openSearchCluster:
 
   credentialsSecretName: ""
 
-  adminPassword: ""
-
   internalUsers: |
     # This is the internal user database
     # The hash value is a bcrypt hash and can be generated with plugin/tools/hash.sh


### PR DESCRIPTION
## Summary
- Remove `openSearchCluster.adminPassword` Helm value from both logs and tracing modules; use Helm `lookup` to read the password from the existing credentials secret at install time
- Remove RCA report index templates and ISM policies from the logs OpenSearch setup script
- Bump chart versions: logs `0.3.9` → `0.3.10`, tracing `0.3.7` → `0.3.8`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation and deployment documentation with credentials secret configuration guidance

* **Chores**
  * Helm chart versions bumped (observability-logs-opensearch to 0.3.10, observability-tracing-opensearch to 0.3.8)
  * Credential handling now retrieves OpenSearch admin passwords from external Kubernetes Secrets instead of direct chart configuration
  * Removed RCA reports index templates and automated setup lifecycle management from OpenSearch deployments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->