### PR TITLE
fix: add retry logic to OpenSearch setup scripts to handle non-JSON responses

### DIFF
--- a/observability-logs-opensearch/README.md
+++ b/observability-logs-opensearch/README.md
@@ -59,7 +59,7 @@ helm upgrade --install observability-logs-opensearch \
   oci://ghcr.io/openchoreo/helm-charts/observability-logs-opensearch \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.3.10 \
+  --version 0.3.11 \
   --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials"
 ```
 
@@ -70,7 +70,7 @@ helm upgrade --install observability-logs-opensearch \
 >   oci://ghcr.io/openchoreo/helm-charts/observability-logs-opensearch \
 >   --create-namespace \
 >   --namespace openchoreo-observability-plane \
->   --version 0.3.10 \
+>   --version 0.3.11 \
 >   --set openSearch.enabled=false \
 >   --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials"
 > ```
@@ -87,7 +87,7 @@ helm upgrade observability-logs-opensearch \
   oci://ghcr.io/openchoreo/helm-charts/observability-logs-opensearch \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.3.10 \
+  --version 0.3.11 \
   --reuse-values \
   --set fluent-bit.enabled=true
 ```
@@ -102,7 +102,7 @@ helm upgrade --install observability-logs-opensearch \
   oci://ghcr.io/openchoreo/helm-charts/observability-logs-opensearch \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.3.10 \
+  --version 0.3.11 \
   --set openSearch.enabled=false \
   --set openSearchCluster.enabled=false \
   --set openSearchSetup.enabled=false \

--- a/observability-logs-opensearch/helm/Chart.yaml
+++ b/observability-logs-opensearch/helm/Chart.yaml
@@ -5,8 +5,8 @@ apiVersion: v2
 name: observability-logs-opensearch
 description: A Helm chart for OpenChoreo Observability Logs module with Fluent Bit and OpenSearch
 type: application
-version: 0.3.10
-appVersion: "0.3.10"
+version: 0.3.11
+appVersion: "0.3.11"
 keywords:
   - opensearch
   - observability

--- a/observability-logs-opensearch/init/setup-opensearch.sh
+++ b/observability-logs-opensearch/init/setup-opensearch.sh
@@ -31,11 +31,14 @@ while [ $attempt -le $max_attempts ]; do
     if [ $curlExitCode -ne 0 ]; then
         echo "curl failed with exit code $curlExitCode (attempt $attempt/$max_attempts)"
     else
-        echo $clusterHealth | jq
-        clusterStatus=$(echo "$clusterHealth" | jq --raw-output '.status')
-        if [[ "$clusterStatus" == "green" || "$clusterStatus" == "yellow" ]]; then
-            echo -e "OpenSearch cluster ready. Continuing with setup...\n"
-            break
+        if echo "$clusterHealth" | jq . 2>/dev/null; then
+            clusterStatus=$(echo "$clusterHealth" | jq --raw-output '.status')
+            if [[ "$clusterStatus" == "green" || "$clusterStatus" == "yellow" ]]; then
+                echo -e "OpenSearch cluster ready. Continuing with setup...\n"
+                break
+            fi
+        else
+            echo "Received an invalid response. OpenSearch might still be starting up. (attempt $attempt/$max_attempts)"
         fi
     fi
 

--- a/observability-tracing-opensearch/README.md
+++ b/observability-tracing-opensearch/README.md
@@ -69,7 +69,7 @@ helm upgrade --install observability-tracing-opensearch \
   oci://ghcr.io/openchoreo/helm-charts/observability-tracing-opensearch \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.3.9 \
+  --version 0.3.10 \
   --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials"
 ```
 
@@ -80,7 +80,7 @@ helm upgrade --install observability-tracing-opensearch \
 >   oci://ghcr.io/openchoreo/helm-charts/observability-tracing-opensearch \
 >   --create-namespace \
 >   --namespace openchoreo-observability-plane \
->   --version 0.3.9 \
+>   --version 0.3.10 \
 >   --set openSearch.enabled=false \
 >   --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials"
 > ```
@@ -101,7 +101,7 @@ helm upgrade --install observability-tracing-opensearch \
   oci://ghcr.io/openchoreo/helm-charts/observability-tracing-opensearch \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.3.9 \
+  --version 0.3.10 \
   --set global.installationMode="multiClusterReceiver" \
   --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials"
 ```
@@ -118,7 +118,7 @@ helm upgrade --install observability-tracing-opensearch \
   oci://ghcr.io/openchoreo/helm-charts/observability-tracing-opensearch \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.3.9 \
+  --version 0.3.10 \
   --set global.installationMode="multiClusterExporter" \
   --set openSearch.enabled=false \
   --set openSearchCluster.enabled=false \

--- a/observability-tracing-opensearch/helm/Chart.yaml
+++ b/observability-tracing-opensearch/helm/Chart.yaml
@@ -5,8 +5,8 @@ apiVersion: v2
 name: observability-tracing-opensearch
 description: A Helm chart for OpenChoreo Observability Tracing module with OpenTelemetry Collector and OpenSearch
 type: application
-version: 0.3.9
-appVersion: "0.3.9"
+version: 0.3.10
+appVersion: "0.3.10"
 keywords:
   - opensearch
   - observability

--- a/observability-tracing-opensearch/init/setup-opensearch.sh
+++ b/observability-tracing-opensearch/init/setup-opensearch.sh
@@ -16,17 +16,29 @@ attempt=1
 max_attempts=30
 
 while [ $attempt -le $max_attempts ]; do
+    set +e
     clusterHealth=$(curl --header "Authorization: Basic $authnToken" \
                          --insecure \
                          --location "$openSearchHost/_cluster/health" \
                          --show-error \
                          --silent)
-    echo $clusterHealth | jq
-    clusterStatus=$(echo "$clusterHealth" | jq --raw-output '.status')
-    if [[ "$clusterStatus" == "green" || "$clusterStatus" == "yellow" ]]; then
-        echo -e "OpenSearch cluster ready. Continuing with setup...\n"
-        break
+    curlExitCode=$?
+    set -e
+
+    if [ $curlExitCode -ne 0 ]; then
+        echo "curl failed with exit code $curlExitCode (attempt $attempt/$max_attempts)"
+    else
+        if echo "$clusterHealth" | jq . 2>/dev/null; then
+            clusterStatus=$(echo "$clusterHealth" | jq --raw-output '.status')
+            if [[ "$clusterStatus" == "green" || "$clusterStatus" == "yellow" ]]; then
+                echo -e "OpenSearch cluster ready. Continuing with setup...\n"
+                break
+            fi
+        else
+            echo "Received an invalid response. OpenSearch might still be starting up. (attempt $attempt/$max_attempts)"
+        fi
     fi
+
     echo "Waiting for OpenSearch cluster to become ready... (attempt $attempt/$max_attempts)"
 
     if [ $attempt -eq $max_attempts ]; then


### PR DESCRIPTION
## Purpose
https://github.com/openchoreo/openchoreo/issues/2887
The OpenSearch init scripts in observability-logs-opensearch and observability-tracing-opensearch exit prematurely when OpenSearch is still starting up. The health check endpoint returns a non-JSON response during startup, causing jq parsing  to fail with a non-zero exit code. Due to set -euo pipefail, this immediately terminates the script, bypassing the retry logic entirely.

## Goals
Ensure the init scripts gracefully handle non-JSON responses from the OpenSearch health check endpoint and continue retrying until OpenSearch is fully up or the maximum retry attempts are exhausted.

## Approach
- Wrap the jq parsing in a conditional check so that invalid JSON responses do not cause the script to exit.
- If the response is not valid JSON, log an informative message indicating that OpenSearch might still be starting up, and continue the retry loop.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated observability-logs-opensearch Helm chart to version 0.3.11
  * Updated observability-tracing-openobserve Helm chart to version 0.2.1

* **Bug Fixes**
  * Improved cluster health validation with JSON response parsing checks
  * Enhanced error handling and logging for cluster readiness checks in setup scripts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->