### PR TITLE
docs: update observability module installation guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # OpenChoreo Community Modules
 
-Community modules are pluggable integrations that extend [OpenChoreo](https://github.com/openchoreo/openchoreo) platform capabilities. They allow operators to customize and enhance areas such as API gateways, CI workflows, observability, and GitOps delivery — without being locked into a single tool stack.
+Community modules are pluggable integrations that extend [OpenChoreo](https://openchoreo.dev/) platform capabilities. They allow operators to customize and enhance areas such as API gateways, CI workflows, observability, and GitOps, without being locked into a single tool stack.
 
 ## Prerequisites
 
-- An installed and running [OpenChoreo](https://github.com/openchoreo/openchoreo) instance.
+- An installed and running [OpenChoreo](https://openchoreo.dev/) instance.
 
 ## Getting Started
 
 Browse the available modules in the [OpenChoreo Module Catalogue](https://openchoreo.dev/modules/) and follow the installation instructions for each module.
 
-For a deeper understanding of how modules work and how to add a new OpenChoreo module, see the [Modules Overview](https://openchoreo.dev/docs/next/operations/modules/overview/) documentation.
+For a deeper understanding of how modules work and how to add a new OpenChoreo module, see the [modules overview](https://openchoreo.dev/docs/operations/modules/overview/) documentation.

--- a/observability-logs-openobserve/README.md
+++ b/observability-logs-openobserve/README.md
@@ -4,24 +4,53 @@
 | ------------- |-----------|
 | Code coverage | [![Codecov](https://codecov.io/gh/openchoreo/community-modules/branch/main/graph/badge.svg?component=observability_logs_openobserve)](https://codecov.io/gh/openchoreo/community-modules) |
 
-This module collects container logs using Fluent Bit and stores them in [OpenObserve](https://openobserve.ai).
+This module collects container logs using [Fluent Bit](https://fluentbit.io) and stores them in [OpenObserve](https://openobserve.ai).
 
 ## Prerequisites
 
-- [OpenChoreo](https://github.com/openchoreo/openchoreo) must be installed with the **observability plane** enabled for this module to work. Deploy the `openchoreo-observability-plane` helm chart with the helm value `observer.logsAdapter.enabled="true"` to enable the observer to fetch data from this logs module.
+- [OpenChoreo](https://openchoreo.dev) must be installed with the **observability plane** enabled for this module to work. Deploy the `openchoreo-observability-plane` helm chart with the helm value `observer.logsAdapter.enabled="true"` to enable the observer to fetch data from this logs module.
 
 
 ## Installation
 
-Before installing, create Kubernetes Secrets with the OpenObserve admin credentials:
+### Pre-requisites
 
-> ⚠️ **Important:** Replace `YOUR_PASSWORD` with a strong, unique password.
+OpenObserve credentials are required to configure it during installation and to access it. OpenChoreo uses the External Secrets Operator to manage secrets. Add your OpenObserve credentials (`ZO_ROOT_USER_EMAIL` and `ZO_ROOT_USER_PASSWORD`) to a secret store and use an `ExternalSecret` resource to generate a Kubernetes secret named `openobserve-admin-credentials` from it.
+Refer to the [secret management guide](https://openchoreo.dev/docs/operations/secret-management/) for more details.
+
+For example, the commands below add the secrets to OpenBao and pull them from the `ClusterSecretStore` created earlier in the [OpenChoreo installation guide](https://openchoreo.dev/docs).
 
 ```bash
-kubectl create secret generic openobserve-admin-credentials \
-  --namespace openchoreo-observability-plane \
-  --from-literal=ZO_ROOT_USER_EMAIL='root@example.com' \
-  --from-literal=ZO_ROOT_USER_PASSWORD='YOUR_PASSWORD'
+kubectl exec -it -n openbao openbao-0 -- \
+    bao kv put secret/openobserve-admin-credentials \
+    ZO_ROOT_USER_EMAIL='YOUR_USERNAME' \
+    ZO_ROOT_USER_PASSWORD='YOUR_PASSWORD'
+```
+
+```bash
+kubectl apply -f - <<EOF
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: openobserve-admin-credentials
+  namespace: openchoreo-observability-plane
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: default
+  target:
+    name: openobserve-admin-credentials
+  data:
+    - secretKey: ZO_ROOT_USER_EMAIL
+      remoteRef:
+        key: openobserve-admin-credentials
+        property: ZO_ROOT_USER_EMAIL
+    - secretKey: ZO_ROOT_USER_PASSWORD
+      remoteRef:
+        key: openobserve-admin-credentials
+        property: ZO_ROOT_USER_PASSWORD
+EOF
 ```
 
 ## OpenObserve deployment modes

--- a/observability-logs-opensearch/README.md
+++ b/observability-logs-opensearch/README.md
@@ -1,16 +1,19 @@
 # Observability Logs Module for OpenSearch
 
-This module collects logs using Fluent Bit and stores them in OpenSearch.
+This module collects logs using [Fluent Bit](https://fluentbit.io) and stores them in [OpenSearch](https://opensearch.org).
 
 ## Prerequisites
 
-- [OpenChoreo](https://github.com/openchoreo/openchoreo) must be installed with the **observability plane** enabled for this module to work.
+- [OpenChoreo](https://openchoreo.dev) must be installed with the **observability plane** enabled for this module to work.
 
 ## Installation
 
 ### Pre-requisites
 
-1. OpenSearch setup scripts in this helm chart need admin credentials to connect to OpenSearch and configure it. The command below pulls values from the `ClusterSecretStore` created earlier in the [OpenChoreo installation guide](https://openchoreo.dev/docs)
+1. OpenSearch setup scripts in this helm chart need admin credentials to connect to OpenSearch and configure it. OpenChoreo uses the External Secrets Operator to manage secrets. Add your OpenSearch credentials (username and password) to a secret store and use an `ExternalSecret` resource to generate a Kubernetes secret from it.
+Refer to the [secret management guide](https://openchoreo.dev/docs/operations/secret-management/) for more details.
+
+For example, the command below pulls values from the `ClusterSecretStore` created earlier in the [OpenChoreo installation guide](https://openchoreo.dev/docs).
 
 ```bash
 kubectl apply -f - <<EOF

--- a/observability-metrics-prometheus/README.md
+++ b/observability-metrics-prometheus/README.md
@@ -4,11 +4,11 @@
 | ------------- |-----------|
 | Code coverage | [![Codecov](https://codecov.io/gh/openchoreo/community-modules/branch/main/graph/badge.svg?component=observability_metrics_prometheus)](https://codecov.io/gh/openchoreo/community-modules) |
 
-This module collects and stores metrics using Prometheus.
+This module collects and stores metrics using [Prometheus](https://prometheus.io).
 
 ## Prerequisites
 
-- [OpenChoreo](https://github.com/openchoreo/openchoreo) must be installed with the **observability plane** enabled for this module to work.
+- [OpenChoreo](https://openchoreo.dev) must be installed with the **observability plane** enabled for this module to work.
 
 ## Installation
 

--- a/observability-tracing-openobserve/README.md
+++ b/observability-tracing-openobserve/README.md
@@ -4,23 +4,52 @@
 | ------------- |-----------|
 | Code coverage | [![Codecov](https://codecov.io/gh/openchoreo/community-modules/branch/main/graph/badge.svg?component=observability_tracing_openobserve)](https://codecov.io/gh/openchoreo/community-modules) |
 
-This module collects distributed traces using OpenTelemetry collector and stores them in [OpenObserve](https://openobserve.ai).
+This module collects distributed traces using [OpenTelemetry collector](https://opentelemetry.io) and stores them in [OpenObserve](https://openobserve.ai).
 
 ## Prerequisites
 
-- [OpenChoreo](https://github.com/openchoreo/openchoreo) must be installed with the **observability plane** enabled for this module to work. Deploy the `openchoreo-observability-plane` helm chart with the helm value `observer.tracingAdapter.enabled="true"` to enable the observer to fetch data from this tracing module.
+- [OpenChoreo](https://openchoreo.dev) must be installed with the **observability plane** enabled for this module to work. Deploy the `openchoreo-observability-plane` helm chart with the helm value `observer.tracingAdapter.enabled="true"` to enable the observer to fetch data from this tracing module.
 
 ## Installation
 
-Before installing, create Kubernetes Secrets with the OpenObserve admin credentials:
+### Pre-requisites
 
-> ⚠️ **Important:** Replace `YOUR_PASSWORD` with a strong, unique password.
+1. OpenObserve credentials are required to configure it during installation and to access it. OpenChoreo uses the External Secrets Operator to manage secrets. Add your OpenObserve credentials (`ZO_ROOT_USER_EMAIL` and `ZO_ROOT_USER_PASSWORD`) to a secret store and use an `ExternalSecret` resource to generate a Kubernetes secret named `openobserve-admin-credentials` from it.
+Refer to the [secret management guide](https://openchoreo.dev/docs/operations/secret-management/) for more details.
+
+For example, the commands below add the secrets to OpenBao and pull them from the `ClusterSecretStore` created earlier in the [OpenChoreo installation guide](https://openchoreo.dev/docs).
 
 ```bash
-kubectl create secret generic openobserve-admin-credentials \
-  --namespace openchoreo-observability-plane \
-  --from-literal=ZO_ROOT_USER_EMAIL='root@example.com' \
-  --from-literal=ZO_ROOT_USER_PASSWORD='YOUR_PASSWORD'
+kubectl exec -it -n openbao openbao-0 -- \
+    bao kv put secret/openobserve-admin-credentials \
+    ZO_ROOT_USER_EMAIL='YOUR_USERNAME' \
+    ZO_ROOT_USER_PASSWORD='YOUR_PASSWORD'
+```
+
+```bash
+kubectl apply -f - <<EOF
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: openobserve-admin-credentials
+  namespace: openchoreo-observability-plane
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: default
+  target:
+    name: openobserve-admin-credentials
+  data:
+    - secretKey: ZO_ROOT_USER_EMAIL
+      remoteRef:
+        key: openobserve-admin-credentials
+        property: ZO_ROOT_USER_EMAIL
+    - secretKey: ZO_ROOT_USER_PASSWORD
+      remoteRef:
+        key: openobserve-admin-credentials
+        property: ZO_ROOT_USER_PASSWORD
+EOF
 ```
 
 ## OpenObserve deployment modes

--- a/observability-tracing-opensearch/README.md
+++ b/observability-tracing-opensearch/README.md
@@ -1,16 +1,19 @@
 # Observability Tracing Module for OpenSearch
 
-This module collects traces using OpenTelemetry Collector and stores them in OpenSearch.
+This module collects traces using [OpenTelemetry collector](https://opentelemetry.io) and stores them in [OpenSearch](https://opensearch.org).
 
 ## Prerequisites
 
-- [OpenChoreo](https://github.com/openchoreo/openchoreo) must be installed with the **observability plane** enabled for this module to work.
+- [OpenChoreo](https://openchoreo.dev) must be installed with the **observability plane** enabled for this module to work.
 
 ## Installation
 
 ### Pre-requisites
 
-1. OpenSearch setup scripts in this helm chart need admin credentials to connect to OpenSearch and configure it. The command below pulls values from the `ClusterSecretStore` created earlier in the [OpenChoreo installation guide](https://openchoreo.dev/docs)
+1. OpenSearch setup scripts in this helm chart need admin credentials to connect to OpenSearch and configure it. OpenChoreo uses the External Secrets Operator to manage secrets. Add your OpenSearch credentials (username and password) to a secret store and use an `ExternalSecret` resource to generate a Kubernetes secret from it.
+Refer to the [secret management guide](https://openchoreo.dev/docs/operations/secret-management/) for more details.
+
+For example, the command below pulls values from the `ClusterSecretStore` created earlier in the [OpenChoreo installation guide](https://openchoreo.dev/docs).
 
 ```bash
 kubectl apply -f - <<EOF


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat: add observability-logs-opensearch module
  fix: handle opensearch startup delay in init script
  docs: update observability-logs-opensearch module installation guide
  chore(deps): bump fluent-bit version in observability-logs-openobserve module

See: https://github.com/openchoreo/openchoreo/blob/main/docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
Update README files across observability modules to point to the official OpenChoreo website (openchoreo.dev) instead of the GitHub repository, add hyperlinks to third-party tool references, and replace the manual kubectl create secret instructions with the External Secrets Operator (ESO) approach used by OpenChoreo.

## Approach
- Replace all OpenChoreo links from github.com/openchoreo/openchoreo to openchoreo.dev and update documentation paths (e.g., remove /next/ from URLs).
- Add hyperlinks to plain-text references of Fluent Bit, OpenSearch, Prometheus, and OpenTelemetry.
- Replace inline kubectl create secret instructions in the OpenObserve module READMEs with the ESO-based secret management workflow - storing credentials in OpenBao and syncing them via ExternalSecret resources.
- Add references to the secret management guide in the OpenSearch module READMEs for consistency.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated OpenChoreo links to openchoreo.dev across READMEs.
  * Standardized installation guidance to use External Secrets Operator for credential management instead of inline secret creation.
  * Added example ExternalSecret usage and clarified secret-materialization workflow for observability modules.
  * Turned plain mentions of third-party tools into direct links (Prometheus, OpenSearch, OpenTelemetry, Fluent Bit).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->