### PR TITLE
docs: fix broken documentation URLs in module READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,4 @@ Community modules are pluggable integrations that extend [OpenChoreo](https://op
 
 Browse the available modules in the [OpenChoreo Module Catalogue](https://openchoreo.dev/modules/) and follow the installation instructions for each module.
 
-For a deeper understanding of how modules work and how to add a new OpenChoreo module, see the [modules overview](https://openchoreo.dev/docs/operations/modules/overview/) documentation.
+For a deeper understanding of how modules work and how to add a new OpenChoreo module, see the [modules overview](https://openchoreo.dev/docs/platform-engineer-guide/modules/overview/) documentation.

--- a/observability-logs-openobserve/README.md
+++ b/observability-logs-openobserve/README.md
@@ -16,7 +16,7 @@ This module collects container logs using [Fluent Bit](https://fluentbit.io) and
 ### Pre-requisites
 
 OpenObserve credentials are required to configure it during installation and to access it. OpenChoreo uses the External Secrets Operator to manage secrets. Add your OpenObserve credentials (`ZO_ROOT_USER_EMAIL` and `ZO_ROOT_USER_PASSWORD`) to a secret store and use an `ExternalSecret` resource to generate a Kubernetes secret named `openobserve-admin-credentials` from it.
-Refer to the [secret management guide](https://openchoreo.dev/docs/operations/secret-management/) for more details.
+Refer to the [secret management guide](https://openchoreo.dev/docs/platform-engineer-guide/secret-management/) for more details.
 
 For example, the commands below add the secrets to OpenBao and pull them from the `ClusterSecretStore` created earlier in the [OpenChoreo installation guide](https://openchoreo.dev/docs).
 

--- a/observability-logs-opensearch/README.md
+++ b/observability-logs-opensearch/README.md
@@ -11,7 +11,7 @@ This module collects logs using [Fluent Bit](https://fluentbit.io) and stores th
 ### Pre-requisites
 
 1. OpenSearch setup scripts in this helm chart need admin credentials to connect to OpenSearch and configure it. OpenChoreo uses the External Secrets Operator to manage secrets. Add your OpenSearch credentials (username and password) to a secret store and use an `ExternalSecret` resource to generate a Kubernetes secret from it.
-Refer to the [secret management guide](https://openchoreo.dev/docs/operations/secret-management/) for more details.
+Refer to the [secret management guide](https://openchoreo.dev/docs/platform-engineer-guide/secret-management/) for more details.
 
 For example, the command below pulls values from the `ClusterSecretStore` created earlier in the [OpenChoreo installation guide](https://openchoreo.dev/docs).
 

--- a/observability-tracing-openobserve/README.md
+++ b/observability-tracing-openobserve/README.md
@@ -15,7 +15,7 @@ This module collects distributed traces using [OpenTelemetry collector](https://
 ### Pre-requisites
 
 1. OpenObserve credentials are required to configure it during installation and to access it. OpenChoreo uses the External Secrets Operator to manage secrets. Add your OpenObserve credentials (`ZO_ROOT_USER_EMAIL` and `ZO_ROOT_USER_PASSWORD`) to a secret store and use an `ExternalSecret` resource to generate a Kubernetes secret named `openobserve-admin-credentials` from it.
-Refer to the [secret management guide](https://openchoreo.dev/docs/operations/secret-management/) for more details.
+Refer to the [secret management guide](https://openchoreo.dev/docs/platform-engineer-guide/secret-management/) for more details.
 
 For example, the commands below add the secrets to OpenBao and pull them from the `ClusterSecretStore` created earlier in the [OpenChoreo installation guide](https://openchoreo.dev/docs).
 

--- a/observability-tracing-opensearch/README.md
+++ b/observability-tracing-opensearch/README.md
@@ -11,7 +11,7 @@ This module collects traces using [OpenTelemetry collector](https://opentelemetr
 ### Pre-requisites
 
 1. OpenSearch setup scripts in this helm chart need admin credentials to connect to OpenSearch and configure it. OpenChoreo uses the External Secrets Operator to manage secrets. Add your OpenSearch credentials (username and password) to a secret store and use an `ExternalSecret` resource to generate a Kubernetes secret from it.
-Refer to the [secret management guide](https://openchoreo.dev/docs/operations/secret-management/) for more details.
+Refer to the [secret management guide](https://openchoreo.dev/docs/platform-engineer-guide/secret-management/) for more details.
 
 For example, the command below pulls values from the `ClusterSecretStore` created earlier in the [OpenChoreo installation guide](https://openchoreo.dev/docs).
 


### PR DESCRIPTION
## Purpose
Fix broken documentation URLs in module READMEs that reference old page paths.

## Approach
Updated 5 broken links across 5 README files:
- `operations/modules/overview/` → `platform-engineer-guide/modules/overview/` (1 file)
- `operations/secret-management/` → `platform-engineer-guide/secret-management/` (4 files)

## Related Issues
N/A

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [x] Samples updated (if applicable)

## Remarks
These links broke during the docs restructuring that renamed `operations/` to `platform-engineer-guide/`.