### PR TITLE
Adding OpenChoreo trace module for Moesif

### DIFF
--- a/observability-tracing-moesif/README.md
+++ b/observability-tracing-moesif/README.md
@@ -1,0 +1,109 @@
+# Observability Tracing Module for Moesif
+
+This module collects traces using [OpenTelemetry Collector](https://opentelemetry.io) and exports them to [Moesif](https://www.moesif.com).
+
+## Prerequisites
+
+- [OpenChoreo](https://github.com/openchoreo/openchoreo) must be installed with the **observability plane** enabled for this module to work.
+- A Moesif account and a **Collector Application ID** for each environment from [Moesif](https://www.moesif.com/).
+
+## Installation
+
+### Create a Kubernetes Secret
+
+Create a Kubernetes secret containing your Moesif Collector Application IDs, with one key per environment.
+
+> **Note:**
+> - Use the environment name as the key (e.g., `development`, `production`).
+> - For environment names that contain hyphens (e.g., `my-env`), replace hyphens with underscores in the secret key (e.g., `my_env`).
+
+```bash
+kubectl create secret generic moesif-tracing-secret \
+  --from-literal=development="YOUR_DEV_COLLECTOR_APP_ID" \
+  --from-literal=production="YOUR_PROD_COLLECTOR_APP_ID" \
+  --namespace openchoreo-observability-plane
+```
+
+### Configuration Options
+
+For easier configuration management, create a `moesif-tracing-values.yaml` file:
+
+```yaml
+# moesif-tracing-values.yaml
+
+moesif:
+  # List of environment names to collect traces from.
+  # These must match the openchoreo.dev/environment label on your resources.
+  environments:
+    - development
+    - production
+
+  # (Optional) Moesif API endpoint. Defaults to https://api.moesif.net
+  # endpoint: "https://api.moesif.net"
+
+opentelemetryCollectorCustomizations:
+  tailSampling:
+    enabled: false  # Enable tail-based sampling if needed
+```
+
+Then install with:
+
+```bash
+helm upgrade --install observability-tracing-moesif \
+  oci://ghcr.io/openchoreo/helm-charts/observability-tracing-moesif \
+  --create-namespace \
+  --namespace openchoreo-observability-plane \
+  --version 0.1.0 \
+  -f moesif-tracing-values.yaml
+```
+
+#### Configuration Parameters
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `moesif.environments` | List of environment names to collect traces from | `[development, production]` |
+| `moesif.endpoint` | (Optional) Moesif API endpoint URL | `https://api.moesif.net` |
+| `opentelemetryCollectorCustomizations.tailSampling.enabled` | Enable tail-based sampling | `false` |
+
+## How It Works
+
+This module deploys an **OpenTelemetry Collector** that:
+
+1. Receives OTLP traces (gRPC on port `4317`, HTTP on port `4318`) from instrumented workloads.
+2. Enriches spans with Kubernetes metadata (pod name, deployment, namespace, etc.) using the `k8sattributes` processor.
+3. Routes traces to the correct Moesif application based on the `openchoreo.dev/environment` resource attribute.
+4. Exports traces to Moesif using the Moesif Collector Application ID stored in the `moesif-tracing-secret` Kubernetes secret.
+
+## Troubleshooting
+
+### Check OpenTelemetry Collector logs
+
+```bash
+kubectl -n openchoreo-observability-plane logs -f deploy/moesif-tracing-collector
+```
+
+### Verify the secret exists
+
+```bash
+kubectl -n openchoreo-observability-plane get secret moesif-tracing-secret
+```
+
+### Check pod health
+
+```bash
+kubectl -n openchoreo-observability-plane get pods
+```
+
+## Uninstalling
+
+```bash
+helm uninstall observability-tracing-moesif \
+  --namespace openchoreo-observability-plane
+```
+
+To also remove the secret:
+
+```bash
+kubectl delete secret moesif-tracing-secret \
+  --namespace openchoreo-observability-plane
+```

--- a/observability-tracing-moesif/helm/.helmignore
+++ b/observability-tracing-moesif/helm/.helmignore
@@ -1,0 +1,26 @@
+# Copyright 2026 The OpenChoreo Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/observability-tracing-moesif/helm/Chart.lock
+++ b/observability-tracing-moesif/helm/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: opentelemetry-collector
+  repository: https://open-telemetry.github.io/opentelemetry-helm-charts
+  version: 0.140.0
+digest: sha256:95b44d32f6aa013cfb900bb0a34e42551bf87c4891cabba2cfc56b1898c13a3b
+generated: "2026-04-02T17:13:19.651043+05:30"

--- a/observability-tracing-moesif/helm/Chart.yaml
+++ b/observability-tracing-moesif/helm/Chart.yaml
@@ -1,0 +1,21 @@
+# Copyright 2026 The OpenChoreo Authors
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v2
+name: observability-tracing-moesif
+description: A Helm chart for OpenChoreo Moesif Tracing module
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+keywords:
+  - moesif
+  - observability
+  - tracing
+home: https://github.com/openchoreo/community-modules
+maintainers:
+  - name: Moesif Team
+dependencies:
+  - name: opentelemetry-collector
+    repository: https://open-telemetry.github.io/opentelemetry-helm-charts
+    version: 0.140.0
+    condition: opentelemetry-collector.enabled

--- a/observability-tracing-moesif/helm/templates/opentelemetry-collector/configMap.yaml
+++ b/observability-tracing-moesif/helm/templates/opentelemetry-collector/configMap.yaml
@@ -1,0 +1,104 @@
+# Copyright 2026 The OpenChoreo Authors
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: moesif-tracing-collector-config
+  namespace: {{ .Release.Namespace }}
+data:
+  relay: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:4317
+          http:
+            endpoint: 0.0.0.0:4318
+
+    exporters:
+      {{- if .Values.opentelemetryCollectorCustomizations.debug.enabled }}
+      debug:
+        verbosity: detailed
+      {{- end }}
+      {{- range .Values.moesif.environments }}
+      otlphttp/{{ . }}:
+        endpoint: {{ $.Values.moesif.endpoint | default "https://api.moesif.net" | quote }}
+        headers:
+          X-Moesif-Application-Id: ${env:{{ . | replace "-" "_" }}}
+      {{- end }}
+
+    connectors:
+      routing:
+        table:
+          {{- range .Values.moesif.environments }}
+          - context: resource
+            statement: route() where resource.attributes["openchoreo.dev/environment"] == {{ . | quote }}
+            pipelines: [ traces/{{ . }} ]
+          {{- end }}
+
+    extensions:
+      health_check:
+        endpoint: ${env:MY_POD_IP}:13133
+
+    processors:
+      k8sattributes:
+        auth_type: "serviceAccount"
+        passthrough: false
+
+        extract:
+          labels:
+            - tag_name: $$1
+              key_regex: (.*)
+              from: pod
+
+          metadata:
+            - k8s.pod.name
+            - k8s.pod.uid
+            - k8s.deployment.name
+            - k8s.namespace.name
+            - k8s.node.name
+      {{- if .Values.opentelemetryCollectorCustomizations.tailSampling.enabled }}
+      tail_sampling:
+        decision_wait: {{ .Values.opentelemetryCollectorCustomizations.tailSampling.decisionWait }}
+        num_traces: {{ .Values.opentelemetryCollectorCustomizations.tailSampling.numTraces }}
+        expected_new_traces_per_sec: {{ .Values.opentelemetryCollectorCustomizations.tailSampling.expectedNewTracesPerSec }}
+        decision_cache:
+          sampled_cache_size: {{ .Values.opentelemetryCollectorCustomizations.tailSampling.decisionCache.sampledCacheSize }}
+          non_sampled_cache_size: {{ .Values.opentelemetryCollectorCustomizations.tailSampling.decisionCache.nonSampledCacheSize }}
+        policies: [
+            {
+              name: rate_limiting,
+              type: rate_limiting,
+              rate_limiting: {spans_per_second: {{ .Values.opentelemetryCollectorCustomizations.tailSampling.spansPerSecond }} }
+            },
+        ]
+      {{- end }}
+
+    service:
+      extensions: [health_check]
+      pipelines:
+        traces/in:
+          receivers: [otlp]
+          {{- $processors := list }}
+          {{- $processors = append $processors "k8sattributes" }}
+          {{- if .Values.opentelemetryCollectorCustomizations.tailSampling.enabled }}
+          {{- $processors = append $processors "tail_sampling" }}
+          {{- end }}
+          {{- if $processors }}
+          processors: [{{ join ", " $processors }}]
+          {{- end }}
+          exporters: [ routing ]
+        {{- range .Values.moesif.environments }}
+        traces/{{ . }}:
+          receivers: [ routing ]
+          exporters: [ otlphttp/{{ . }}{{- if $.Values.opentelemetryCollectorCustomizations.debug.enabled }}, debug{{- end }} ]
+        {{- end }}
+      telemetry:
+        metrics:
+          readers:
+            - pull:
+                exporter:
+                  prometheus:
+                    host: '0.0.0.0'
+                    port: 8888

--- a/observability-tracing-moesif/helm/values.yaml
+++ b/observability-tracing-moesif/helm/values.yaml
@@ -1,0 +1,57 @@
+# Copyright 2026 The OpenChoreo Authors
+# SPDX-License-Identifier: Apache-2.0
+
+## -----------------------------------------------------------
+## Values for OpenTelemetry Collector configuration
+## -----------------------------------------------------------
+opentelemetry-collector:
+  enabled: true
+  fullnameOverride: "moesif-tracing-collector"
+
+  clusterRole:
+    create: true
+    rules:
+      - apiGroups: [""]
+        resources: ["pods"]
+        verbs: ["list", "watch"]
+      - apiGroups: ["apps"]
+        resources: ["replicasets"]
+        verbs: ["list", "watch"]
+
+  configMap:
+    create: false
+    existingName: "moesif-tracing-collector-config"
+
+  image:
+    repository: otel/opentelemetry-collector-contrib
+
+  mode: deployment
+
+  extraEnvsFrom:
+    - secretRef:
+        name: moesif-tracing-secret
+
+  resources:
+    limits:
+      cpu: 100m
+      memory: 200Mi
+    requests:
+      cpu: 50m
+      memory: 100Mi
+
+  service:
+    type: ClusterIP
+
+opentelemetryCollectorCustomizations:
+  debug:
+    enabled: false
+
+  tailSampling:
+    enabled: true
+    decisionWait: 10s
+    numTraces: 100
+    expectedNewTracesPerSec: 10
+    decisionCache:
+      sampledCacheSize: 10000
+      nonSampledCacheSize: 1000
+    spansPerSecond: 10

--- a/observability-tracing-moesif/module.yaml
+++ b/observability-tracing-moesif/module.yaml
@@ -1,0 +1,8 @@
+# Copyright 2026 The OpenChoreo Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Module manifest used by the CI workflow to discover Docker images to build.
+# Each entry defines the image name, build context, Dockerfile path, and the
+# corresponding field in helm/values.yaml to update with the published image URI.
+
+images: []


### PR DESCRIPTION
- Adding OpenChoreo trace module for Moesif

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced observability tracing module for Moesif integration via Helm chart (v0.1.0).
  * OpenTelemetry Collector configuration for trace collection, routing, and export to Moesif.
  * Kubernetes metadata enrichment and optional tail sampling capabilities.
  * Complete setup documentation and operational guidance included.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->