### PR TITLE
feat: add status.code field to tracing-opensearch module index template

### DIFF
--- a/observability-tracing-opensearch/README.md
+++ b/observability-tracing-opensearch/README.md
@@ -11,7 +11,7 @@ This module collects traces using [OpenTelemetry collector](https://opentelemetr
 ### Pre-requisites
 
 1. OpenSearch setup scripts in this helm chart need admin credentials to connect to OpenSearch and configure it. OpenChoreo uses the External Secrets Operator to manage secrets. Add your OpenSearch credentials (username and password) to a secret store and use an `ExternalSecret` resource to generate a Kubernetes secret from it.
-Refer to the [secret management guide](https://openchoreo.dev/docs/platform-engineer-guide/secret-management/) for more details.
+   Refer to the [secret management guide](https://openchoreo.dev/docs/platform-engineer-guide/secret-management/) for more details.
 
 For example, the command below pulls values from the `ClusterSecretStore` created earlier in the [OpenChoreo installation guide](https://openchoreo.dev/docs).
 
@@ -42,6 +42,7 @@ EOF
 ```
 
 2. If you wish to use the Kubernetes operator-based OpenSearch version included with this Helm chart, install the operator as follows
+
 ```bash
 helm repo add opensearch-operator https://opensearch-project.github.io/opensearch-k8s-operator/
 helm repo update
@@ -72,7 +73,7 @@ helm upgrade --install observability-tracing-opensearch \
   oci://ghcr.io/openchoreo/helm-charts/observability-tracing-opensearch \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.3.10 \
+  --version 0.3.11 \
   --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials"
 ```
 
@@ -83,7 +84,7 @@ helm upgrade --install observability-tracing-opensearch \
 >   oci://ghcr.io/openchoreo/helm-charts/observability-tracing-opensearch \
 >   --create-namespace \
 >   --namespace openchoreo-observability-plane \
->   --version 0.3.10 \
+>   --version 0.3.11 \
 >   --set openSearch.enabled=false \
 >   --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials"
 > ```
@@ -104,7 +105,7 @@ helm upgrade --install observability-tracing-opensearch \
   oci://ghcr.io/openchoreo/helm-charts/observability-tracing-opensearch \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.3.10 \
+  --version 0.3.11 \
   --set global.installationMode="multiClusterReceiver" \
   --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials"
 ```
@@ -121,7 +122,7 @@ helm upgrade --install observability-tracing-opensearch \
   oci://ghcr.io/openchoreo/helm-charts/observability-tracing-opensearch \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.3.10 \
+  --version 0.3.11 \
   --set global.installationMode="multiClusterExporter" \
   --set openSearch.enabled=false \
   --set openSearchCluster.enabled=false \

--- a/observability-tracing-opensearch/helm/Chart.yaml
+++ b/observability-tracing-opensearch/helm/Chart.yaml
@@ -5,8 +5,8 @@ apiVersion: v2
 name: observability-tracing-opensearch
 description: A Helm chart for OpenChoreo Observability Tracing module with OpenTelemetry Collector and OpenSearch
 type: application
-version: 0.3.10
-appVersion: "0.3.10"
+version: 0.3.11
+appVersion: "0.3.11"
 keywords:
   - opensearch
   - observability

--- a/observability-tracing-opensearch/init/setup-opensearch.sh
+++ b/observability-tracing-opensearch/init/setup-opensearch.sh
@@ -109,6 +109,9 @@ otelTracesIndexTemplate='
         },
         "traceId": {
           "type": "keyword"
+        },
+        "status.code": {
+          "type": "keyword"
         }
       }
     }
@@ -233,8 +236,8 @@ for ((i=0; i<${#ismPolicies[@]}; i+=2)); do
         # Extract and normalize policy definitions for comparison
         # Remove OpenSearch-generated metadata fields that change on every update or are auto-added
         existingPolicy=$(echo "$responseBody" | jq -c -S '
-            .policy | 
-            del(.policy_id, .last_updated_time, .schema_version, .error_notification) | 
+            .policy |
+            del(.policy_id, .last_updated_time, .schema_version, .error_notification) |
             del(.ism_template[]?.last_updated_time) |
             walk(if type == "object" then del(.retry) else . end)
         ')


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat: add observability-logs-opensearch module
  fix: handle opensearch startup delay in init script
  docs: update observability-logs-opensearch module installation guide
  chore(deps): bump fluent-bit version in observability-logs-openobserve module

See: https://github.com/openchoreo/openchoreo/blob/main/docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
This pull request updates the observability tracing module, primarily introducing a new field to OpenSearch trace indices and bumping the chart and app versions to reflect the change.

Version updates:

* Bumped `version` and `appVersion` in `Chart.yaml` from `0.3.10` to `0.3.11` to reflect the new changes.

OpenSearch schema improvements:

* Added a new `status.code` field of type `keyword` to the OpenSearch trace index template in `setup-opensearch.sh`, enabling storage and querying of trace status codes.

## Approach
> Summarize the solution and implementation details.

## Related Issues
https://github.com/openchoreo/openchoreo/issues/3067

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README formatting and installation examples to reflect latest Helm chart version 0.3.11.

* **Chores**
  * Bumped Helm chart version to 0.3.11.
  * Enhanced OpenSearch index template with additional trace status tracking capability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->