### PR TITLE
fix(tracing-openobserve): use correct parent_span_id field name

### DIFF
--- a/observability-tracing-openobserve/internal/handlers_test.go
+++ b/observability-tracing-openobserve/internal/handlers_test.go
@@ -446,7 +446,7 @@ func TestQueryTraces_Success(t *testing.T) {
 					"span_kind":                   "SERVER",
 					"start_time":                  json.Number(fmt.Sprintf("%d", startNs)),
 					"end_time":                    json.Number(fmt.Sprintf("%d", endNs)),
-					"reference_parent_span_id":    "",
+					"parent_span_id":    "",
 					"service_openchoreo_dev_namespace": "test-ns",
 				},
 				{
@@ -456,7 +456,7 @@ func TestQueryTraces_Success(t *testing.T) {
 					"span_kind":                "CLIENT",
 					"start_time":               json.Number(fmt.Sprintf("%d", startNs+1000)),
 					"end_time":                 json.Number(fmt.Sprintf("%d", endNs-1000)),
-					"reference_parent_span_id": "span-root",
+					"parent_span_id": "span-root",
 				},
 			},
 		}
@@ -504,7 +504,7 @@ func TestQuerySpansForTrace_Success(t *testing.T) {
 					"start_time":               json.Number(fmt.Sprintf("%d", startNs)),
 					"end_time":                 json.Number(fmt.Sprintf("%d", endNs)),
 					"duration":                 json.Number(fmt.Sprintf("%d", endNs-startNs)),
-					"reference_parent_span_id": "span-root",
+					"parent_span_id": "span-root",
 				},
 			},
 		}
@@ -552,7 +552,7 @@ func TestGetSpanDetailsForTrace_Success(t *testing.T) {
 					"start_time":               json.Number(fmt.Sprintf("%d", startNs)),
 					"end_time":                 json.Number(fmt.Sprintf("%d", endNs)),
 					"duration":                 json.Number(fmt.Sprintf("%d", endNs-startNs)),
-					"reference_parent_span_id": "span-root",
+					"parent_span_id": "span-root",
 					"http.method":              "GET",
 					"service.name":             "my-service",
 				},

--- a/observability-tracing-openobserve/internal/openobserve/client.go
+++ b/observability-tracing-openobserve/internal/openobserve/client.go
@@ -228,7 +228,7 @@ func (c *Client) GetTraces(ctx context.Context, params TracesQueryParams) (*Trac
 		}
 
 		// Identify root span: the span with no parent
-		parentSpanID, _ := hit["reference_parent_span_id"].(string)
+		parentSpanID, _ := hit["parent_span_id"].(string)
 		if parentSpanID == "" {
 			if v, ok := hit["span_id"].(string); ok {
 				agg.entry.RootSpanID = v
@@ -374,7 +374,7 @@ func parseSpanEntry(hit map[string]interface{}) SpanEntry {
 	if v, ok := hit["duration"].(json.Number); ok {
 		entry.DurationNs, _ = v.Int64()
 	}
-	if v, ok := hit["reference_parent_span_id"].(string); ok {
+	if v, ok := hit["parent_span_id"].(string); ok {
 		entry.ParentSpanID = v
 	}
 	entry.Status = determineSpanStatus(hit)
@@ -409,7 +409,6 @@ var internalFields = []string{
 	"end_time",
 	"duration",
 	"parent_span_id",
-	"reference_parent_span_id",
 	"trace_id",
 	"span_status",
 }
@@ -438,7 +437,7 @@ func parseSpanDetail(hit map[string]interface{}) SpanDetail {
 	if v, ok := hit["duration"].(json.Number); ok {
 		detail.DurationNs, _ = v.Int64()
 	}
-	if v, ok := hit["reference_parent_span_id"].(string); ok {
+	if v, ok := hit["parent_span_id"].(string); ok {
 		detail.ParentSpanID = v
 	}
 	detail.Status = determineSpanStatus(hit)

--- a/observability-tracing-openobserve/internal/openobserve/client_test.go
+++ b/observability-tracing-openobserve/internal/openobserve/client_test.go
@@ -114,7 +114,7 @@ func TestGetTraces(t *testing.T) {
 					"span_kind":                "SERVER",
 					"start_time":               json.Number(fmt.Sprintf("%d", startNs)),
 					"end_time":                 json.Number(fmt.Sprintf("%d", endNs)),
-					"reference_parent_span_id": "",
+					"parent_span_id": "",
 				},
 				{
 					"trace_id":                 "trace-1",
@@ -123,7 +123,7 @@ func TestGetTraces(t *testing.T) {
 					"span_kind":                "CLIENT",
 					"start_time":               json.Number(fmt.Sprintf("%d", startNs+1000)),
 					"end_time":                 json.Number(fmt.Sprintf("%d", endNs-1000)),
-					"reference_parent_span_id": "span-root",
+					"parent_span_id": "span-root",
 				},
 				{
 					"trace_id":                 "trace-2",
@@ -132,7 +132,7 @@ func TestGetTraces(t *testing.T) {
 					"span_kind":                "SERVER",
 					"start_time":               json.Number(fmt.Sprintf("%d", startNs+5000)),
 					"end_time":                 json.Number(fmt.Sprintf("%d", endNs+5000)),
-					"reference_parent_span_id": "",
+					"parent_span_id": "",
 				},
 			},
 		}
@@ -289,7 +289,7 @@ func TestGetSpans(t *testing.T) {
 					"start_time":               json.Number(fmt.Sprintf("%d", startNs)),
 					"end_time":                 json.Number(fmt.Sprintf("%d", endNs)),
 					"duration":                 json.Number(fmt.Sprintf("%d", endNs-startNs)),
-					"reference_parent_span_id": "",
+					"parent_span_id": "",
 				},
 				{
 					"span_id":                  "span-2",
@@ -298,7 +298,7 @@ func TestGetSpans(t *testing.T) {
 					"start_time":               json.Number(fmt.Sprintf("%d", startNs+100)),
 					"end_time":                 json.Number(fmt.Sprintf("%d", endNs-100)),
 					"duration":                 json.Number(fmt.Sprintf("%d", endNs-startNs-200)),
-					"reference_parent_span_id": "span-1",
+					"parent_span_id": "span-1",
 				},
 			},
 		}
@@ -382,7 +382,7 @@ func TestGetSpanDetail(t *testing.T) {
 					"start_time":               json.Number(fmt.Sprintf("%d", startNs)),
 					"end_time":                 json.Number(fmt.Sprintf("%d", endNs)),
 					"duration":                 json.Number(fmt.Sprintf("%d", endNs-startNs)),
-					"reference_parent_span_id": "span-root",
+					"parent_span_id": "span-root",
 					"http.method":              "GET",
 					"http.status_code":         "200",
 					"service.name":             "my-service",
@@ -481,7 +481,7 @@ func TestParseSpanEntry(t *testing.T) {
 		"start_time":               json.Number(fmt.Sprintf("%d", startNs)),
 		"end_time":                 json.Number(fmt.Sprintf("%d", endNs)),
 		"duration":                 json.Number(fmt.Sprintf("%d", endNs-startNs)),
-		"reference_parent_span_id": "span-root",
+		"parent_span_id": "span-root",
 	}
 
 	entry := parseSpanEntry(hit)
@@ -536,7 +536,7 @@ func TestParseSpanDetail(t *testing.T) {
 		"start_time":               json.Number(fmt.Sprintf("%d", startNs)),
 		"end_time":                 json.Number(fmt.Sprintf("%d", endNs)),
 		"duration":                 json.Number(fmt.Sprintf("%d", endNs-startNs)),
-		"reference_parent_span_id": "span-root",
+		"parent_span_id": "span-root",
 		"trace_id":                 "trace-1",
 		"_timestamp":               json.Number("1234567890"),
 		"http.method":              "GET",
@@ -769,7 +769,7 @@ func TestGetTraces_HasErrors(t *testing.T) {
 					"span_kind":                "SERVER",
 					"start_time":               json.Number(fmt.Sprintf("%d", startNs)),
 					"end_time":                 json.Number(fmt.Sprintf("%d", endNs)),
-					"reference_parent_span_id": "",
+					"parent_span_id": "",
 					"span_status":              "error",
 				},
 			},
@@ -952,7 +952,7 @@ func TestParseSpanDetail_NoExtraAttributes(t *testing.T) {
 		"start_time":               json.Number("1000"),
 		"end_time":                 json.Number("2000"),
 		"duration":                 json.Number("1000"),
-		"reference_parent_span_id": "",
+		"parent_span_id": "",
 		"trace_id":                 "trace-1",
 		"_timestamp":               json.Number("1234"),
 	}

--- a/observability-tracing-openobserve/internal/openobserve/queries.go
+++ b/observability-tracing-openobserve/internal/openobserve/queries.go
@@ -49,7 +49,7 @@ func generateTracesListQuery(params TracesQueryParams, stream string, logger *sl
 
 	sql := fmt.Sprintf(
 		"SELECT trace_id, span_id, operation_name, span_kind, "+
-			"start_time, end_time, reference_parent_span_id, span_status "+
+			"start_time, end_time, parent_span_id, span_status "+
 			"FROM %s",
 		safeStream,
 	)
@@ -106,7 +106,7 @@ func generateSpansListQuery(params TracesQueryParams, stream string, logger *slo
 
 	sql := fmt.Sprintf(
 		"SELECT span_id, operation_name, span_kind, start_time, end_time, "+
-			"end_time - start_time as duration, reference_parent_span_id, span_status "+
+			"end_time - start_time as duration, parent_span_id, span_status "+
 			"FROM %s WHERE %s",
 		safeStream, strings.Join(conditions, " AND "),
 	)


### PR DESCRIPTION
## Summary
- Replace `reference_parent_span_id` with `parent_span_id` in SQL queries and hit parsing
- OpenObserve OTLP ingestion stores parent span ID as `parent_span_id`, not `reference_parent_span_id`
- Fixes `Search field not found: reference_parent_span_id` errors when querying traces

## Changes
- `queries.go`: 2 SQL query updates (generateTracesListQuery, generateSpansListQuery)
- `client.go`: 3 hit-parsing updates + removed from internalFields
- `client_test.go`: Updated test fixtures
- `handlers_test.go`: Updated test fixtures

## Testing
- `go test ./...` passes
- Verified against live OpenObserve instance with OTLP trace data on GKE
- Built and deployed custom image (`ghcr.io/yehia2amer/observability-tracing-openobserve-adapter:fix-parent-span`) — tracing adapter logs clean after fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated span parent relationship tracking to correctly identify root and child spans in trace queries and span details.

* **Tests**
  * Updated test fixtures and assertions to reflect revised parent span field handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->