### PR TITLE
fix: default adapter tag in helm chart

### DIFF
--- a/observability-logs-openobserve/README.md
+++ b/observability-logs-openobserve/README.md
@@ -67,7 +67,7 @@ helm upgrade --install observability-logs-openobserve \
   oci://ghcr.io/openchoreo/helm-charts/observability-logs-openobserve \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.4.2
+  --version 0.4.3
 ```
 
 To switch to HA mode, disable the standalone chart and enable the distributed chart:
@@ -76,7 +76,7 @@ To switch to HA mode, disable the standalone chart and enable the distributed ch
 helm upgrade --install observability-logs-openobserve \
   oci://ghcr.io/openchoreo/helm-charts/observability-logs-openobserve \
   --namespace openchoreo-observability-plane \
-  --version 0.4.2 \
+  --version 0.4.3 \
   --reuse-values \
   --set openobserve-standalone.enabled=false \
   --set openobserve.enabled=true
@@ -95,7 +95,7 @@ to start collecting logs from the cluster and publish them to OpenObserve:
 helm upgrade observability-logs-openobserve \
   oci://ghcr.io/openchoreo/helm-charts/observability-logs-openobserve \
   --namespace openchoreo-observability-plane \
-  --version 0.4.2 \
+  --version 0.4.3 \
   --reuse-values \
   --set fluent-bit.enabled=true
 ```
@@ -110,7 +110,7 @@ helm upgrade --install observability-logs-openobserve \
   oci://ghcr.io/openchoreo/helm-charts/observability-logs-openobserve \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.4.2 \
+  --version 0.4.3 \
   --set fluent-bit.enabled=true \
   --set openobserve-standalone.enabled=false \
   --set openObserveSetup.enabled=false \

--- a/observability-logs-openobserve/helm/Chart.yaml
+++ b/observability-logs-openobserve/helm/Chart.yaml
@@ -5,8 +5,8 @@ apiVersion: v2
 name: observability-logs-openobserve
 description: A Helm chart for OpenChoreo Logs Module for OpenObserve
 type: application
-version: 0.4.2
-appVersion: "0.4.2"
+version: 0.4.3
+appVersion: "0.4.3"
 keywords:
   - openobserve
   - openchoreo

--- a/observability-logs-openobserve/helm/values.yaml
+++ b/observability-logs-openobserve/helm/values.yaml
@@ -127,7 +127,7 @@ adapter:
   observerUrl: "http://observer-internal.openchoreo-observability-plane:8081"
   image:
     repository: "ghcr.io/openchoreo/observability-logs-openobserve-adapter"
-    tag: "latest"
+    tag: "" # Defaults to Chart.AppVersion via the template
   resources:
     limits:
       cpu: 200m

--- a/observability-metrics-prometheus/helm/Chart.yaml
+++ b/observability-metrics-prometheus/helm/Chart.yaml
@@ -5,8 +5,8 @@ apiVersion: v2
 name: observability-metrics-prometheus
 description: A Helm chart for OpenChoreo Observability Metrics module based on Prometheus
 type: application
-version: 0.4.0
-appVersion: "0.4.0"
+version: 0.4.1
+appVersion: "0.4.1"
 keywords:
   - prometheus
   - observability

--- a/observability-metrics-prometheus/helm/values.yaml
+++ b/observability-metrics-prometheus/helm/values.yaml
@@ -153,7 +153,7 @@ kube-prometheus-stack:
 adapter:
   image:
     repository: "ghcr.io/openchoreo/observability-metrics-prometheus-adapter"
-    tag: "latest" # Replaced by CI with the published image tag
+    tag: "" # Defaults to Chart.AppVersion via the template
     pullPolicy: IfNotPresent
   resources:
     limits:


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat: add observability-logs-opensearch module
  fix: handle opensearch startup delay in init script
  docs: update observability-logs-opensearch module installation guide
  chore(deps): bump fluent-bit version in observability-logs-openobserve module

See: https://github.com/openchoreo/openchoreo/blob/main/docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
The adapter image tags in observability-* module Helm values were hardcoded to "latest", which bypasses the version pinning provided by Chart.AppVersion. This change ensures all adapter images default to the chart's app version

## Approach
Set .Values.adapter.tag to "" in observability-metrics-prometheus and observability-logs-openobserve.

## Related Issues
https://github.com/openchoreo/openchoreo/issues/3250

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
The README was not updated in the Prometheus module. This is intentional and it will be done with the OpenChoreo 1.1 release


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Released observability-logs chart v0.4.3 and observability-metrics chart v0.4.2
  * Adjusted chart defaults so adapter image tags fall back to the chart app version (aligning deployed images with chart versions)
* **Documentation**
  * Updated README examples to reference the new chart versions (0.4.3)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->