### PR TITLE
fix: expose adapter log level via helm chart

### DIFF
--- a/observability-metrics-prometheus/helm/Chart.yaml
+++ b/observability-metrics-prometheus/helm/Chart.yaml
@@ -5,8 +5,8 @@ apiVersion: v2
 name: observability-metrics-prometheus
 description: A Helm chart for OpenChoreo Observability Metrics module based on Prometheus
 type: application
-version: 0.4.1
-appVersion: "0.4.1"
+version: 0.4.2
+appVersion: "0.4.2"
 keywords:
   - prometheus
   - observability

--- a/observability-metrics-prometheus/helm/templates/adapter/configmap.yaml
+++ b/observability-metrics-prometheus/helm/templates/adapter/configmap.yaml
@@ -14,4 +14,5 @@ data:
   OBSERVER_INTERNAL_URL: "http://observer-internal.{{ .Release.Namespace }}:8081"
   PROMETHEUS_ADDRESS: "http://openchoreo-observability-prometheus.{{ .Release.Namespace }}:9091"
   SERVER_PORT: "9099"
+  LOG_LEVEL: "{{ .Values.adapter.logLevel | default "INFO" }}"
 {{- end }}

--- a/observability-metrics-prometheus/helm/values.yaml
+++ b/observability-metrics-prometheus/helm/values.yaml
@@ -155,6 +155,7 @@ adapter:
     repository: "ghcr.io/openchoreo/observability-metrics-prometheus-adapter"
     tag: "" # Defaults to Chart.AppVersion via the template
     pullPolicy: IfNotPresent
+  logLevel: "INFO" # Supports DEBUG, INFO, WARN, ERROR
   resources:
     limits:
       cpu: 100m


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat: add observability-logs-opensearch module
  fix: handle opensearch startup delay in init script
  docs: update observability-logs-opensearch module installation guide
  chore(deps): bump fluent-bit version in observability-logs-openobserve module

See: https://github.com/openchoreo/openchoreo/blob/main/docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
This pull request introduces a configurable log level for the Prometheus metrics adapter, allowing users to set the desired logging verbosity through Helm values. This makes it easier to adjust log output for debugging or production use.

Configuration improvements:

* Added a `logLevel` field to the `adapter` section in `values.yaml`, supporting options like DEBUG, INFO, WARN, and ERROR.
* Updated the `configmap.yaml` template to set the `LOG_LEVEL` environment variable for the adapter, defaulting to "INFO" if not specified.

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Adapter component now supports configurable log level settings. Users can customize logging verbosity through Helm configuration, with a default setting of INFO level.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->