### PR TITLE
feat: specify kube-state-metrics as job in prometheus queries and update startup log of configs

### DIFF
--- a/observability-metrics-prometheus/helm/Chart.yaml
+++ b/observability-metrics-prometheus/helm/Chart.yaml
@@ -5,8 +5,8 @@ apiVersion: v2
 name: observability-metrics-prometheus
 description: A Helm chart for OpenChoreo Observability Metrics module based on Prometheus
 type: application
-version: 0.4.2
-appVersion: "0.4.2"
+version: 0.4.3
+appVersion: "0.4.3"
 keywords:
   - prometheus
   - observability

--- a/observability-metrics-prometheus/internal/prometheus/alertrules.go
+++ b/observability-metrics-prometheus/internal/prometheus/alertrules.go
@@ -125,7 +125,7 @@ func buildCPUUsageAlertExpression(componentUID, projectUID, environmentUID, oper
 	rateWindow := ensureMinimumWindow(window, "2m")
 
 	return fmt.Sprintf(
-		`(sum(rate(container_cpu_usage_seconds_total{container!=""}[%s]) * on (pod) group_left(label_openchoreo_dev_component_uid,label_openchoreo_dev_project_uid,label_openchoreo_dev_environment_uid) kube_pod_labels{%s}) / sum(kube_pod_container_resource_limits{resource="cpu"} * on (pod) group_left(label_openchoreo_dev_component_uid,label_openchoreo_dev_project_uid,label_openchoreo_dev_environment_uid) kube_pod_labels{%s})) * 100 %s %v`,
+		`(sum(rate(container_cpu_usage_seconds_total{container!=""}[%s]) * on (pod) group_left(label_openchoreo_dev_component_uid,label_openchoreo_dev_project_uid,label_openchoreo_dev_environment_uid) kube_pod_labels{job="kube-state-metrics",%s}) / sum(kube_pod_container_resource_limits{resource="cpu",job="kube-state-metrics"} * on (pod) group_left(label_openchoreo_dev_component_uid,label_openchoreo_dev_project_uid,label_openchoreo_dev_environment_uid) kube_pod_labels{job="kube-state-metrics",%s})) * 100 %s %v`,
 		rateWindow, labelFilter, labelFilter, operator, threshold,
 	)
 }
@@ -137,7 +137,7 @@ func buildMemoryUsageAlertExpression(componentUID, projectUID, environmentUID, o
 	labelFilter := BuildComponentLabelFilter(componentUID, projectUID, environmentUID)
 
 	return fmt.Sprintf(
-		`(sum(container_memory_working_set_bytes{container!=""} * on (pod) group_left(label_openchoreo_dev_component_uid,label_openchoreo_dev_project_uid,label_openchoreo_dev_environment_uid) kube_pod_labels{%s}) / sum(kube_pod_container_resource_limits{resource="memory"} * on (pod) group_left(label_openchoreo_dev_component_uid,label_openchoreo_dev_project_uid,label_openchoreo_dev_environment_uid) kube_pod_labels{%s})) * 100 %s %v`,
+		`(sum(container_memory_working_set_bytes{container!=""} * on (pod) group_left(label_openchoreo_dev_component_uid,label_openchoreo_dev_project_uid,label_openchoreo_dev_environment_uid) kube_pod_labels{job="kube-state-metrics",%s}) / sum(kube_pod_container_resource_limits{resource="memory",job="kube-state-metrics"} * on (pod) group_left(label_openchoreo_dev_component_uid,label_openchoreo_dev_project_uid,label_openchoreo_dev_environment_uid) kube_pod_labels{job="kube-state-metrics",%s})) * 100 %s %v`,
 		labelFilter, labelFilter, operator, threshold,
 	)
 }

--- a/observability-metrics-prometheus/internal/prometheus/queries.go
+++ b/observability-metrics-prometheus/internal/prometheus/queries.go
@@ -108,19 +108,19 @@ func BuildComponentLabelFilter(componentUID, projectUID, environmentUID string) 
 // BuildCPUUsageQuery builds a PromQL query for CPU usage rate.
 func BuildCPUUsageQuery(labelFilter, sumByClause, groupLeftClause string) string {
 	return fmt.Sprintf(`sum by (%s) (
-    rate(container_cpu_usage_seconds_total{container!=""}[2m]) * on (pod, namespace) %s kube_pod_labels{%s} )`, sumByClause, groupLeftClause, labelFilter)
+    rate(container_cpu_usage_seconds_total{container!=""}[2m]) * on (pod, namespace) %s kube_pod_labels{job="kube-state-metrics",%s} )`, sumByClause, groupLeftClause, labelFilter)
 }
 
 // BuildCPURequestsQuery builds a PromQL query for CPU requests.
 func BuildCPURequestsQuery(labelFilter, sumByClause, groupLeftClause string) string {
 	return fmt.Sprintf(`sum by (%s) (
             (
-                kube_pod_container_resource_requests{resource="cpu"}
+                kube_pod_container_resource_requests{resource="cpu",job="kube-state-metrics"}
                 AND ON (pod, namespace)
                 (kube_pod_status_phase{phase="Running"} == 1)
             )
           * ON (pod, namespace) %s
-            kube_pod_labels{%s}
+            kube_pod_labels{job="kube-state-metrics",%s}
         )`, sumByClause, groupLeftClause, labelFilter)
 }
 
@@ -128,12 +128,12 @@ func BuildCPURequestsQuery(labelFilter, sumByClause, groupLeftClause string) str
 func BuildCPULimitsQuery(labelFilter, sumByClause, groupLeftClause string) string {
 	return fmt.Sprintf(`sum by (%s) (
             (
-                kube_pod_container_resource_limits{resource="cpu"}
+                kube_pod_container_resource_limits{resource="cpu",job="kube-state-metrics"}
                 AND ON (pod, namespace)
                 (kube_pod_status_phase{phase="Running"} == 1)
             )
           * ON (pod, namespace) %s
-            kube_pod_labels{%s}
+            kube_pod_labels{job="kube-state-metrics",%s}
         )`, sumByClause, groupLeftClause, labelFilter)
 }
 
@@ -142,7 +142,7 @@ func BuildMemoryUsageQuery(labelFilter, sumByClause, groupLeftClause string) str
 	return fmt.Sprintf(`sum by (%s) (
               container_memory_working_set_bytes{container!=""}
               * on (pod, namespace) %s
-                kube_pod_labels{%s}
+                kube_pod_labels{job="kube-state-metrics",%s}
             )`, sumByClause, groupLeftClause, labelFilter)
 }
 
@@ -150,12 +150,12 @@ func BuildMemoryUsageQuery(labelFilter, sumByClause, groupLeftClause string) str
 func BuildMemoryRequestsQuery(labelFilter, sumByClause, groupLeftClause string) string {
 	return fmt.Sprintf(`sum by (%s) (
             (
-                kube_pod_container_resource_requests{resource="memory"}
+                kube_pod_container_resource_requests{resource="memory",job="kube-state-metrics"}
                 AND ON (pod, namespace)
                 (kube_pod_status_phase{phase="Running"} == 1)
             )
           * ON (pod, namespace) %s
-            kube_pod_labels{%s}
+            kube_pod_labels{job="kube-state-metrics",%s}
         )`, sumByClause, groupLeftClause, labelFilter)
 }
 
@@ -163,12 +163,12 @@ func BuildMemoryRequestsQuery(labelFilter, sumByClause, groupLeftClause string) 
 func BuildMemoryLimitsQuery(labelFilter, sumByClause, groupLeftClause string) string {
 	return fmt.Sprintf(`sum by (%s) (
             (
-                kube_pod_container_resource_limits{resource="memory"}
+                kube_pod_container_resource_limits{resource="memory",job="kube-state-metrics"}
                 AND ON (pod, namespace)
                 (kube_pod_status_phase{phase="Running"} == 1)
             )
           * ON (pod, namespace) %s
-            kube_pod_labels{%s}
+            kube_pod_labels{job="kube-state-metrics",%s}
         )`, sumByClause, groupLeftClause, labelFilter)
 }
 
@@ -184,7 +184,7 @@ func BuildHTTPRequestCountQuery(labelFilter, sumByClause, groupLeftClause string
 	            * on(destination_pod, destination_namespace) %s
 	            label_replace(
 	                label_replace(
-	                    kube_pod_labels{%s},
+	                    kube_pod_labels{job="kube-state-metrics",%s},
 	                    "destination_pod",
 	                    "$1",
 	                    "pod",
@@ -209,7 +209,7 @@ func BuildSuccessfulHTTPRequestCountQuery(labelFilter, sumByClause, groupLeftCla
 	            * on(destination_pod, destination_namespace) %s
 	            label_replace(
 	                label_replace(
-	                    kube_pod_labels{%s},
+	                    kube_pod_labels{job="kube-state-metrics",%s},
 	                    "destination_pod",
 	                    "$1",
 	                    "pod",
@@ -234,7 +234,7 @@ func BuildUnsuccessfulHTTPRequestCountQuery(labelFilter, sumByClause, groupLeftC
 	            * on(destination_pod, destination_namespace) %s
 	            label_replace(
 	                label_replace(
-	                    kube_pod_labels{%s},
+	                    kube_pod_labels{job="kube-state-metrics",%s},
 	                    "destination_pod",
 	                    "$1",
 	                    "pod",
@@ -259,7 +259,7 @@ func BuildMeanHTTPRequestLatencyQuery(labelFilter, sumByClause, groupLeftClause 
 	                * on(destination_pod, destination_namespace) %s
 	                label_replace(
 	                    label_replace(
-	                        kube_pod_labels{%s},
+	                        kube_pod_labels{job="kube-state-metrics",%s},
 	                        "destination_pod",
 	                        "$1",
 	                        "pod",
@@ -277,7 +277,7 @@ func BuildMeanHTTPRequestLatencyQuery(labelFilter, sumByClause, groupLeftClause 
 	                * on(destination_pod, destination_namespace) %s
 	                label_replace(
 	                    label_replace(
-	                        kube_pod_labels{%s},
+	                        kube_pod_labels{job="kube-state-metrics",%s},
 	                        "destination_pod",
 	                        "$1",
 	                        "pod",
@@ -305,7 +305,7 @@ func Build50thPercentileHTTPRequestLatencyQuery(labelFilter, sumByClause, groupL
 	                * on(destination_pod, destination_namespace) %s
 	                label_replace(
 	                    label_replace(
-	                        kube_pod_labels{%s},
+	                        kube_pod_labels{job="kube-state-metrics",%s},
 	                        "destination_pod",
 	                        "$1",
 	                        "pod",
@@ -333,7 +333,7 @@ func Build90thPercentileHTTPRequestLatencyQuery(labelFilter, sumByClause, groupL
 	                * on(destination_pod, destination_namespace) %s
 	                label_replace(
 	                    label_replace(
-	                        kube_pod_labels{%s},
+	                        kube_pod_labels{job="kube-state-metrics",%s},
 	                        "destination_pod",
 	                        "$1",
 	                        "pod",
@@ -361,7 +361,7 @@ func Build99thPercentileHTTPRequestLatencyQuery(labelFilter, sumByClause, groupL
 	                * on(destination_pod, destination_namespace) %s
 	                label_replace(
 	                    label_replace(
-	                        kube_pod_labels{%s},
+	                        kube_pod_labels{job="kube-state-metrics",%s},
 	                        "destination_pod",
 	                        "$1",
 	                        "pod",

--- a/observability-metrics-prometheus/main.go
+++ b/observability-metrics-prometheus/main.go
@@ -32,10 +32,10 @@ func main() {
 	}))
 
 	logger.Info("Configurations loaded from environment variables successfully",
-		slog.String("Log Level", cfg.LogLevel.String()),
-		slog.String("Server Port", cfg.ServerPort),
-		slog.String("Prometheus Address", cfg.PrometheusAddress),
-		slog.String("Alert Rule Namespace", cfg.AlertRuleNamespace),
+		slog.String("LOG_LEVEL", cfg.LogLevel.String()),
+		slog.String("SERVER_PORT", cfg.ServerPort),
+		slog.String("PROMETHEUS_ADDRESS", cfg.PrometheusAddress),
+		slog.String("OBSERVABILITY_NAMESPACE", cfg.AlertRuleNamespace),
 	)
 
 	promClient, err := prometheus.NewClient(cfg.PrometheusAddress, logger)


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat: add observability-logs-opensearch module
  fix: handle opensearch startup delay in init script
  docs: update observability-logs-opensearch module installation guide
  chore(deps): bump fluent-bit version in observability-logs-openobserve module

See: https://github.com/openchoreo/openchoreo/blob/main/docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
- Duplicate kube_pod_labels metrics get scraped when other tools (e.g. OpenCost) are installed in the same Kubernetes cluster. This results in "many-to-many matching not allowed" errors in Prometheus queries.
- Update the startup log message to show the exact environment variables read by the metrics adapter

## Approach
- Added job="kube-state-metrics" filter to all kube_pod_labels queries in the adapter to exclusively use the kube-state-metrics source and avoid duplicate series. 
- Updated the log message to show the environment variable names

## Related Issues
https://github.com/openchoreo/openchoreo/issues/3323

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Version Update**
  * Helm chart version and appVersion updated to 0.4.3.

* **Improvements**
  * Prometheus queries and alerting refined with stricter label filtering for more accurate CPU, memory and HTTP metrics.

* **Chores**
  * Startup log field keys standardized to uppercase env-var style names for consistent observability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->