### PR TITLE
fix: fix Prometheus queries and tests for HTTP metrics with hubble

### DIFF
--- a/observability-metrics-prometheus/helm/Chart.yaml
+++ b/observability-metrics-prometheus/helm/Chart.yaml
@@ -5,8 +5,8 @@ apiVersion: v2
 name: observability-metrics-prometheus
 description: A Helm chart for OpenChoreo Observability Metrics module based on Prometheus
 type: application
-version: 0.4.3
-appVersion: "0.4.3"
+version: 0.4.4
+appVersion: "0.4.4"
 keywords:
   - prometheus
   - observability

--- a/observability-metrics-prometheus/internal/prometheus/client.go
+++ b/observability-metrics-prometheus/internal/prometheus/client.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"math"
 	"time"
 
 	"github.com/prometheus/client_golang/api"
@@ -178,6 +179,8 @@ func convertToTimeSeriesResponse(result model.Value) *TimeSeriesResponse {
 
 // ConvertTimeSeriesToTimeValuePoints converts a TimeSeries to TimeValuePoint slice
 // with ISO 8601 formatted timestamps and float64 values.
+// Non-finite values (+Inf, -Inf, NaN) returned by Prometheus (e.g. from histogram_quantile
+// with insufficient data) are skipped — JSON cannot represent them.
 func ConvertTimeSeriesToTimeValuePoints(ts TimeSeries) []TimeValuePoint {
 	points := make([]TimeValuePoint, 0, len(ts.Values))
 
@@ -188,6 +191,10 @@ func ConvertTimeSeriesToTimeValuePoints(ts TimeSeries) []TimeValuePoint {
 
 		var value float64
 		_, _ = fmt.Sscanf(dp.Value, "%f", &value)
+
+		if math.IsInf(value, 0) || math.IsNaN(value) {
+			continue
+		}
 
 		points = append(points, TimeValuePoint{
 			Time:  t.Format(time.RFC3339Nano),

--- a/observability-metrics-prometheus/internal/prometheus/client_test.go
+++ b/observability-metrics-prometheus/internal/prometheus/client_test.go
@@ -90,6 +90,44 @@ func TestConvertTimeSeriesToTimeValuePoints_InvalidValue(t *testing.T) {
 	}
 }
 
+func TestConvertTimeSeriesToTimeValuePoints_NonFiniteValues(t *testing.T) {
+	ts := TimeSeries{
+		Values: []DataPoint{
+			{Timestamp: 1700000000, Value: "1.5"},
+			{Timestamp: 1700000300, Value: "+Inf"},
+			{Timestamp: 1700000600, Value: "-Inf"},
+			{Timestamp: 1700000900, Value: "NaN"},
+			{Timestamp: 1700001200, Value: "2.5"},
+		},
+	}
+
+	points := ConvertTimeSeriesToTimeValuePoints(ts)
+	if len(points) != 2 {
+		t.Fatalf("expected 2 points (non-finite skipped), got %d", len(points))
+	}
+	if points[0].Value != 1.5 {
+		t.Errorf("expected value 1.5, got %f", points[0].Value)
+	}
+	if points[1].Value != 2.5 {
+		t.Errorf("expected value 2.5, got %f", points[1].Value)
+	}
+}
+
+func TestConvertTimeSeriesToTimeValuePoints_AllNonFinite(t *testing.T) {
+	ts := TimeSeries{
+		Values: []DataPoint{
+			{Timestamp: 1700000000, Value: "+Inf"},
+			{Timestamp: 1700000300, Value: "-Inf"},
+			{Timestamp: 1700000600, Value: "NaN"},
+		},
+	}
+
+	points := ConvertTimeSeriesToTimeValuePoints(ts)
+	if len(points) != 0 {
+		t.Fatalf("expected 0 points, got %d", len(points))
+	}
+}
+
 func TestConvertToTimeSeriesResponse_Vector(t *testing.T) {
 	// Create a mock model.Vector
 	vector := model.Vector{

--- a/observability-metrics-prometheus/internal/prometheus/queries.go
+++ b/observability-metrics-prometheus/internal/prometheus/queries.go
@@ -176,204 +176,99 @@ func BuildMemoryLimitsQuery(labelFilter, sumByClause, groupLeftClause string) st
 // HTTP Request Metrics Queries
 // ----------------------------
 
+// buildHubblePodMappingExpr returns a PromQL expression that exposes
+// kube_pod_labels (filtered by labelFilter) under Hubble's join keys
+// (destination_namespace, destination_pod).
+func buildHubblePodMappingExpr(labelFilter string) string {
+	return fmt.Sprintf(`label_replace(
+            label_replace(
+                kube_pod_labels{job="kube-state-metrics",%s},
+                "destination_namespace", "$1", "namespace", "(.*)"
+            ),
+            "destination_pod", "$1", "pod", "(.*)"
+        )`, labelFilter)
+}
+
+// buildHTTPRequestCountQueryWithStatus builds the request-count PromQL,
+// optionally filtered by an extra `status=~...` matcher.
+func buildHTTPRequestCountQueryWithStatus(labelFilter, sumByClause, groupLeftClause, statusMatcher string) string {
+	mapping := buildHubblePodMappingExpr(labelFilter)
+	return fmt.Sprintf(`
+    sum by (%s) (
+        rate(hubble_http_requests_total{reporter="server"%s}[2m])
+            * on(destination_namespace, destination_pod) %s
+            %s
+    )
+    >= 0
+`, sumByClause, statusMatcher, groupLeftClause, mapping)
+}
+
 // BuildHTTPRequestCountQuery builds a PromQL query for HTTP request count.
 func BuildHTTPRequestCountQuery(labelFilter, sumByClause, groupLeftClause string) string {
-	return fmt.Sprintf(`
-	    sum by (%s) (
-	        rate(hubble_http_requests_total{reporter="server"}[2m])
-	            * on(destination_namespace, destination_workload) %s
-	            label_replace(
-	                label_replace(
-	                    kube_pod_labels{job="kube-state-metrics",%s},
-	                    "destination_namespace",
-	                    "$1",
-	                    "namespace",
-	                    "(.*)"
-	                ),
-	                "destination_workload",
-	                "$1",
-	                "pod",
-	                "^(.*)-[^-]+-[^-]+$"
-	            )
-	    )
-	    >= 0
-	`, sumByClause, groupLeftClause, labelFilter)
+	return buildHTTPRequestCountQueryWithStatus(labelFilter, sumByClause, groupLeftClause, "")
 }
 
 // BuildSuccessfulHTTPRequestCountQuery builds a PromQL query for successful HTTP request count
 // (1xx, 2xx, 3xx).
 func BuildSuccessfulHTTPRequestCountQuery(labelFilter, sumByClause, groupLeftClause string) string {
-	return fmt.Sprintf(`
-	    sum by (%s) (
-	        rate(hubble_http_requests_total{reporter="server", status=~"^[123]..?$"}[2m])
-	            * on(destination_namespace, destination_workload) %s
-	            label_replace(
-	                label_replace(
-	                    kube_pod_labels{job="kube-state-metrics",%s},
-	                    "destination_namespace",
-	                    "$1",
-	                    "namespace",
-	                    "(.*)"
-	                ),
-	                "destination_workload",
-	                "$1",
-	                "pod",
-	                "^(.*)-[^-]+-[^-]+$"
-	            )
-	    )
-	    >= 0
-	`, sumByClause, groupLeftClause, labelFilter)
+	return buildHTTPRequestCountQueryWithStatus(labelFilter, sumByClause, groupLeftClause, `, status=~"^[123]..?$"`)
 }
 
 // BuildUnsuccessfulHTTPRequestCountQuery builds a PromQL query for unsuccessful HTTP request
 // count (4xx, 5xx).
 func BuildUnsuccessfulHTTPRequestCountQuery(labelFilter, sumByClause, groupLeftClause string) string {
-	return fmt.Sprintf(`
-	    sum by (%s) (
-	        rate(hubble_http_requests_total{reporter="server", status=~"^[45]..?$"}[2m])
-	            * on(destination_namespace, destination_workload) %s
-	            label_replace(
-	                label_replace(
-	                    kube_pod_labels{job="kube-state-metrics",%s},
-	                    "destination_namespace",
-	                    "$1",
-	                    "namespace",
-	                    "(.*)"
-	                ),
-	                "destination_workload",
-	                "$1",
-	                "pod",
-	                "^(.*)-[^-]+-[^-]+$"
-	            )
-	    )
-	    >= 0
-	`, sumByClause, groupLeftClause, labelFilter)
+	return buildHTTPRequestCountQueryWithStatus(labelFilter, sumByClause, groupLeftClause, `, status=~"^[45]..?$"`)
 }
 
 // BuildMeanHTTPRequestLatencyQuery builds a PromQL query for mean HTTP request latency.
 func BuildMeanHTTPRequestLatencyQuery(labelFilter, sumByClause, groupLeftClause string) string {
+	mapping := buildHubblePodMappingExpr(labelFilter)
 	return fmt.Sprintf(`
-	    (
-	        sum by (%s) (
-	            rate(hubble_http_request_duration_seconds_sum{reporter="server"}[2m])
-	                * on(destination_namespace, destination_workload) %s
-	                label_replace(
-	                    label_replace(
-	                        kube_pod_labels{job="kube-state-metrics",%s},
-	                        "destination_namespace",
-	                        "$1",
-	                        "namespace",
-	                        "(.*)"
-	                    ),
-	                    "destination_workload",
-	                    "$1",
-	                    "pod",
-	                    "^(.*)-[^-]+-[^-]+$"
-	                )
-	        )
-	        /
-	        sum by (%s) (
-	            rate(hubble_http_requests_total{reporter="server"}[2m])
-	                * on(destination_namespace, destination_workload) %s
-	                label_replace(
-	                    label_replace(
-	                        kube_pod_labels{job="kube-state-metrics",%s},
-	                        "destination_namespace",
-	                        "$1",
-	                        "namespace",
-	                        "(.*)"
-	                    ),
-	                    "destination_workload",
-	                    "$1",
-	                    "pod",
-	                    "^(.*)-[^-]+-[^-]+$"
-	                )
-	        )
-	    )
-	    >= 0
-	`, sumByClause, groupLeftClause, labelFilter, sumByClause, groupLeftClause, labelFilter)
+    (
+        sum by (%s) (
+            rate(hubble_http_request_duration_seconds_sum{reporter="server"}[2m])
+                * on(destination_namespace, destination_pod) %s
+                %s
+        )
+        /
+        sum by (%s) (
+            rate(hubble_http_requests_total{reporter="server"}[2m])
+                * on(destination_namespace, destination_pod) %s
+                %s
+        )
+    )
+    >= 0
+`, sumByClause, groupLeftClause, mapping, sumByClause, groupLeftClause, mapping)
+}
+
+// buildHTTPRequestLatencyPercentileQuery builds a histogram_quantile PromQL
+// expression for the given quantile (e.g. "0.5", "0.9", "0.99").
+func buildHTTPRequestLatencyPercentileQuery(quantile, labelFilter, sumByClause, groupLeftClause string) string {
+	mapping := buildHubblePodMappingExpr(labelFilter)
+	return fmt.Sprintf(`
+    histogram_quantile(
+        %s,
+        sum by (%s) (
+            rate(hubble_http_request_duration_seconds_bucket{reporter="server"}[2m])
+                * on(destination_namespace, destination_pod) %s
+                %s
+        )
+    )
+    >= 0
+`, quantile, BuildHistogramSumByClause(sumByClause), groupLeftClause, mapping)
 }
 
 // Build50thPercentileHTTPRequestLatencyQuery builds a PromQL query for 50th percentile HTTP request latency.
 func Build50thPercentileHTTPRequestLatencyQuery(labelFilter, sumByClause, groupLeftClause string) string {
-	histogramSumByClause := BuildHistogramSumByClause(sumByClause)
-	return fmt.Sprintf(`
-	    histogram_quantile(
-	        0.5,
-	        sum by (%s) (
-	            rate(hubble_http_request_duration_seconds_bucket{reporter="server"}[2m])
-	                * on(destination_namespace, destination_workload) %s
-	                label_replace(
-	                    label_replace(
-	                        kube_pod_labels{job="kube-state-metrics",%s},
-	                        "destination_namespace",
-	                        "$1",
-	                        "namespace",
-	                        "(.*)"
-	                    ),
-	                    "destination_workload",
-	                    "$1",
-	                    "pod",
-	                    "^(.*)-[^-]+-[^-]+$"
-	                )
-	        )
-	    )
-	    >= 0
-	`, histogramSumByClause, groupLeftClause, labelFilter)
+	return buildHTTPRequestLatencyPercentileQuery("0.5", labelFilter, sumByClause, groupLeftClause)
 }
 
 // Build90thPercentileHTTPRequestLatencyQuery builds a PromQL query for 90th percentile HTTP request latency.
 func Build90thPercentileHTTPRequestLatencyQuery(labelFilter, sumByClause, groupLeftClause string) string {
-	histogramSumByClause := BuildHistogramSumByClause(sumByClause)
-	return fmt.Sprintf(`
-	    histogram_quantile(
-	        0.9,
-	        sum by (%s) (
-	            rate(hubble_http_request_duration_seconds_bucket{reporter="server"}[2m])
-	                * on(destination_namespace, destination_workload) %s
-	                label_replace(
-	                    label_replace(
-	                        kube_pod_labels{job="kube-state-metrics",%s},
-	                        "destination_namespace",
-	                        "$1",
-	                        "namespace",
-	                        "(.*)"
-	                    ),
-	                    "destination_workload",
-	                    "$1",
-	                    "pod",
-	                    "^(.*)-[^-]+-[^-]+$"
-	                )
-	        )
-	    )
-	    >= 0
-	`, histogramSumByClause, groupLeftClause, labelFilter)
+	return buildHTTPRequestLatencyPercentileQuery("0.9", labelFilter, sumByClause, groupLeftClause)
 }
 
 // Build99thPercentileHTTPRequestLatencyQuery builds a PromQL query for 99th percentile HTTP request latency.
 func Build99thPercentileHTTPRequestLatencyQuery(labelFilter, sumByClause, groupLeftClause string) string {
-	histogramSumByClause := BuildHistogramSumByClause(sumByClause)
-	return fmt.Sprintf(`
-	    histogram_quantile(
-	        0.99,
-	        sum by (%s) (
-	            rate(hubble_http_request_duration_seconds_bucket{reporter="server"}[2m])
-	                * on(destination_namespace, destination_workload) %s
-	                label_replace(
-	                    label_replace(
-	                        kube_pod_labels{job="kube-state-metrics",%s},
-	                        "destination_namespace",
-	                        "$1",
-	                        "namespace",
-	                        "(.*)"
-	                    ),
-	                    "destination_workload",
-	                    "$1",
-	                    "pod",
-	                    "^(.*)-[^-]+-[^-]+$"
-	                )
-	        )
-	    )
-	    >= 0
-	`, histogramSumByClause, groupLeftClause, labelFilter)
+	return buildHTTPRequestLatencyPercentileQuery("0.99", labelFilter, sumByClause, groupLeftClause)
 }

--- a/observability-metrics-prometheus/internal/prometheus/queries.go
+++ b/observability-metrics-prometheus/internal/prometheus/queries.go
@@ -180,20 +180,20 @@ func BuildMemoryLimitsQuery(labelFilter, sumByClause, groupLeftClause string) st
 func BuildHTTPRequestCountQuery(labelFilter, sumByClause, groupLeftClause string) string {
 	return fmt.Sprintf(`
 	    sum by (%s) (
-	        rate(hubble_http_requests_total{reporter="client"}[2m])
-	            * on(destination_pod, destination_namespace) %s
+	        rate(hubble_http_requests_total{reporter="server"}[2m])
+	            * on(destination_namespace, destination_workload) %s
 	            label_replace(
 	                label_replace(
 	                    kube_pod_labels{job="kube-state-metrics",%s},
-	                    "destination_pod",
+	                    "destination_namespace",
 	                    "$1",
-	                    "pod",
+	                    "namespace",
 	                    "(.*)"
 	                ),
-	                "destination_namespace",
+	                "destination_workload",
 	                "$1",
-	                "namespace",
-	                "(.*)"
+	                "pod",
+	                "^(.*)-[^-]+-[^-]+$"
 	            )
 	    )
 	    >= 0
@@ -205,20 +205,20 @@ func BuildHTTPRequestCountQuery(labelFilter, sumByClause, groupLeftClause string
 func BuildSuccessfulHTTPRequestCountQuery(labelFilter, sumByClause, groupLeftClause string) string {
 	return fmt.Sprintf(`
 	    sum by (%s) (
-	        rate(hubble_http_requests_total{reporter="client", status=~"^[123]..?$"}[2m])
-	            * on(destination_pod, destination_namespace) %s
+	        rate(hubble_http_requests_total{reporter="server", status=~"^[123]..?$"}[2m])
+	            * on(destination_namespace, destination_workload) %s
 	            label_replace(
 	                label_replace(
 	                    kube_pod_labels{job="kube-state-metrics",%s},
-	                    "destination_pod",
+	                    "destination_namespace",
 	                    "$1",
-	                    "pod",
+	                    "namespace",
 	                    "(.*)"
 	                ),
-	                "destination_namespace",
+	                "destination_workload",
 	                "$1",
-	                "namespace",
-	                "(.*)"
+	                "pod",
+	                "^(.*)-[^-]+-[^-]+$"
 	            )
 	    )
 	    >= 0
@@ -230,20 +230,20 @@ func BuildSuccessfulHTTPRequestCountQuery(labelFilter, sumByClause, groupLeftCla
 func BuildUnsuccessfulHTTPRequestCountQuery(labelFilter, sumByClause, groupLeftClause string) string {
 	return fmt.Sprintf(`
 	    sum by (%s) (
-	        rate(hubble_http_requests_total{reporter="client", status=~"^[45]..?$"}[2m])
-	            * on(destination_pod, destination_namespace) %s
+	        rate(hubble_http_requests_total{reporter="server", status=~"^[45]..?$"}[2m])
+	            * on(destination_namespace, destination_workload) %s
 	            label_replace(
 	                label_replace(
 	                    kube_pod_labels{job="kube-state-metrics",%s},
-	                    "destination_pod",
+	                    "destination_namespace",
 	                    "$1",
-	                    "pod",
+	                    "namespace",
 	                    "(.*)"
 	                ),
-	                "destination_namespace",
+	                "destination_workload",
 	                "$1",
-	                "namespace",
-	                "(.*)"
+	                "pod",
+	                "^(.*)-[^-]+-[^-]+$"
 	            )
 	    )
 	    >= 0
@@ -255,38 +255,38 @@ func BuildMeanHTTPRequestLatencyQuery(labelFilter, sumByClause, groupLeftClause 
 	return fmt.Sprintf(`
 	    (
 	        sum by (%s) (
-	            rate(hubble_http_request_duration_seconds_sum{reporter="client"}[2m])
-	                * on(destination_pod, destination_namespace) %s
+	            rate(hubble_http_request_duration_seconds_sum{reporter="server"}[2m])
+	                * on(destination_namespace, destination_workload) %s
 	                label_replace(
 	                    label_replace(
 	                        kube_pod_labels{job="kube-state-metrics",%s},
-	                        "destination_pod",
+	                        "destination_namespace",
 	                        "$1",
-	                        "pod",
+	                        "namespace",
 	                        "(.*)"
 	                    ),
-	                    "destination_namespace",
+	                    "destination_workload",
 	                    "$1",
-	                    "namespace",
-	                    "(.*)"
+	                    "pod",
+	                    "^(.*)-[^-]+-[^-]+$"
 	                )
 	        )
 	        /
 	        sum by (%s) (
-	            rate(hubble_http_requests_total{reporter="client"}[2m])
-	                * on(destination_pod, destination_namespace) %s
+	            rate(hubble_http_requests_total{reporter="server"}[2m])
+	                * on(destination_namespace, destination_workload) %s
 	                label_replace(
 	                    label_replace(
 	                        kube_pod_labels{job="kube-state-metrics",%s},
-	                        "destination_pod",
+	                        "destination_namespace",
 	                        "$1",
-	                        "pod",
+	                        "namespace",
 	                        "(.*)"
 	                    ),
-	                    "destination_namespace",
+	                    "destination_workload",
 	                    "$1",
-	                    "namespace",
-	                    "(.*)"
+	                    "pod",
+	                    "^(.*)-[^-]+-[^-]+$"
 	                )
 	        )
 	    )
@@ -301,20 +301,20 @@ func Build50thPercentileHTTPRequestLatencyQuery(labelFilter, sumByClause, groupL
 	    histogram_quantile(
 	        0.5,
 	        sum by (%s) (
-	            rate(hubble_http_request_duration_seconds_bucket{reporter="client"}[2m])
-	                * on(destination_pod, destination_namespace) %s
+	            rate(hubble_http_request_duration_seconds_bucket{reporter="server"}[2m])
+	                * on(destination_namespace, destination_workload) %s
 	                label_replace(
 	                    label_replace(
 	                        kube_pod_labels{job="kube-state-metrics",%s},
-	                        "destination_pod",
+	                        "destination_namespace",
 	                        "$1",
-	                        "pod",
+	                        "namespace",
 	                        "(.*)"
 	                    ),
-	                    "destination_namespace",
+	                    "destination_workload",
 	                    "$1",
-	                    "namespace",
-	                    "(.*)"
+	                    "pod",
+	                    "^(.*)-[^-]+-[^-]+$"
 	                )
 	        )
 	    )
@@ -329,20 +329,20 @@ func Build90thPercentileHTTPRequestLatencyQuery(labelFilter, sumByClause, groupL
 	    histogram_quantile(
 	        0.9,
 	        sum by (%s) (
-	            rate(hubble_http_request_duration_seconds_bucket{reporter="client"}[2m])
-	                * on(destination_pod, destination_namespace) %s
+	            rate(hubble_http_request_duration_seconds_bucket{reporter="server"}[2m])
+	                * on(destination_namespace, destination_workload) %s
 	                label_replace(
 	                    label_replace(
 	                        kube_pod_labels{job="kube-state-metrics",%s},
-	                        "destination_pod",
+	                        "destination_namespace",
 	                        "$1",
-	                        "pod",
+	                        "namespace",
 	                        "(.*)"
 	                    ),
-	                    "destination_namespace",
+	                    "destination_workload",
 	                    "$1",
-	                    "namespace",
-	                    "(.*)"
+	                    "pod",
+	                    "^(.*)-[^-]+-[^-]+$"
 	                )
 	        )
 	    )
@@ -357,20 +357,20 @@ func Build99thPercentileHTTPRequestLatencyQuery(labelFilter, sumByClause, groupL
 	    histogram_quantile(
 	        0.99,
 	        sum by (%s) (
-	            rate(hubble_http_request_duration_seconds_bucket{reporter="client"}[2m])
-	                * on(destination_pod, destination_namespace) %s
+	            rate(hubble_http_request_duration_seconds_bucket{reporter="server"}[2m])
+	                * on(destination_namespace, destination_workload) %s
 	                label_replace(
 	                    label_replace(
 	                        kube_pod_labels{job="kube-state-metrics",%s},
-	                        "destination_pod",
+	                        "destination_namespace",
 	                        "$1",
-	                        "pod",
+	                        "namespace",
 	                        "(.*)"
 	                    ),
-	                    "destination_namespace",
+	                    "destination_workload",
 	                    "$1",
-	                    "namespace",
-	                    "(.*)"
+	                    "pod",
+	                    "^(.*)-[^-]+-[^-]+$"
 	                )
 	        )
 	    )

--- a/observability-metrics-prometheus/internal/prometheus/queries_test.go
+++ b/observability-metrics-prometheus/internal/prometheus/queries_test.go
@@ -233,21 +233,21 @@ func TestHTTPQueryBuilders(t *testing.T) {
 	groupLeftClause := "group_left (label_openchoreo_dev_component_uid)"
 
 	serverReporter := `reporter="server"`
-	workloadJoin := "destination_namespace, destination_workload"
-	workloadRegex := `^(.*)-[^-]+-[^-]+$`
+	podJoin := "destination_namespace, destination_pod"
+	kubePodLabels := "kube_pod_labels"
 
 	tests := []struct {
 		name     string
 		queryFn  func(string, string, string) string
 		contains []string
 	}{
-		{"HTTPRequestCount", BuildHTTPRequestCountQuery, []string{"hubble_http_requests_total", serverReporter, workloadJoin, workloadRegex, labelFilter}},
-		{"SuccessfulHTTPRequestCount", BuildSuccessfulHTTPRequestCountQuery, []string{"hubble_http_requests_total", serverReporter, `status=~"^[123]..?$"`, workloadJoin, workloadRegex, labelFilter}},
-		{"UnsuccessfulHTTPRequestCount", BuildUnsuccessfulHTTPRequestCountQuery, []string{"hubble_http_requests_total", serverReporter, `status=~"^[45]..?$"`, workloadJoin, workloadRegex, labelFilter}},
-		{"MeanHTTPRequestLatency", BuildMeanHTTPRequestLatencyQuery, []string{"hubble_http_request_duration_seconds_sum", serverReporter, workloadJoin, workloadRegex, labelFilter}},
-		{"P50Latency", Build50thPercentileHTTPRequestLatencyQuery, []string{"histogram_quantile", "0.5", serverReporter, workloadJoin, workloadRegex, labelFilter}},
-		{"P90Latency", Build90thPercentileHTTPRequestLatencyQuery, []string{"histogram_quantile", "0.9", serverReporter, workloadJoin, workloadRegex, labelFilter}},
-		{"P99Latency", Build99thPercentileHTTPRequestLatencyQuery, []string{"histogram_quantile", "0.99", serverReporter, workloadJoin, workloadRegex, labelFilter}},
+		{"HTTPRequestCount", BuildHTTPRequestCountQuery, []string{"hubble_http_requests_total", serverReporter, podJoin, kubePodLabels, labelFilter}},
+		{"SuccessfulHTTPRequestCount", BuildSuccessfulHTTPRequestCountQuery, []string{"hubble_http_requests_total", serverReporter, `status=~"^[123]..?$"`, podJoin, kubePodLabels, labelFilter}},
+		{"UnsuccessfulHTTPRequestCount", BuildUnsuccessfulHTTPRequestCountQuery, []string{"hubble_http_requests_total", serverReporter, `status=~"^[45]..?$"`, podJoin, kubePodLabels, labelFilter}},
+		{"MeanHTTPRequestLatency", BuildMeanHTTPRequestLatencyQuery, []string{"hubble_http_request_duration_seconds_sum", serverReporter, podJoin, kubePodLabels, labelFilter}},
+		{"P50Latency", Build50thPercentileHTTPRequestLatencyQuery, []string{"histogram_quantile", "0.5", serverReporter, podJoin, kubePodLabels, labelFilter}},
+		{"P90Latency", Build90thPercentileHTTPRequestLatencyQuery, []string{"histogram_quantile", "0.9", serverReporter, podJoin, kubePodLabels, labelFilter}},
+		{"P99Latency", Build99thPercentileHTTPRequestLatencyQuery, []string{"histogram_quantile", "0.99", serverReporter, podJoin, kubePodLabels, labelFilter}},
 	}
 
 	for _, tt := range tests {

--- a/observability-metrics-prometheus/internal/prometheus/queries_test.go
+++ b/observability-metrics-prometheus/internal/prometheus/queries_test.go
@@ -232,18 +232,22 @@ func TestHTTPQueryBuilders(t *testing.T) {
 	sumByClause := "label_openchoreo_dev_component_uid"
 	groupLeftClause := "group_left (label_openchoreo_dev_component_uid)"
 
+	serverReporter := `reporter="server"`
+	workloadJoin := "destination_namespace, destination_workload"
+	workloadRegex := `^(.*)-[^-]+-[^-]+$`
+
 	tests := []struct {
 		name     string
 		queryFn  func(string, string, string) string
 		contains []string
 	}{
-		{"HTTPRequestCount", BuildHTTPRequestCountQuery, []string{"hubble_http_requests_total", labelFilter}},
-		{"SuccessfulHTTPRequestCount", BuildSuccessfulHTTPRequestCountQuery, []string{"hubble_http_requests_total", `status=~"^[123]..?$"`, labelFilter}},
-		{"UnsuccessfulHTTPRequestCount", BuildUnsuccessfulHTTPRequestCountQuery, []string{"hubble_http_requests_total", `status=~"^[45]..?$"`, labelFilter}},
-		{"MeanHTTPRequestLatency", BuildMeanHTTPRequestLatencyQuery, []string{"hubble_http_request_duration_seconds_sum", labelFilter}},
-		{"P50Latency", Build50thPercentileHTTPRequestLatencyQuery, []string{"histogram_quantile", "0.5", labelFilter}},
-		{"P90Latency", Build90thPercentileHTTPRequestLatencyQuery, []string{"histogram_quantile", "0.9", labelFilter}},
-		{"P99Latency", Build99thPercentileHTTPRequestLatencyQuery, []string{"histogram_quantile", "0.99", labelFilter}},
+		{"HTTPRequestCount", BuildHTTPRequestCountQuery, []string{"hubble_http_requests_total", serverReporter, workloadJoin, workloadRegex, labelFilter}},
+		{"SuccessfulHTTPRequestCount", BuildSuccessfulHTTPRequestCountQuery, []string{"hubble_http_requests_total", serverReporter, `status=~"^[123]..?$"`, workloadJoin, workloadRegex, labelFilter}},
+		{"UnsuccessfulHTTPRequestCount", BuildUnsuccessfulHTTPRequestCountQuery, []string{"hubble_http_requests_total", serverReporter, `status=~"^[45]..?$"`, workloadJoin, workloadRegex, labelFilter}},
+		{"MeanHTTPRequestLatency", BuildMeanHTTPRequestLatencyQuery, []string{"hubble_http_request_duration_seconds_sum", serverReporter, workloadJoin, workloadRegex, labelFilter}},
+		{"P50Latency", Build50thPercentileHTTPRequestLatencyQuery, []string{"histogram_quantile", "0.5", serverReporter, workloadJoin, workloadRegex, labelFilter}},
+		{"P90Latency", Build90thPercentileHTTPRequestLatencyQuery, []string{"histogram_quantile", "0.9", serverReporter, workloadJoin, workloadRegex, labelFilter}},
+		{"P99Latency", Build99thPercentileHTTPRequestLatencyQuery, []string{"histogram_quantile", "0.99", serverReporter, workloadJoin, workloadRegex, labelFilter}},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat: add observability-logs-opensearch module
  fix: handle opensearch startup delay in init script
  docs: update observability-logs-opensearch module installation guide
  chore(deps): bump fluent-bit version in observability-logs-openobserve module

See: https://github.com/openchoreo/openchoreo/blob/main/docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
This pull request improves the robustness and accuracy of Prometheus HTTP metrics queries and their processing in the observability metrics module. The main changes include switching HTTP metrics queries to use the "server" reporter and more precise workload joins, as well as ensuring that non-finite values (such as NaN or Inf) are properly filtered out of time series responses. The tests have also been updated and extended to cover these changes.

**Prometheus HTTP metrics query improvements:**

* All HTTP request count and latency queries now use `reporter="server"` instead of `reporter="client"`, and join on `destination_namespace` and `destination_workload` instead of `destination_pod`, for more accurate aggregation by workload. The queries also use a new regex to extract the workload name from pod labels. [[1]](diffhunk://#diff-afedf6266088180e6e2e0dc930d44799617e4741170480fd498567508cc26672L183-R196) [[2]](diffhunk://#diff-afedf6266088180e6e2e0dc930d44799617e4741170480fd498567508cc26672L208-R221) [[3]](diffhunk://#diff-afedf6266088180e6e2e0dc930d44799617e4741170480fd498567508cc26672L233-R246) [[4]](diffhunk://#diff-afedf6266088180e6e2e0dc930d44799617e4741170480fd498567508cc26672L258-R289) [[5]](diffhunk://#diff-afedf6266088180e6e2e0dc930d44799617e4741170480fd498567508cc26672L304-R317) [[6]](diffhunk://#diff-afedf6266088180e6e2e0dc930d44799617e4741170480fd498567508cc26672L332-R345) [[7]](diffhunk://#diff-afedf6266088180e6e2e0dc930d44799617e4741170480fd498567508cc26672L360-R373)

* The corresponding unit tests in `queries_test.go` are updated to assert the presence of the new join fields and regex, ensuring the queries are constructed as expected.

**Time series data handling:**

* The `ConvertTimeSeriesToTimeValuePoints` function now skips non-finite values (`+Inf`, `-Inf`, `NaN`) when converting Prometheus data to JSON-friendly time series, preventing invalid JSON output. [[1]](diffhunk://#diff-62adde3e3f03e15d461ff9ac817cbc44e3c2f90ed11be6377ad8cc4244615042R10) [[2]](diffhunk://#diff-62adde3e3f03e15d461ff9ac817cbc44e3c2f90ed11be6377ad8cc4244615042R182-R183) [[3]](diffhunk://#diff-62adde3e3f03e15d461ff9ac817cbc44e3c2f90ed11be6377ad8cc4244615042R195-R198)

* New unit tests verify that non-finite values are correctly excluded from the output, including edge cases where all values are non-finite.

**Other:**

* Bumped the Helm chart version and `appVersion` to `0.4.4` to reflect these changes.

## Approach
> Summarize the solution and implementation details.

## Related Issues
https://github.com/openchoreo/openchoreo/issues/3293

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Skip non-finite metric values (Inf/NaN) when converting time-series so invalid points are not emitted.

* **Chores**
  * Bumped chart/app version to 0.4.4.
  * Switched HTTP metrics to use server-side reporting for improved accuracy.

* **Refactor**
  * Reworked label mapping and join logic for pod/namespace metrics.

* **Tests**
  * Added/updated tests for non-finite value handling and HTTP query generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->