### PR TITLE
feat: add agent-sandbox module for upstream controller installation

### DIFF
--- a/agent-sandbox/README.md
+++ b/agent-sandbox/README.md
@@ -2,11 +2,13 @@
 
 This module installs the [kubernetes-sigs/agent-sandbox](https://github.com/kubernetes-sigs/agent-sandbox) controller on the data plane, enabling kernel-level isolation for AI agent workloads deployed through OpenChoreo.
 
+> **Important:** This module must be installed on each data plane cluster where agent workloads will run. In a multi-cluster setup, install it on every data plane cluster separately.
+
 ## What it does
 
-- Installs the upstream `kubernetes-sigs/agent-sandbox` controller and CRDs via a Helm pre-install hook
+- Installs the upstream `kubernetes-sigs/agent-sandbox` controller and CRDs on the data plane cluster via a Helm pre-install hook
 - Grants the data plane `cluster-agent` service account permissions to manage `SandboxTemplate`, `SandboxClaim`, `SandboxWarmPool`, and `Sandbox` resources
-- The core OpenChoreo `agent` ClusterComponentType renders the sandbox resources; this module provides the upstream controller that fulfills them
+- The core OpenChoreo `agent` ClusterComponentType renders the sandbox resources; this module provides the upstream controller that fulfills them on the data plane
 
 ## Upstream CRDs installed
 
@@ -20,25 +22,39 @@ This module installs the [kubernetes-sigs/agent-sandbox](https://github.com/kube
 ## Prerequisites
 
 - OpenChoreo installed and running
-- `kubectl` configured to point at your cluster
+- `kubectl` configured to point at the **data plane cluster**
 - `helm` v3.16+
 
 ## Installation
+
+Install on each data plane cluster:
 
 ```bash
 helm repo add openchoreo-community https://openchoreo.github.io/community-modules
 helm repo update openchoreo-community
 
+# Point kubectl at your data plane cluster, then:
 helm upgrade --install agent-sandbox \
   openchoreo-community/agent-sandbox \
-  --namespace openchoreo-control-plane \
+  --namespace openchoreo-data-plane \
+  --wait --timeout 10m
+```
+
+For multi-cluster setups, repeat for each data plane cluster:
+```bash
+# Switch context to each data plane cluster
+kubectl config use-context <data-plane-cluster>
+
+helm upgrade --install agent-sandbox \
+  openchoreo-community/agent-sandbox \
+  --namespace openchoreo-data-plane \
   --wait --timeout 10m
 ```
 
 ## Verify
 
 ```bash
-# Upstream controller running
+# Upstream controller running on the data plane
 kubectl get pods -n agent-sandbox-system
 
 # CRDs registered
@@ -52,8 +68,8 @@ kubectl get clusterrole openchoreo-agent-sandbox-access
 
 | Value | Default | Description |
 |---|---|---|
-| `namespace` | `openchoreo-control-plane` | Control plane namespace |
-| `dataPlaneNamespace` | `openchoreo-data-plane` | Data plane namespace |
+| `namespace` | `openchoreo-control-plane` | Namespace for the installer Job |
+| `dataPlaneNamespace` | `openchoreo-data-plane` | Data plane namespace (for RBAC binding) |
 | `dataPlaneServiceAccount` | `cluster-agent-dataplane` | Data plane SA for RBAC |
 | `upstream.install` | `true` | Install upstream controller via pre-install Job |
 | `upstream.version` | `v0.4.3` | Upstream release version |
@@ -62,7 +78,7 @@ kubectl get clusterrole openchoreo-agent-sandbox-access
 ## Uninstall
 
 ```bash
-helm uninstall agent-sandbox -n openchoreo-control-plane
+helm uninstall agent-sandbox -n openchoreo-data-plane
 ```
 
 Note: Helm does not delete CRDs on uninstall. To fully remove:

--- a/agent-sandbox/README.md
+++ b/agent-sandbox/README.md
@@ -1,0 +1,74 @@
+# Agent Sandbox Module for OpenChoreo
+
+This module installs the [kubernetes-sigs/agent-sandbox](https://github.com/kubernetes-sigs/agent-sandbox) controller on the data plane, enabling kernel-level isolation for AI agent workloads deployed through OpenChoreo.
+
+## What it does
+
+- Installs the upstream `kubernetes-sigs/agent-sandbox` controller and CRDs via a Helm pre-install hook
+- Grants the data plane `cluster-agent` service account permissions to manage `SandboxTemplate`, `SandboxClaim`, `SandboxWarmPool`, and `Sandbox` resources
+- The core OpenChoreo `agent` ClusterComponentType renders the sandbox resources; this module provides the upstream controller that fulfills them
+
+## Upstream CRDs installed
+
+| CRD | API Group | Description |
+|---|---|---|
+| `Sandbox` | `agents.x-k8s.io` | Stateful pod with stable identity |
+| `SandboxTemplate` | `extensions.agents.x-k8s.io` | Pod spec + isolation config |
+| `SandboxClaim` | `extensions.agents.x-k8s.io` | Claims a sandbox from a template/pool |
+| `SandboxWarmPool` | `extensions.agents.x-k8s.io` | Pre-warmed sandbox pool |
+
+## Prerequisites
+
+- OpenChoreo installed and running
+- `kubectl` configured to point at your cluster
+- `helm` v3.16+
+
+## Installation
+
+```bash
+helm repo add openchoreo-community https://openchoreo.github.io/community-modules
+helm repo update openchoreo-community
+
+helm upgrade --install agent-sandbox \
+  openchoreo-community/agent-sandbox \
+  --namespace openchoreo-control-plane \
+  --wait --timeout 10m
+```
+
+## Verify
+
+```bash
+# Upstream controller running
+kubectl get pods -n agent-sandbox-system
+
+# CRDs registered
+kubectl get crd | grep agents.x-k8s.io
+
+# RBAC applied
+kubectl get clusterrole openchoreo-agent-sandbox-access
+```
+
+## Configuration
+
+| Value | Default | Description |
+|---|---|---|
+| `namespace` | `openchoreo-control-plane` | Control plane namespace |
+| `dataPlaneNamespace` | `openchoreo-data-plane` | Data plane namespace |
+| `dataPlaneServiceAccount` | `cluster-agent-dataplane` | Data plane SA for RBAC |
+| `upstream.install` | `true` | Install upstream controller via pre-install Job |
+| `upstream.version` | `v0.4.3` | Upstream release version |
+| `upstream.manifestURL` | `""` | Override manifest URL (auto-built from version if empty) |
+
+## Uninstall
+
+```bash
+helm uninstall agent-sandbox -n openchoreo-control-plane
+```
+
+Note: Helm does not delete CRDs on uninstall. To fully remove:
+```bash
+kubectl delete crd sandboxes.agents.x-k8s.io
+kubectl delete crd sandboxclaims.extensions.agents.x-k8s.io
+kubectl delete crd sandboxtemplates.extensions.agents.x-k8s.io
+kubectl delete crd sandboxwarmpools.extensions.agents.x-k8s.io
+```

--- a/agent-sandbox/helm/Chart.yaml
+++ b/agent-sandbox/helm/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: agent-sandbox
+description: |
+  Installs the kubernetes-sigs/agent-sandbox controller on the data plane,
+  enabling SandboxTemplate, SandboxClaim, and SandboxWarmPool support for
+  OpenChoreo agent workloads with kernel-level isolation (runc/gvisor/kata).
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+keywords:
+  - openchoreo
+  - agent
+  - sandbox
+  - gvisor
+  - kata
+  - security
+home: https://github.com/openchoreo/community-modules/tree/main/agent-sandbox
+sources:
+  - https://github.com/openchoreo/community-modules
+  - https://github.com/kubernetes-sigs/agent-sandbox
+annotations:
+  openchoreo.dev/module-category: AI
+  openchoreo.dev/upstream-controller: "kubernetes-sigs/agent-sandbox"
+  openchoreo.dev/upstream-version: "v0.4.3"

--- a/agent-sandbox/helm/templates/agent-clustercomponenttype.yaml
+++ b/agent-sandbox/helm/templates/agent-clustercomponenttype.yaml
@@ -1,0 +1,328 @@
+apiVersion: openchoreo.dev/v1alpha1
+kind: ClusterComponentType
+metadata:
+  name: agent
+  annotations:
+    openchoreo.dev/description: "An AI agent workload with kernel-level sandbox isolation via kubernetes-sigs/agent-sandbox"
+spec:
+  workloadType: proxy
+
+  allowedWorkflows:
+    - kind: ClusterWorkflow
+      name: paketo-buildpacks-builder
+    - kind: ClusterWorkflow
+      name: gcp-buildpacks-builder
+    - kind: ClusterWorkflow
+      name: dockerfile-builder
+    - kind: ClusterWorkflow
+      name: ballerina-buildpack-builder
+
+  allowedTraits:
+    - kind: ClusterTrait
+      name: observability-alert-rule
+
+  parameters:
+    openAPIV3Schema:
+      type: object
+      properties:
+        isolationTier:
+          type: string
+          description: "Container runtime for sandbox isolation: runc (standard Linux), gvisor (syscall interception), kata (microVM)."
+          default: runc
+          enum:
+            - runc
+            - gvisor
+            - kata
+        warmPoolSize:
+          type: integer
+          description: "Number of pre-warmed sandbox instances to keep ready for fast claiming."
+          default: 0
+          minimum: 0
+        ttlSeconds:
+          type: integer
+          description: "Time-to-live in seconds for the sandbox after being claimed. 0 means no expiry."
+          default: 0
+          minimum: 0
+
+  validations:
+    - rule: >-
+        ${workload.endpoints.exists(name, ep, "external" in ep.visibility)
+          ? has(gateway.ingress) && has(gateway.ingress.external)
+          : true}
+      message: "Endpoints with 'external' visibility require gateway.ingress.external to be configured on the Environment or DataPlane."
+    - rule: >-
+        ${workload.endpoints.exists(name, ep, "internal" in ep.visibility)
+          ? has(gateway.ingress) && has(gateway.ingress.internal)
+          : true}
+      message: "Endpoints with 'internal' visibility require gateway.ingress.internal to be configured on the Environment or DataPlane."
+
+  environmentConfigs:
+    openAPIV3Schema:
+      type: object
+      $defs:
+        ResourceQuantity:
+          type: object
+          default: {}
+          properties:
+            cpu:
+              type: string
+              default: "100m"
+            memory:
+              type: string
+              default: "256Mi"
+        ResourceRequirements:
+          type: object
+          properties:
+            requests:
+              $ref: "#/$defs/ResourceQuantity"
+            limits:
+              $ref: "#/$defs/ResourceQuantity"
+          default: {}
+      properties:
+        replicas:
+          type: integer
+          default: 1
+          minimum: 0
+        resources:
+          $ref: "#/$defs/ResourceRequirements"
+        imagePullPolicy:
+          type: string
+          default: IfNotPresent
+          enum:
+            - Always
+            - IfNotPresent
+            - Never
+
+  resources:
+    # ── SandboxTemplate: defines the sandbox spec for the upstream controller ─
+    - id: sandbox-template
+      template:
+        apiVersion: extensions.agents.x-k8s.io/v1alpha1
+        kind: SandboxTemplate
+        metadata:
+          name: ${metadata.name}
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+        spec:
+          podTemplate:
+            metadata:
+              labels: ${metadata.podSelectors}
+            spec:
+              automountServiceAccountToken: false
+              runtimeClassName: |
+                ${parameters.isolationTier == "gvisor" ? "gvisor"
+                  : parameters.isolationTier == "kata" ? "kata-qemu"
+                  : oc_omit()}
+              nodeSelector: |
+                ${parameters.isolationTier == "gvisor"
+                  ? {"gvisor-enabled": "true"}
+                  : parameters.isolationTier == "kata"
+                    ? {"kata-enabled": "true"}
+                    : oc_omit()}
+              containers:
+                - name: main
+                  image: ${workload.container.image}
+                  imagePullPolicy: ${environmentConfigs.imagePullPolicy}
+                  command: |
+                    ${has(workload.container.command) ? workload.container.command : oc_omit()}
+                  args: |
+                    ${has(workload.container.args) ? workload.container.args : oc_omit()}
+                  resources:
+                    requests:
+                      cpu: ${environmentConfigs.resources.requests.cpu}
+                      memory: ${environmentConfigs.resources.requests.memory}
+                    limits:
+                      cpu: ${environmentConfigs.resources.limits.cpu}
+                      memory: ${environmentConfigs.resources.limits.memory}
+                  env: ${dependencies.toContainerEnvs()}
+                  envFrom: ${configurations.toContainerEnvFrom()}
+                  volumeMounts: ${configurations.toContainerVolumeMounts()}
+              volumes: ${configurations.toVolumes()}
+
+    # ── SandboxClaim: claims one sandbox from the template ───────────────
+    - id: sandbox-claim
+      template:
+        apiVersion: extensions.agents.x-k8s.io/v1alpha1
+        kind: SandboxClaim
+        metadata:
+          name: ${metadata.name}
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+        spec:
+          sandboxTemplateRef:
+            name: ${metadata.name}
+          lifecycle: |
+            ${parameters.ttlSeconds > 0
+              ? {"ttlSecondsAfterFinished": parameters.ttlSeconds}
+              : oc_omit()}
+
+    # ── SandboxWarmPool: pre-warmed sandbox instances ────────────────────
+    - id: sandbox-warmpool
+      includeWhen: ${parameters.warmPoolSize > 0}
+      template:
+        apiVersion: extensions.agents.x-k8s.io/v1alpha1
+        kind: SandboxWarmPool
+        metadata:
+          name: ${metadata.name}
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+        spec:
+          replicas: ${parameters.warmPoolSize}
+          sandboxTemplateRef:
+            name: ${metadata.name}
+
+    # ── Service (optional, only if endpoints are defined) ────────────────
+    - id: service
+      includeWhen: ${size(workload.endpoints) > 0}
+      template:
+        apiVersion: v1
+        kind: Service
+        metadata:
+          name: ${metadata.componentName}
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+        spec:
+          type: ClusterIP
+          selector: ${metadata.podSelectors}
+          ports: ${workload.toServicePorts()}
+
+    - id: httproute-external
+      forEach: '${workload.endpoints.transformMap(name, ep, "external" in ep.visibility && ep.type in ["HTTP", "GraphQL", "Websocket"], ep)}'
+      var: endpoint
+      template:
+        apiVersion: gateway.networking.k8s.io/v1
+        kind: HTTPRoute
+        metadata:
+          name: ${oc_generate_name(metadata.componentName, endpoint.key)}
+          namespace: ${metadata.namespace}
+          labels: '${oc_merge(metadata.labels, {"openchoreo.dev/endpoint-name": endpoint.key, "openchoreo.dev/endpoint-visibility": "external"})}'
+        spec:
+          parentRefs:
+            - name: ${gateway.ingress.external.name}
+              namespace: ${gateway.ingress.external.namespace}
+          hostnames: |
+            ${[gateway.ingress.external.?http, gateway.ingress.external.?https]
+              .filter(g, g.hasValue()).map(g, g.value().host).distinct()
+              .map(h, metadata.environmentName + "-" + metadata.componentNamespace + "." + h)}
+          rules:
+          - matches:
+            - path:
+                type: PathPrefix
+                value: /${metadata.componentName}-${endpoint.key}
+            filters:
+              - type: URLRewrite
+                urlRewrite:
+                  path:
+                    type: ReplacePrefixMatch
+                    replacePrefixMatch: '${endpoint.value.?basePath.orValue("/")}'
+            backendRefs:
+            - name: ${metadata.componentName}
+              port: ${endpoint.value.port}
+
+    - id: httproute-internal
+      forEach: '${workload.endpoints.transformMap(name, ep, "internal" in ep.visibility && ep.type in ["HTTP", "GraphQL", "Websocket"], ep)}'
+      var: endpoint
+      template:
+        apiVersion: gateway.networking.k8s.io/v1
+        kind: HTTPRoute
+        metadata:
+          name: '${oc_generate_name(metadata.componentName, endpoint.key, "internal")}'
+          namespace: ${metadata.namespace}
+          labels: '${oc_merge(metadata.labels, {"openchoreo.dev/endpoint-name": endpoint.key, "openchoreo.dev/endpoint-visibility": "internal"})}'
+        spec:
+          parentRefs:
+            - name: ${gateway.ingress.internal.name}
+              namespace: ${gateway.ingress.internal.namespace}
+          hostnames: |
+            ${[gateway.ingress.internal.?http, gateway.ingress.internal.?https]
+              .filter(g, g.hasValue()).map(g, g.value().host).distinct()
+              .map(h, metadata.environmentName + "-" + metadata.componentNamespace + "." + h)}
+          rules:
+          - matches:
+            - path:
+                type: PathPrefix
+                value: /${metadata.componentName}-${endpoint.key}
+            filters:
+              - type: URLRewrite
+                urlRewrite:
+                  path:
+                    type: ReplacePrefixMatch
+                    replacePrefixMatch: '${endpoint.value.?basePath.orValue("/")}'
+            backendRefs:
+            - name: ${metadata.componentName}
+              port: ${endpoint.value.port}
+
+    - id: env-config
+      forEach: ${configurations.toConfigEnvsByContainer()}
+      var: envConfig
+      template:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: ${envConfig.resourceName}
+          namespace: ${metadata.namespace}
+        data: |
+          ${envConfig.envs.transformMapEntry(index, env, {env.name: env.value})}
+
+    - id: file-config
+      forEach: ${configurations.toConfigFileList()}
+      var: config
+      template:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: ${config.resourceName}
+          namespace: ${metadata.namespace}
+        data:
+          ${config.name}: |
+            ${config.value}
+
+    - id: secret-env-external
+      forEach: ${configurations.toSecretEnvsByContainer()}
+      var: secretEnv
+      template:
+        apiVersion: external-secrets.io/v1
+        kind: ExternalSecret
+        metadata:
+          name: ${secretEnv.resourceName}
+          namespace: ${metadata.namespace}
+        spec:
+          refreshInterval: 15s
+          secretStoreRef:
+            name: ${dataplane.secretStore}
+            kind: ClusterSecretStore
+          target:
+            name: ${secretEnv.resourceName}
+            creationPolicy: Owner
+          data: |
+            ${secretEnv.envs.map(secret, {
+              "secretKey": secret.name,
+              "remoteRef": {
+                "key": secret.remoteRef.key,
+                ?"property": secret.remoteRef.?property
+              }
+            })}
+
+    - id: secret-file-external
+      forEach: ${configurations.toSecretFileList()}
+      var: file
+      template:
+        apiVersion: external-secrets.io/v1
+        kind: ExternalSecret
+        metadata:
+          name: ${file.resourceName}
+          namespace: ${metadata.namespace}
+        spec:
+          refreshInterval: 15s
+          secretStoreRef:
+            name: ${dataplane.secretStore}
+            kind: ClusterSecretStore
+          target:
+            name: ${file.resourceName}
+            creationPolicy: Owner
+          data:
+            - secretKey: ${file.name}
+              remoteRef:
+                key: ${file.remoteRef.key}
+                property: |
+                  ${has(file.remoteRef.property) ? file.remoteRef.property : oc_omit()}

--- a/agent-sandbox/helm/templates/agent-clustercomponenttype.yaml
+++ b/agent-sandbox/helm/templates/agent-clustercomponenttype.yaml
@@ -40,7 +40,7 @@ spec:
           minimum: 0
         ttlSeconds:
           type: integer
-          description: "Time-to-live in seconds for the sandbox after being claimed. 0 means no expiry."
+          description: "Time-to-live in seconds after the sandbox finishes execution. 0 means no automatic cleanup."
           default: 0
           minimum: 0
 
@@ -79,10 +79,6 @@ spec:
               $ref: "#/$defs/ResourceQuantity"
           default: {}
       properties:
-        replicas:
-          type: integer
-          default: 1
-          minimum: 0
         resources:
           $ref: "#/$defs/ResourceRequirements"
         imagePullPolicy:

--- a/agent-sandbox/helm/templates/rbac.yaml
+++ b/agent-sandbox/helm/templates/rbac.yaml
@@ -1,0 +1,28 @@
+# Grant the data plane cluster-agent service account permission to create
+# and manage agent-sandbox resources. The OpenChoreo RenderedRelease controller
+# uses this SA to server-side-apply SandboxTemplate, SandboxClaim, and
+# SandboxWarmPool resources in data-plane namespaces.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: openchoreo-agent-sandbox-access
+rules:
+  - apiGroups: ["agents.x-k8s.io"]
+    resources: ["sandboxes"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["extensions.agents.x-k8s.io"]
+    resources: ["sandboxclaims", "sandboxtemplates", "sandboxwarmpools"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: openchoreo-agent-sandbox-access
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: openchoreo-agent-sandbox-access
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.dataPlaneServiceAccount }}
+    namespace: {{ .Values.dataPlaneNamespace }}

--- a/agent-sandbox/helm/templates/upstream-install.yaml
+++ b/agent-sandbox/helm/templates/upstream-install.yaml
@@ -7,7 +7,10 @@
 {{- if eq $manifestURL "" }}
   {{- $manifestURL = printf "https://github.com/kubernetes-sigs/agent-sandbox/releases/download/%s/manifest.yaml" .Values.upstream.version }}
 {{- end }}
-{{- $extensionsURL := printf "https://github.com/kubernetes-sigs/agent-sandbox/releases/download/%s/extensions.yaml" .Values.upstream.version }}
+{{- $extensionsURL := .Values.upstream.extensionsManifestURL }}
+{{- if eq $extensionsURL "" }}
+  {{- $extensionsURL = printf "https://github.com/kubernetes-sigs/agent-sandbox/releases/download/%s/extensions.yaml" .Values.upstream.version }}
+{{- end }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -94,7 +97,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: kubectl
-          image: bitnami/kubectl:latest
+          image: bitnami/kubectl:1.32
           command:
             - /bin/sh
             - -c

--- a/agent-sandbox/helm/templates/upstream-install.yaml
+++ b/agent-sandbox/helm/templates/upstream-install.yaml
@@ -1,0 +1,115 @@
+{{- if .Values.upstream.install }}
+# Pre-install Job that installs the upstream kubernetes-sigs/agent-sandbox
+# controller on the cluster. It applies both the core manifest (Sandbox CRD +
+# controller) and extensions manifest (SandboxTemplate, SandboxClaim,
+# SandboxWarmPool CRDs + controller).
+{{- $manifestURL := .Values.upstream.manifestURL }}
+{{- if eq $manifestURL "" }}
+  {{- $manifestURL = printf "https://github.com/kubernetes-sigs/agent-sandbox/releases/download/%s/manifest.yaml" .Values.upstream.version }}
+{{- end }}
+{{- $extensionsURL := printf "https://github.com/kubernetes-sigs/agent-sandbox/releases/download/%s/extensions.yaml" .Values.upstream.version }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: agent-sandbox-upstream-installer
+  namespace: {{ .Values.namespace }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: agent-sandbox-upstream-installer
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+rules:
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["clusterroles", "clusterrolebindings"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "escalate", "bind"]
+  - apiGroups: [""]
+    resources: ["serviceaccounts", "namespaces", "services"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: ["agents.x-k8s.io", "extensions.agents.x-k8s.io"]
+    resources: ["*"]
+    verbs: ["*"]
+  # Required to avoid RBAC escalation denial when the upstream manifest
+  # creates its own ClusterRole with these permissions.
+  - apiGroups: [""]
+    resources: ["pods", "persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: ["events.k8s.io"]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: agent-sandbox-upstream-installer
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: agent-sandbox-upstream-installer
+subjects:
+  - kind: ServiceAccount
+    name: agent-sandbox-upstream-installer
+    namespace: {{ .Values.namespace }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: agent-sandbox-upstream-install
+  namespace: {{ .Values.namespace }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  ttlSecondsAfterFinished: 600
+  backoffLimit: 3
+  template:
+    spec:
+      serviceAccountName: agent-sandbox-upstream-installer
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: kubectl
+          image: bitnami/kubectl:latest
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+              echo "Installing kubernetes-sigs/agent-sandbox {{ .Values.upstream.version }}..."
+              echo "Applying core manifest..."
+              kubectl apply --server-side -f {{ $manifestURL | quote }}
+              echo "Applying extensions manifest..."
+              kubectl apply --server-side -f {{ $extensionsURL | quote }}
+              echo "Upstream controller installed successfully."
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 1000
+            capabilities:
+              drop: ["ALL"]
+{{- end }}

--- a/agent-sandbox/helm/templates/upstream-install.yaml
+++ b/agent-sandbox/helm/templates/upstream-install.yaml
@@ -97,7 +97,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: kubectl
-          image: bitnami/kubectl:1.32
+          image: bitnami/kubectl:latest
           command:
             - /bin/sh
             - -c

--- a/agent-sandbox/helm/values.yaml
+++ b/agent-sandbox/helm/values.yaml
@@ -21,3 +21,6 @@ upstream:
   # manifestURL: override the full URL for the core manifest; leave empty
   # to auto-build from the version.
   manifestURL: ""
+  # extensionsManifestURL: override the full URL for the extensions manifest;
+  # leave empty to auto-build from the version.
+  extensionsManifestURL: ""

--- a/agent-sandbox/helm/values.yaml
+++ b/agent-sandbox/helm/values.yaml
@@ -1,0 +1,23 @@
+# Default values for agent-sandbox.
+
+# Namespace where OpenChoreo control plane runs.
+namespace: openchoreo-control-plane
+
+# Namespace where the data plane cluster-agent runs.
+dataPlaneNamespace: openchoreo-data-plane
+
+# Data plane service account name (used for RBAC binding).
+dataPlaneServiceAccount: cluster-agent-dataplane
+
+# upstream controls the installation of the kubernetes-sigs/agent-sandbox
+# controller, which manages Sandbox, SandboxTemplate, SandboxClaim, and
+# SandboxWarmPool resources on the data plane.
+upstream:
+  # install: when true, a pre-install Helm hook Job applies the upstream
+  # manifests before the rest of the chart is deployed.
+  install: true
+  # version: the kubernetes-sigs/agent-sandbox release tag to install.
+  version: "v0.4.3"
+  # manifestURL: override the full URL for the core manifest; leave empty
+  # to auto-build from the version.
+  manifestURL: ""


### PR DESCRIPTION
## Summary
- Adds the `agent-sandbox` community module that installs the [kubernetes-sigs/agent-sandbox](https://github.com/kubernetes-sigs/agent-sandbox) controller on the data plane
- Grants the data plane cluster-agent SA permissions to manage SandboxTemplate, SandboxClaim, SandboxWarmPool, and Sandbox resources
- Registers the `ai-agent` ClusterComponentType (`proxy/ai-agent`) with sandbox resource templates
- No custom Go controller — pure Helm chart

> **This module must be installed on each data plane cluster** where agent workloads will run. In multi-cluster setups, install it on every data plane cluster separately.

### What gets installed
1. Pre-install Helm hook Job applies upstream `manifest.yaml` + `extensions.yaml` (installs CRDs + controller on the data plane)
2. ClusterRole + ClusterRoleBinding grants the data plane SA permissions for `agents.x-k8s.io` and `extensions.agents.x-k8s.io` resources
3. `ai-agent` ClusterComponentType that renders SandboxTemplate, SandboxClaim, SandboxWarmPool, Service, and HTTPRoute resources via the standard OpenChoreo pipeline

### Component parameters

| Parameter | Type | Default | Values | Description |
|---|---|---|---|---|
| `isolationTier` | string | `runc` | `runc`, `gvisor`, `kata` | Container runtime for sandbox isolation |
| `warmPoolSize` | integer | `0` | >= 0 | Pre-warmed sandbox instances (0 = no warm pool) |
| `ttlSeconds` | integer | `0` | >= 0 | Time-to-live after execution finishes (0 = no expiry) |

## Test plan
- [ ] `helm install` on a data plane cluster succeeds
- [ ] Upstream controller running in `agent-sandbox-system` namespace
- [ ] All 4 CRDs registered
- [ ] `ai-agent` ClusterComponentType registered
- [ ] Create a Component with `proxy/ai-agent` type — sandbox resources rendered to data plane
- [ ] Data plane SA can create/manage sandbox resources
- [ ] `helm uninstall` cleans up module resources (CRDs retained by design)