### PR TITLE
chore: perform missed version bump of Prometheus metrics module for #95

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -51,13 +51,14 @@ jobs:
               continue
             fi
 
-            # Check if any files in this module were changed (init/ or helm/)
+            # Check if any files in this module were changed
             if ! echo "$CHANGED_FILES" | grep -q "^${module}/"; then
               continue
             fi
 
-            # Skip if only non-helm, non-init files changed (e.g., README.md)
-            if ! echo "$CHANGED_FILES" | grep -qE "^${module}/(init/|helm/|module\.yaml)"; then
+            # Skip if only non-substantive files changed (e.g., README.md, docs)
+            # Require version bump for: init/, helm/, module.yaml, .go files, go.mod/sum, Dockerfile, Makefile
+            if ! echo "$CHANGED_FILES" | grep -qE "^${module}/(init/|helm/|module\.yaml$|.*\.go$|(.*/)?go\.mod$|(.*/)?go\.sum$|(.*/)?Dockerfile$|(.*/)?Makefile$)"; then
               continue
             fi
 

--- a/observability-metrics-prometheus/helm/Chart.yaml
+++ b/observability-metrics-prometheus/helm/Chart.yaml
@@ -5,8 +5,8 @@ apiVersion: v2
 name: observability-metrics-prometheus
 description: A Helm chart for OpenChoreo Observability Metrics module based on Prometheus
 type: application
-version: 0.4.4
-appVersion: "0.4.4"
+version: 0.5.0
+appVersion: "0.5.0"
 keywords:
   - prometheus
   - observability


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat: add observability-logs-opensearch module
  fix: handle opensearch startup delay in init script
  docs: update observability-logs-opensearch module installation guide
  chore(deps): bump fluent-bit version in observability-logs-openobserve module

See: https://github.com/openchoreo/openchoreo/blob/main/docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
- The helm version bump was missed in #95 and the PR check did not detect it. Hence this PR performs the version bump
- Update PR check logic to detect changes to Go files as requiring a version bump

## Approach
- Changes the helm chart version of the observability-metrics-prometheus module from 0.4.4 to 0.5.0
- Update PR check GitHub workflow

## Related Issues
https://github.com/openchoreo/openchoreo/issues/3396

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated observability-metrics-prometheus Helm chart to version 0.5.0 with corresponding appVersion bump.
  * Expanded pull request validation workflow to enforce version consistency when detecting changes across infrastructure files, build configurations, and initialization scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->