### PR TITLE
docs: improve multi-cluster setup guide and add TLS skip-verify for remote write

### DIFF
--- a/observability-logs-opensearch/README.md
+++ b/observability-logs-opensearch/README.md
@@ -98,9 +98,16 @@ helm upgrade observability-logs-opensearch \
 ```
 
 ### Multi-cluster topology
+
 In a **multi-cluster topology**, where the observability plane runs in a separate cluster
-from the data-plane / workflow-plane clusters, install the Helm chart in those clusters with Fluent Bit enabled and OpenSearch disabled
-to start collecting logs from the cluster and publish them to the observability plane cluster's OpenSearch endpoint.
+from the data-plane / workflow-plane clusters, you need two things:
+
+1. **On the observability plane cluster**: expose OpenSearch through the gateway via TLS passthrough so remote fluent-bit instances can reach it.
+2. **On each remote cluster**: install this chart with only fluent-bit enabled, pointed at the obs cluster's OpenSearch endpoint.
+
+#### Observability plane cluster setup
+
+The recommended approach is the **OpenSearch Operator** (`openSearchCluster.enabled=true`), which automatically creates the TLSRoute needed for gateway passthrough. Install the operator first (see [Prerequisites](#pre-requisites)), then install the chart with:
 
 ```bash
 helm upgrade --install observability-logs-opensearch \
@@ -110,17 +117,48 @@ helm upgrade --install observability-logs-opensearch \
   --version 0.4.0 \
   --set adapter.openSearchSecretName="opensearch-admin-credentials" \
   --set openSearch.enabled=false \
+  --set openSearchCluster.enabled=true \
+  --set openSearchCluster.credentialsSecretName="opensearch-admin-credentials" \
+  --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials"
+```
+
+You also need TLS passthrough enabled on the observability plane gateway. When installing the `openchoreo-observability-plane` chart, include:
+
+```yaml
+gateway:
+  tlsPassthrough:
+    enabled: true
+    hostname: "opensearch.<OBS_BASE_DOMAIN>"
+```
+
+> **Note:** If you use the helm subchart OpenSearch (`openSearch.enabled=true`) instead of the operator, the TLSRoute is not auto-generated and the `BackendConfigPolicy` on the default `opensearch` Service conflicts with TLS passthrough (causes double-TLS). You would need to create a separate passthrough Service and TLSRoute manually. The operator approach avoids this complexity.
+
+#### Remote cluster setup (data-plane / workflow-plane clusters)
+
+Install the chart with only fluent-bit enabled:
+
+```bash
+helm upgrade --install observability-logs-opensearch \
+  oci://ghcr.io/openchoreo/helm-charts/observability-logs-opensearch \
+  --create-namespace \
+  --namespace openchoreo-observability-plane \
+  --version 0.4.0 \
+  --set adapter.enabled=false \
+  --set openSearch.enabled=false \
   --set openSearchCluster.enabled=false \
   --set openSearchSetup.enabled=false \
   --set fluent-bit.enabled=true \
-  --set fluent-bit.openSearchHost=opensearch.<gateway-domain> \
-  --set fluent-bit.openSearchPort=<gateway-port>
+  --set fluent-bit.openSearchHost=opensearch.<OBS_BASE_DOMAIN> \
+  --set fluent-bit.openSearchPort=<gateway-tls-passthrough-port> \
+  --set fluent-bit.openSearchVHost=opensearch.<OBS_BASE_DOMAIN>
 ```
+
 > **Note:**
 >
-> Make sure the `opensearch-admin-credentials` secret is available in the data-plane / workflow-plane clusters as well,
-> and `fluent-bit.openSearchHost`, `fluent-bit.openSearchPort` and `fluent-bit.openSearchVHost` values are set to the OpenSearch endpoint exposed from the observability plane cluster.
-> Also, set `fluent-bit.openSearchVHost` if openSearchHost differs from gateway domain
+> - The `opensearch-admin-credentials` secret must exist on the remote cluster. If you don't have a shared secret backend, create it manually (see the [Multi-Cluster Connectivity](https://openchoreo.dev/docs/platform-engineer-guide/multi-cluster-connectivity/) guide).
+> - `fluent-bit.openSearchHost` and `fluent-bit.openSearchVHost` should match the TLS passthrough hostname on the obs gateway.
+> - `fluent-bit.openSearchPort` should match the passthrough listener port (commonly `11443` if the obs gateway uses non-standard ports).
+> - The adapter and setup job are disabled because they only need to run on the observability plane cluster.
 
 ## Compatibility
 

--- a/observability-logs-opensearch/README.md
+++ b/observability-logs-opensearch/README.md
@@ -62,7 +62,7 @@ helm upgrade --install observability-logs-opensearch \
   oci://ghcr.io/openchoreo/helm-charts/observability-logs-opensearch \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.4.0 \
+  --version 0.4.1 \
   --set adapter.openSearchSecretName="opensearch-admin-credentials" \
   --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials"
 ```
@@ -74,7 +74,7 @@ helm upgrade --install observability-logs-opensearch \
 >   oci://ghcr.io/openchoreo/helm-charts/observability-logs-opensearch \
 >   --create-namespace \
 >   --namespace openchoreo-observability-plane \
->   --version 0.4.0 \
+>   --version 0.4.1 \
 >   --set adapter.openSearchSecretName="opensearch-admin-credentials" \
 >   --set openSearch.enabled=false \
 >   --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials"
@@ -92,7 +92,7 @@ helm upgrade observability-logs-opensearch \
   oci://ghcr.io/openchoreo/helm-charts/observability-logs-opensearch \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.4.0 \
+  --version 0.4.1 \
   --reuse-values \
   --set fluent-bit.enabled=true
 ```
@@ -114,7 +114,7 @@ helm upgrade --install observability-logs-opensearch \
   oci://ghcr.io/openchoreo/helm-charts/observability-logs-opensearch \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.4.0 \
+  --version 0.4.1 \
   --set adapter.openSearchSecretName="opensearch-admin-credentials" \
   --set openSearch.enabled=false \
   --set openSearchCluster.enabled=true \
@@ -142,7 +142,7 @@ helm upgrade --install observability-logs-opensearch \
   oci://ghcr.io/openchoreo/helm-charts/observability-logs-opensearch \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.4.0 \
+  --version 0.4.1 \
   --set adapter.enabled=false \
   --set openSearch.enabled=false \
   --set openSearchCluster.enabled=false \

--- a/observability-logs-opensearch/helm/Chart.yaml
+++ b/observability-logs-opensearch/helm/Chart.yaml
@@ -5,8 +5,8 @@ apiVersion: v2
 name: observability-logs-opensearch
 description: A Helm chart for OpenChoreo Observability Logs module with Fluent Bit and OpenSearch
 type: application
-version: 0.4.0
-appVersion: "0.4.0"
+version: 0.4.1
+appVersion: "0.4.1"
 keywords:
   - opensearch
   - observability

--- a/observability-metrics-prometheus/README.md
+++ b/observability-metrics-prometheus/README.md
@@ -60,11 +60,14 @@ helm upgrade --install observability-metrics-prometheus \
   --set kube-prometheus-stack.alertmanager.enabled=false
 ```
 
+> **Note:** If the observability plane gateway uses self-signed certificates, remote write will fail with `x509: certificate signed by unknown authority`. Add `--set prometheusCustomizations.remoteWrite.tlsInsecureSkipVerify=true` to skip TLS verification.
+
 #### Exporter configuration options
 
-| Option                                                | Default    | Description                                                                           |
-| ----------------------------------------------------- | ---------- | ------------------------------------------------------------------------------------- |
-| `prometheusCustomizations.http.observabilityPlaneUrl` | (required) | Central receiver URL for remote write. The URL hostname is used as the `Host` header. |
+| Option                                                          | Default    | Description                                                                           |
+| --------------------------------------------------------------- | ---------- | ------------------------------------------------------------------------------------- |
+| `prometheusCustomizations.http.observabilityPlaneUrl`           | (required) | Central receiver URL for remote write. The URL hostname is used as the `Host` header. |
+| `prometheusCustomizations.remoteWrite.tlsInsecureSkipVerify`    | `false`    | Skip TLS certificate verification for self-signed certs on the receiver.              |
 
 ## Verification
 

--- a/observability-metrics-prometheus/README.md
+++ b/observability-metrics-prometheus/README.md
@@ -27,7 +27,7 @@ helm upgrade --install observability-metrics-prometheus \
   oci://ghcr.io/openchoreo/helm-charts/observability-metrics-prometheus \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.5.1
+  --version 0.5.2
 ```
 
 ### Multi-cluster topology
@@ -39,7 +39,7 @@ helm upgrade --install observability-metrics-prometheus \
   oci://ghcr.io/openchoreo/helm-charts/observability-metrics-prometheus \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.5.1 \
+  --version 0.5.2 \
   --set global.installationMode="multiClusterReceiver" \
   --set-json 'prometheusCustomizations.http.hostnames=["prometheus.observability.example.com"]'
 ```
@@ -53,7 +53,7 @@ helm upgrade --install observability-metrics-prometheus \
   oci://ghcr.io/openchoreo/helm-charts/observability-metrics-prometheus \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.5.1 \
+  --version 0.5.2 \
   --set global.installationMode="multiClusterExporter" \
   --set prometheusCustomizations.http.observabilityPlaneUrl=http://prometheus.observability.example.com:9091/api/v1/write \
   --set kube-prometheus-stack.prometheus.enabled=false \

--- a/observability-metrics-prometheus/helm/Chart.yaml
+++ b/observability-metrics-prometheus/helm/Chart.yaml
@@ -5,8 +5,8 @@ apiVersion: v2
 name: observability-metrics-prometheus
 description: A Helm chart for OpenChoreo Observability Metrics module based on Prometheus
 type: application
-version: 0.5.1
-appVersion: "0.5.1"
+version: 0.5.2
+appVersion: "0.5.2"
 keywords:
   - prometheus
   - observability

--- a/observability-metrics-prometheus/helm/templates/prometheus-agent.yaml
+++ b/observability-metrics-prometheus/helm/templates/prometheus-agent.yaml
@@ -15,6 +15,10 @@ spec:
   podMonitorNamespaceSelector: {}
   remoteWrite:
     - url: {{ .Values.prometheusCustomizations.http.observabilityPlaneUrl | quote }}
+      {{- if .Values.prometheusCustomizations.remoteWrite.tlsInsecureSkipVerify }}
+      tlsConfig:
+        insecureSkipVerify: true
+      {{- end }}
       queueConfig:
         capacity: 2500
         maxShards: 200

--- a/observability-metrics-prometheus/helm/values.yaml
+++ b/observability-metrics-prometheus/helm/values.yaml
@@ -172,3 +172,5 @@ prometheusCustomizations:
   http:
     observabilityPlaneUrl: ""         # multiClusterExporter: remote write receiver URL (e.g., http://prometheus.<gateway-domain>:9091/api/v1/write)
     hostnames: []                     # multiClusterReceiver: hostnames for the gateway HTTPRoute
+  remoteWrite:
+    tlsInsecureSkipVerify: false      # multiClusterExporter: skip TLS verification for self-signed certs on the receiver


### PR DESCRIPTION
## Summary

- Rewrites the multi-cluster topology section in the OpenSearch logs module README with step-by-step instructions for both the observability plane cluster and remote clusters, including TLS passthrough gateway setup
- Adds `tlsInsecureSkipVerify` option to the Prometheus metrics module for remote write against self-signed certs
- Bumps `observability-logs-opensearch` to 0.4.1 and `observability-metrics-prometheus` to 0.5.2

## Test plan

- [ ] Verify multi-cluster OpenSearch setup following the updated README on a real cluster pair
- [ ] Confirm `prometheusCustomizations.remoteWrite.tlsInsecureSkipVerify=true` renders the correct `tlsConfig` block in the prometheus-agent manifest
- [ ] Helm template lint passes for both charts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced multi-cluster setup instructions with clearer OpenSearch Operator and gateway TLS passthrough configuration
  * Added TLS verification bypass option for Prometheus remote-write scenarios with self-signed certificates

* **Chores**
  * Released patch updates for observability-logs-opensearch (v0.4.1) and observability-metrics-prometheus (v0.5.2)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openchoreo/community-modules/pull/100)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->