### PR TITLE
docs: improve multi-cluster install instructions for tracing opensearch

### DIFF
--- a/observability-tracing-opensearch/README.md
+++ b/observability-tracing-opensearch/README.md
@@ -110,11 +110,25 @@ helm upgrade --install observability-tracing-opensearch \
   --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials"
 ```
 
+> **Note:** If OpenSearch is already installed by another module (e.g., `observability-logs-opensearch`), disable it to avoid conflicts:
+>
+> ```bash
+> helm upgrade --install observability-tracing-opensearch \
+>   oci://ghcr.io/openchoreo/helm-charts/observability-tracing-opensearch \
+>   --create-namespace \
+>   --namespace openchoreo-observability-plane \
+>   --version 0.4.1 \
+>   --set openSearch.enabled=false \
+>   --set global.installationMode="multiClusterReceiver" \
+>   --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials"
+> ```
+
 ### 2) Install an exporter (each dataplane cluster)
 
 Install the chart in each dataplane cluster. The exporter does **not** need OpenSearch or the OpenSearch setup job; it only needs to export OTLP to the receiver.
 
 Set `opentelemetryCollectorCustomizations.http.observabilityPlaneUrl` to the receiver endpoint (for example: `http://opentelemetry.<gateway-domain>:<port>`).
+If the observability plane gateway is exposed over a TLS/HTTPS listener, use the `https://` scheme instead (for example: `https://opentelemetry.<gateway-domain>:<port>`).
 Also set `opentelemetryCollectorCustomizations.http.observabilityPlaneVirtualHost` if observabilityPlaneUrl differs from the gateway hostname.
 
 ```bash
@@ -127,7 +141,8 @@ helm upgrade --install observability-tracing-opensearch \
   --set openSearch.enabled=false \
   --set openSearchCluster.enabled=false \
   --set openSearchSetup.enabled=false \
-  --set opentelemetry-collector.extraEnvs=[] \
+  --set adapter.enabled=false \
+  --set-json opentelemetry-collector.extraEnvs="[]" \
   --set opentelemetryCollectorCustomizations.http.observabilityPlaneUrl="http://opentelemetry.<gateway-domain>:<port>" \
   --set opentelemetryCollectorCustomizations.http.observabilityPlaneVirtualHost="opentelemetry.<gateway-domain>"
 ```


### PR DESCRIPTION
## Purpose

Improve the installation documentation for the `observability-tracing-opensearch` module to cover scenarios that were missing or unclear in the multi-cluster setup, and fix a couple of incorrect `helm` flags in the exporter install command.

## Approach

- Add a note under the multi-cluster receiver section explaining how to disable OpenSearch when it is already installed by another module (e.g., `observability-logs-opensearch`) to avoid conflicts
- Document that the `observabilityPlaneUrl` can use the `https://` scheme when the observability plane gateway is exposed over a TLS/HTTPS listener
- Add `--set adapter.enabled=false` to the exporter install command since the adapter is not required in dataplane clusters
- Use `--set-json opentelemetry-collector.extraEnvs="[]"` so the empty array is parsed correctly by Helm

## Related Issues

N/A

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added conflict detection warning to OpenSearch tracing module documentation for scenarios where OpenSearch is already installed by another module
  * Included Helm command example showing how to disable OpenSearch installations to prevent conflicts
  * Updated multi-cluster exporter installation instructions with improved Helm configuration parameter guidance for better deployment flexibility

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openchoreo/community-modules/pull/101)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->