### PR TITLE
feat: Implement runtime topology endpoint in metrics-prometheus module

### DIFF
--- a/observability-metrics-prometheus/README.md
+++ b/observability-metrics-prometheus/README.md
@@ -27,7 +27,7 @@ helm upgrade --install observability-metrics-prometheus \
   oci://ghcr.io/openchoreo/helm-charts/observability-metrics-prometheus \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.5.2
+  --version 0.6.0
 ```
 
 ### Multi-cluster topology
@@ -39,7 +39,7 @@ helm upgrade --install observability-metrics-prometheus \
   oci://ghcr.io/openchoreo/helm-charts/observability-metrics-prometheus \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.5.2 \
+  --version 0.6.0 \
   --set global.installationMode="multiClusterReceiver" \
   --set-json 'prometheusCustomizations.http.hostnames=["prometheus.observability.example.com"]'
 ```
@@ -53,7 +53,7 @@ helm upgrade --install observability-metrics-prometheus \
   oci://ghcr.io/openchoreo/helm-charts/observability-metrics-prometheus \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.5.2 \
+  --version 0.6.0 \
   --set global.installationMode="multiClusterExporter" \
   --set prometheusCustomizations.http.observabilityPlaneUrl=http://prometheus.observability.example.com:9091/api/v1/write \
   --set kube-prometheus-stack.prometheus.enabled=false \
@@ -64,10 +64,10 @@ helm upgrade --install observability-metrics-prometheus \
 
 #### Exporter configuration options
 
-| Option                                                          | Default    | Description                                                                           |
-| --------------------------------------------------------------- | ---------- | ------------------------------------------------------------------------------------- |
-| `prometheusCustomizations.http.observabilityPlaneUrl`           | (required) | Central receiver URL for remote write. The URL hostname is used as the `Host` header. |
-| `prometheusCustomizations.remoteWrite.tlsInsecureSkipVerify`    | `false`    | Skip TLS certificate verification for self-signed certs on the receiver.              |
+| Option                                                       | Default    | Description                                                                           |
+| ------------------------------------------------------------ | ---------- | ------------------------------------------------------------------------------------- |
+| `prometheusCustomizations.http.observabilityPlaneUrl`        | (required) | Central receiver URL for remote write. The URL hostname is used as the `Host` header. |
+| `prometheusCustomizations.remoteWrite.tlsInsecureSkipVerify` | `false`    | Skip TLS certificate verification for self-signed certs on the receiver.              |
 
 ## Verification
 
@@ -118,12 +118,11 @@ If remote write from exporter to receiver is failing:
 3. Check that queue capacity and batch settings are appropriate for your metrics volume
 4. Monitor central Prometheus for import errors: `rate(prometheus_tsdb_symbol_table_size_bytes[5m])`
 
-
 ## Compatibility
 
 > **Note:** The Helm chart versions specified in the installation commands above are for the latest module version compatible with the development version of OpenChoreo. Refer to the compatibility table below to determine the appropriate module version for your OpenChoreo installation.
 
 | Module Version | OpenChoreo Version |
-|----------------|--------------------|
+| -------------- | ------------------ |
 | >= v0.4.x      | v1.1.x             |
 | v0.3.x         | v1.0.x             |

--- a/observability-metrics-prometheus/README.md
+++ b/observability-metrics-prometheus/README.md
@@ -120,7 +120,7 @@ If remote write from exporter to receiver is failing:
 
 ## Compatibility
 
-> **Note:** The Helm chart versions specified in the installation commands above are for the latest module version compatible with the development version of OpenChoreo. Refer to the compatibility table below to determine the appropriate module version for your OpenChoreo installation.
+> **Note:** The Helm chart versions specified in the installation commands above reflect the latest module version and is compatible with the development version of OpenChoreo. Refer to the compatibility table below to determine the appropriate module version for your OpenChoreo installation.
 
 | Module Version | OpenChoreo Version |
 | -------------- | ------------------ |

--- a/observability-metrics-prometheus/helm/Chart.yaml
+++ b/observability-metrics-prometheus/helm/Chart.yaml
@@ -5,8 +5,8 @@ apiVersion: v2
 name: observability-metrics-prometheus
 description: A Helm chart for OpenChoreo Observability Metrics module based on Prometheus
 type: application
-version: 0.5.2
-appVersion: "0.5.2"
+version: 0.6.0
+appVersion: "0.6.0"
 keywords:
   - prometheus
   - observability

--- a/observability-metrics-prometheus/helm/values.yaml
+++ b/observability-metrics-prometheus/helm/values.yaml
@@ -118,7 +118,7 @@ kube-prometheus-stack:
       - kube_pod_start_time
       - kube_pod_status_phase
     metricLabelsAllowlist:
-      - pods=[openchoreo.dev/component-uid,openchoreo.dev/project-uid,openchoreo.dev/environment-uid,openchoreo.dev/namespace]
+      - pods=[openchoreo.dev/component-uid,openchoreo.dev/project-uid,openchoreo.dev/environment-uid,openchoreo.dev/namespace,openchoreo.dev/component,openchoreo.dev/project,openchoreo.dev/environment]
 
   thanosRuler:
     enabled: false

--- a/observability-metrics-prometheus/internal/api/gen/models.gen.go
+++ b/observability-metrics-prometheus/internal/api/gen/models.gen.go
@@ -5,6 +5,7 @@ package gen
 
 import (
 	"encoding/json"
+	"errors"
 	"time"
 
 	"github.com/oapi-codegen/runtime"
@@ -75,8 +76,43 @@ const (
 
 // Defines values for MetricsQueryRequestMetric.
 const (
-	Http     MetricsQueryRequestMetric = "http"
-	Resource MetricsQueryRequestMetric = "resource"
+	MetricsQueryRequestMetricHttp     MetricsQueryRequestMetric = "http"
+	MetricsQueryRequestMetricResource MetricsQueryRequestMetric = "resource"
+)
+
+// Defines values for RuntimeTopologyEdgeProtocol.
+const (
+	RuntimeTopologyEdgeProtocolHttp RuntimeTopologyEdgeProtocol = "http"
+)
+
+// Defines values for RuntimeTopologyNodeComponentKind.
+const (
+	RuntimeTopologyNodeComponentKindComponent RuntimeTopologyNodeComponentKind = "component"
+)
+
+// Defines values for RuntimeTopologyNodeExternalKind.
+const (
+	RuntimeTopologyNodeExternalKindExternal RuntimeTopologyNodeExternalKind = "external"
+)
+
+// Defines values for RuntimeTopologyNodeGatewayKind.
+const (
+	RuntimeTopologyNodeGatewayKindGateway RuntimeTopologyNodeGatewayKind = "gateway"
+)
+
+// Defines values for RuntimeTopologyNodeRefComponentKind.
+const (
+	RuntimeTopologyNodeRefComponentKindComponent RuntimeTopologyNodeRefComponentKind = "component"
+)
+
+// Defines values for RuntimeTopologyNodeRefExternalKind.
+const (
+	RuntimeTopologyNodeRefExternalKindExternal RuntimeTopologyNodeRefExternalKind = "external"
+)
+
+// Defines values for RuntimeTopologyNodeRefGatewayKind.
+const (
+	RuntimeTopologyNodeRefGatewayKindGateway RuntimeTopologyNodeRefGatewayKind = "gateway"
 )
 
 // AlertRuleRequest defines model for AlertRuleRequest.
@@ -284,6 +320,190 @@ type ResourceMetricsTimeSeries struct {
 	MemoryUsage    *[]MetricsTimeSeriesItem `json:"memoryUsage,omitempty"`
 }
 
+// RuntimeTopologyEdge An observed traffic flow from a source node to a target node.
+type RuntimeTopologyEdge struct {
+	// Id Stable identifier for the edge. Convention:
+	//   - component->component: `${srcComponentUid}->${dstComponentUid}`
+	//   - gateway->component:   `gateway:${gatewayName}->${dstComponentUid}`
+	//   - component->external:  `${srcComponentUid}->external:${externalHost}`
+	Id string `json:"id"`
+
+	// Metrics Aggregate HTTP metrics over the requested window. Latency values are
+	// in seconds, matching /api/v1/metrics/query.
+	Metrics  *RuntimeTopologyMetrics     `json:"metrics,omitempty"`
+	Protocol RuntimeTopologyEdgeProtocol `json:"protocol"`
+	Source   RuntimeTopologyNodeRef      `json:"source"`
+	Target   RuntimeTopologyNodeRef      `json:"target"`
+}
+
+// RuntimeTopologyEdgeProtocol defines model for RuntimeTopologyEdge.Protocol.
+type RuntimeTopologyEdgeProtocol string
+
+// RuntimeTopologyMetrics Aggregate HTTP metrics over the requested window. Latency values are
+// in seconds, matching /api/v1/metrics/query.
+type RuntimeTopologyMetrics struct {
+	LatencyP50               *float64 `json:"latencyP50,omitempty"`
+	LatencyP90               *float64 `json:"latencyP90,omitempty"`
+	LatencyP99               *float64 `json:"latencyP99,omitempty"`
+	MeanLatency              *float64 `json:"meanLatency,omitempty"`
+	RequestCount             *float64 `json:"requestCount,omitempty"`
+	UnsuccessfulRequestCount *float64 `json:"unsuccessfulRequestCount,omitempty"`
+}
+
+// RuntimeTopologyNode defines model for RuntimeTopologyNode.
+type RuntimeTopologyNode struct {
+	union json.RawMessage
+}
+
+// RuntimeTopologyNodeComponent A component node observed in the runtime topology with its aggregated metrics.
+type RuntimeTopologyNodeComponent struct {
+	// Component The component name (from pod label).
+	Component string `json:"component"`
+
+	// ComponentUid The component UID (from pod label).
+	ComponentUid openapi_types.UUID               `json:"componentUid"`
+	Kind         RuntimeTopologyNodeComponentKind `json:"kind"`
+
+	// Metrics Aggregate HTTP metrics over the requested window. Latency values are
+	// in seconds, matching /api/v1/metrics/query.
+	Metrics   *RuntimeTopologyMetrics `json:"metrics,omitempty"`
+	Namespace *string                 `json:"namespace,omitempty"`
+
+	// Project The project name (from pod label).
+	Project *string `json:"project,omitempty"`
+
+	// ProjectUid The project UID.
+	ProjectUid *openapi_types.UUID `json:"projectUid,omitempty"`
+}
+
+// RuntimeTopologyNodeComponentKind defines model for RuntimeTopologyNodeComponent.Kind.
+type RuntimeTopologyNodeComponentKind string
+
+// RuntimeTopologyNodeExternal An external node observed in the runtime topology with its aggregated metrics.
+type RuntimeTopologyNodeExternal struct {
+	Component    *string                         `json:"component,omitempty"`
+	ComponentUid *openapi_types.UUID             `json:"componentUid,omitempty"`
+	ExternalHost *string                         `json:"externalHost,omitempty"`
+	Kind         RuntimeTopologyNodeExternalKind `json:"kind"`
+
+	// Metrics Aggregate HTTP metrics over the requested window. Latency values are
+	// in seconds, matching /api/v1/metrics/query.
+	Metrics    *RuntimeTopologyMetrics `json:"metrics,omitempty"`
+	Namespace  *string                 `json:"namespace,omitempty"`
+	ProjectUid *openapi_types.UUID     `json:"projectUid,omitempty"`
+}
+
+// RuntimeTopologyNodeExternalKind defines model for RuntimeTopologyNodeExternal.Kind.
+type RuntimeTopologyNodeExternalKind string
+
+// RuntimeTopologyNodeGateway A gateway node observed in the runtime topology with its aggregated metrics.
+type RuntimeTopologyNodeGateway struct {
+	GatewayName string                         `json:"gatewayName"`
+	Kind        RuntimeTopologyNodeGatewayKind `json:"kind"`
+
+	// Metrics Aggregate HTTP metrics over the requested window. Latency values are
+	// in seconds, matching /api/v1/metrics/query.
+	Metrics    *RuntimeTopologyMetrics `json:"metrics,omitempty"`
+	Namespace  *string                 `json:"namespace,omitempty"`
+	ProjectUid *openapi_types.UUID     `json:"projectUid,omitempty"`
+}
+
+// RuntimeTopologyNodeGatewayKind defines model for RuntimeTopologyNodeGateway.Kind.
+type RuntimeTopologyNodeGatewayKind string
+
+// RuntimeTopologyNodeRef defines model for RuntimeTopologyNodeRef.
+type RuntimeTopologyNodeRef struct {
+	union json.RawMessage
+}
+
+// RuntimeTopologyNodeRefComponent Reference to a component node in the runtime topology.
+type RuntimeTopologyNodeRefComponent struct {
+	// Component The component name (from pod label).
+	Component string `json:"component"`
+
+	// ComponentUid The component UID (from pod label).
+	ComponentUid string                              `json:"componentUid"`
+	Kind         RuntimeTopologyNodeRefComponentKind `json:"kind"`
+
+	// Namespace The namespace name (from pod label).
+	Namespace *string `json:"namespace,omitempty"`
+
+	// Project The project name (from pod label).
+	Project *string `json:"project,omitempty"`
+
+	// ProjectUid The project UID.
+	ProjectUid *string `json:"projectUid,omitempty"`
+}
+
+// RuntimeTopologyNodeRefComponentKind defines model for RuntimeTopologyNodeRefComponent.Kind.
+type RuntimeTopologyNodeRefComponentKind string
+
+// RuntimeTopologyNodeRefExternal Reference to an external node in the runtime topology.
+type RuntimeTopologyNodeRefExternal struct {
+	Component    *string                            `json:"component,omitempty"`
+	ComponentUid *openapi_types.UUID                `json:"componentUid,omitempty"`
+	ExternalHost *string                            `json:"externalHost,omitempty"`
+	Kind         RuntimeTopologyNodeRefExternalKind `json:"kind"`
+	Namespace    *string                            `json:"namespace,omitempty"`
+
+	// ProjectUid Included when the source is in a different project
+	ProjectUid *openapi_types.UUID `json:"projectUid,omitempty"`
+}
+
+// RuntimeTopologyNodeRefExternalKind defines model for RuntimeTopologyNodeRefExternal.Kind.
+type RuntimeTopologyNodeRefExternalKind string
+
+// RuntimeTopologyNodeRefGateway Reference to a gateway node in the runtime topology.
+type RuntimeTopologyNodeRefGateway struct {
+	// GatewayName Gateway name (e.g., internet, intranet)
+	GatewayName string                            `json:"gatewayName"`
+	Kind        RuntimeTopologyNodeRefGatewayKind `json:"kind"`
+	Namespace   *string                           `json:"namespace,omitempty"`
+	ProjectUid  *openapi_types.UUID               `json:"projectUid,omitempty"`
+}
+
+// RuntimeTopologyNodeRefGatewayKind defines model for RuntimeTopologyNodeRefGateway.Kind.
+type RuntimeTopologyNodeRefGatewayKind string
+
+// RuntimeTopologyRequest Request body for POST /api/v1alpha1/metrics/runtime-topology.
+// searchScope must include namespace, projectUid, and environmentUid —
+// runtime topology is project- and environment-scoped. The optional
+// componentUid, if set, restricts results to edges that touch that
+// component.
+type RuntimeTopologyRequest struct {
+	// EndTime The end time of the query window
+	EndTime time.Time `json:"endTime"`
+
+	// IncludeExternal Whether to include edges to/from components outside the requested
+	// project. Defaults to true.
+	IncludeExternal *bool `json:"includeExternal,omitempty"`
+
+	// IncludeGateways Whether to include gateway -> component edges. Defaults to true.
+	IncludeGateways *bool                `json:"includeGateways,omitempty"`
+	SearchScope     ComponentSearchScope `json:"searchScope"`
+
+	// StartTime The start time of the query window
+	StartTime time.Time `json:"startTime"`
+}
+
+// RuntimeTopologyResponse Runtime topology response. Nodes and edges only include entities for
+// which traffic was observed in the window — static topology comes from
+// a separate source.
+type RuntimeTopologyResponse struct {
+	Edges *[]RuntimeTopologyEdge `json:"edges,omitempty"`
+	Nodes *[]RuntimeTopologyNode `json:"nodes,omitempty"`
+
+	// Summary Metadata describing the query window.
+	Summary RuntimeTopologySummary `json:"summary"`
+}
+
+// RuntimeTopologySummary Metadata describing the query window.
+type RuntimeTopologySummary struct {
+	EndTime     time.Time `json:"endTime"`
+	GeneratedAt time.Time `json:"generatedAt"`
+	StartTime   time.Time `json:"startTime"`
+}
+
 // HandleAlertWebhookJSONBody defines parameters for HandleAlertWebhook.
 type HandleAlertWebhookJSONBody = map[string]interface{}
 
@@ -298,6 +518,9 @@ type UpdateAlertRuleJSONRequestBody = AlertRuleRequest
 
 // HandleAlertWebhookJSONRequestBody defines body for HandleAlertWebhook for application/json ContentType.
 type HandleAlertWebhookJSONRequestBody = HandleAlertWebhookJSONBody
+
+// QueryRuntimeTopologyJSONRequestBody defines body for QueryRuntimeTopology for application/json ContentType.
+type QueryRuntimeTopologyJSONRequestBody = RuntimeTopologyRequest
 
 // AsResourceMetricsTimeSeries returns the union data inside the MetricsQueryResponse as a ResourceMetricsTimeSeries
 func (t MetricsQueryResponse) AsResourceMetricsTimeSeries() (ResourceMetricsTimeSeries, error) {
@@ -357,6 +580,244 @@ func (t MetricsQueryResponse) MarshalJSON() ([]byte, error) {
 }
 
 func (t *MetricsQueryResponse) UnmarshalJSON(b []byte) error {
+	err := t.union.UnmarshalJSON(b)
+	return err
+}
+
+// AsRuntimeTopologyNodeComponent returns the union data inside the RuntimeTopologyNode as a RuntimeTopologyNodeComponent
+func (t RuntimeTopologyNode) AsRuntimeTopologyNodeComponent() (RuntimeTopologyNodeComponent, error) {
+	var body RuntimeTopologyNodeComponent
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromRuntimeTopologyNodeComponent overwrites any union data inside the RuntimeTopologyNode as the provided RuntimeTopologyNodeComponent
+func (t *RuntimeTopologyNode) FromRuntimeTopologyNodeComponent(v RuntimeTopologyNodeComponent) error {
+	v.Kind = "component"
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeRuntimeTopologyNodeComponent performs a merge with any union data inside the RuntimeTopologyNode, using the provided RuntimeTopologyNodeComponent
+func (t *RuntimeTopologyNode) MergeRuntimeTopologyNodeComponent(v RuntimeTopologyNodeComponent) error {
+	v.Kind = "component"
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsRuntimeTopologyNodeGateway returns the union data inside the RuntimeTopologyNode as a RuntimeTopologyNodeGateway
+func (t RuntimeTopologyNode) AsRuntimeTopologyNodeGateway() (RuntimeTopologyNodeGateway, error) {
+	var body RuntimeTopologyNodeGateway
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromRuntimeTopologyNodeGateway overwrites any union data inside the RuntimeTopologyNode as the provided RuntimeTopologyNodeGateway
+func (t *RuntimeTopologyNode) FromRuntimeTopologyNodeGateway(v RuntimeTopologyNodeGateway) error {
+	v.Kind = "gateway"
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeRuntimeTopologyNodeGateway performs a merge with any union data inside the RuntimeTopologyNode, using the provided RuntimeTopologyNodeGateway
+func (t *RuntimeTopologyNode) MergeRuntimeTopologyNodeGateway(v RuntimeTopologyNodeGateway) error {
+	v.Kind = "gateway"
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsRuntimeTopologyNodeExternal returns the union data inside the RuntimeTopologyNode as a RuntimeTopologyNodeExternal
+func (t RuntimeTopologyNode) AsRuntimeTopologyNodeExternal() (RuntimeTopologyNodeExternal, error) {
+	var body RuntimeTopologyNodeExternal
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromRuntimeTopologyNodeExternal overwrites any union data inside the RuntimeTopologyNode as the provided RuntimeTopologyNodeExternal
+func (t *RuntimeTopologyNode) FromRuntimeTopologyNodeExternal(v RuntimeTopologyNodeExternal) error {
+	v.Kind = "external"
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeRuntimeTopologyNodeExternal performs a merge with any union data inside the RuntimeTopologyNode, using the provided RuntimeTopologyNodeExternal
+func (t *RuntimeTopologyNode) MergeRuntimeTopologyNodeExternal(v RuntimeTopologyNodeExternal) error {
+	v.Kind = "external"
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+func (t RuntimeTopologyNode) Discriminator() (string, error) {
+	var discriminator struct {
+		Discriminator string `json:"kind"`
+	}
+	err := json.Unmarshal(t.union, &discriminator)
+	return discriminator.Discriminator, err
+}
+
+func (t RuntimeTopologyNode) ValueByDiscriminator() (interface{}, error) {
+	discriminator, err := t.Discriminator()
+	if err != nil {
+		return nil, err
+	}
+	switch discriminator {
+	case "component":
+		return t.AsRuntimeTopologyNodeComponent()
+	case "external":
+		return t.AsRuntimeTopologyNodeExternal()
+	case "gateway":
+		return t.AsRuntimeTopologyNodeGateway()
+	default:
+		return nil, errors.New("unknown discriminator value: " + discriminator)
+	}
+}
+
+func (t RuntimeTopologyNode) MarshalJSON() ([]byte, error) {
+	b, err := t.union.MarshalJSON()
+	return b, err
+}
+
+func (t *RuntimeTopologyNode) UnmarshalJSON(b []byte) error {
+	err := t.union.UnmarshalJSON(b)
+	return err
+}
+
+// AsRuntimeTopologyNodeRefComponent returns the union data inside the RuntimeTopologyNodeRef as a RuntimeTopologyNodeRefComponent
+func (t RuntimeTopologyNodeRef) AsRuntimeTopologyNodeRefComponent() (RuntimeTopologyNodeRefComponent, error) {
+	var body RuntimeTopologyNodeRefComponent
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromRuntimeTopologyNodeRefComponent overwrites any union data inside the RuntimeTopologyNodeRef as the provided RuntimeTopologyNodeRefComponent
+func (t *RuntimeTopologyNodeRef) FromRuntimeTopologyNodeRefComponent(v RuntimeTopologyNodeRefComponent) error {
+	v.Kind = "component"
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeRuntimeTopologyNodeRefComponent performs a merge with any union data inside the RuntimeTopologyNodeRef, using the provided RuntimeTopologyNodeRefComponent
+func (t *RuntimeTopologyNodeRef) MergeRuntimeTopologyNodeRefComponent(v RuntimeTopologyNodeRefComponent) error {
+	v.Kind = "component"
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsRuntimeTopologyNodeRefGateway returns the union data inside the RuntimeTopologyNodeRef as a RuntimeTopologyNodeRefGateway
+func (t RuntimeTopologyNodeRef) AsRuntimeTopologyNodeRefGateway() (RuntimeTopologyNodeRefGateway, error) {
+	var body RuntimeTopologyNodeRefGateway
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromRuntimeTopologyNodeRefGateway overwrites any union data inside the RuntimeTopologyNodeRef as the provided RuntimeTopologyNodeRefGateway
+func (t *RuntimeTopologyNodeRef) FromRuntimeTopologyNodeRefGateway(v RuntimeTopologyNodeRefGateway) error {
+	v.Kind = "gateway"
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeRuntimeTopologyNodeRefGateway performs a merge with any union data inside the RuntimeTopologyNodeRef, using the provided RuntimeTopologyNodeRefGateway
+func (t *RuntimeTopologyNodeRef) MergeRuntimeTopologyNodeRefGateway(v RuntimeTopologyNodeRefGateway) error {
+	v.Kind = "gateway"
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsRuntimeTopologyNodeRefExternal returns the union data inside the RuntimeTopologyNodeRef as a RuntimeTopologyNodeRefExternal
+func (t RuntimeTopologyNodeRef) AsRuntimeTopologyNodeRefExternal() (RuntimeTopologyNodeRefExternal, error) {
+	var body RuntimeTopologyNodeRefExternal
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromRuntimeTopologyNodeRefExternal overwrites any union data inside the RuntimeTopologyNodeRef as the provided RuntimeTopologyNodeRefExternal
+func (t *RuntimeTopologyNodeRef) FromRuntimeTopologyNodeRefExternal(v RuntimeTopologyNodeRefExternal) error {
+	v.Kind = "external"
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeRuntimeTopologyNodeRefExternal performs a merge with any union data inside the RuntimeTopologyNodeRef, using the provided RuntimeTopologyNodeRefExternal
+func (t *RuntimeTopologyNodeRef) MergeRuntimeTopologyNodeRefExternal(v RuntimeTopologyNodeRefExternal) error {
+	v.Kind = "external"
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+func (t RuntimeTopologyNodeRef) Discriminator() (string, error) {
+	var discriminator struct {
+		Discriminator string `json:"kind"`
+	}
+	err := json.Unmarshal(t.union, &discriminator)
+	return discriminator.Discriminator, err
+}
+
+func (t RuntimeTopologyNodeRef) ValueByDiscriminator() (interface{}, error) {
+	discriminator, err := t.Discriminator()
+	if err != nil {
+		return nil, err
+	}
+	switch discriminator {
+	case "component":
+		return t.AsRuntimeTopologyNodeRefComponent()
+	case "external":
+		return t.AsRuntimeTopologyNodeRefExternal()
+	case "gateway":
+		return t.AsRuntimeTopologyNodeRefGateway()
+	default:
+		return nil, errors.New("unknown discriminator value: " + discriminator)
+	}
+}
+
+func (t RuntimeTopologyNodeRef) MarshalJSON() ([]byte, error) {
+	b, err := t.union.MarshalJSON()
+	return b, err
+}
+
+func (t *RuntimeTopologyNodeRef) UnmarshalJSON(b []byte) error {
 	err := t.union.UnmarshalJSON(b)
 	return err
 }

--- a/observability-metrics-prometheus/internal/api/gen/server.gen.go
+++ b/observability-metrics-prometheus/internal/api/gen/server.gen.go
@@ -42,6 +42,9 @@ type ServerInterface interface {
 	// Handles triggered alerts from the alerting backend
 	// (POST /api/v1alpha1/alerts/webhook)
 	HandleAlertWebhook(w http.ResponseWriter, r *http.Request)
+	// Query runtime topology
+	// (POST /api/v1alpha1/metrics/runtime-topology)
+	QueryRuntimeTopology(w http.ResponseWriter, r *http.Request)
 	// Health check
 	// (GET /healthz)
 	Health(w http.ResponseWriter, r *http.Request)
@@ -164,6 +167,20 @@ func (siw *ServerInterfaceWrapper) HandleAlertWebhook(w http.ResponseWriter, r *
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.HandleAlertWebhook(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// QueryRuntimeTopology operation middleware
+func (siw *ServerInterfaceWrapper) QueryRuntimeTopology(w http.ResponseWriter, r *http.Request) {
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.QueryRuntimeTopology(w, r)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -313,6 +330,7 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 	m.HandleFunc("GET "+options.BaseURL+"/api/v1alpha1/alerts/rules/{ruleName}", wrapper.GetAlertRule)
 	m.HandleFunc("PUT "+options.BaseURL+"/api/v1alpha1/alerts/rules/{ruleName}", wrapper.UpdateAlertRule)
 	m.HandleFunc("POST "+options.BaseURL+"/api/v1alpha1/alerts/webhook", wrapper.HandleAlertWebhook)
+	m.HandleFunc("POST "+options.BaseURL+"/api/v1alpha1/metrics/runtime-topology", wrapper.QueryRuntimeTopology)
 	m.HandleFunc("GET "+options.BaseURL+"/healthz", wrapper.Health)
 
 	return m
@@ -574,6 +592,59 @@ func (response HandleAlertWebhook500JSONResponse) VisitHandleAlertWebhookRespons
 	return json.NewEncoder(w).Encode(response)
 }
 
+type QueryRuntimeTopologyRequestObject struct {
+	Body *QueryRuntimeTopologyJSONRequestBody
+}
+
+type QueryRuntimeTopologyResponseObject interface {
+	VisitQueryRuntimeTopologyResponse(w http.ResponseWriter) error
+}
+
+type QueryRuntimeTopology200JSONResponse RuntimeTopologyResponse
+
+func (response QueryRuntimeTopology200JSONResponse) VisitQueryRuntimeTopologyResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type QueryRuntimeTopology400JSONResponse ErrorResponse
+
+func (response QueryRuntimeTopology400JSONResponse) VisitQueryRuntimeTopologyResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type QueryRuntimeTopology401JSONResponse ErrorResponse
+
+func (response QueryRuntimeTopology401JSONResponse) VisitQueryRuntimeTopologyResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type QueryRuntimeTopology403JSONResponse ErrorResponse
+
+func (response QueryRuntimeTopology403JSONResponse) VisitQueryRuntimeTopologyResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type QueryRuntimeTopology500JSONResponse ErrorResponse
+
+func (response QueryRuntimeTopology500JSONResponse) VisitQueryRuntimeTopologyResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(500)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
 type HealthRequestObject struct {
 }
 
@@ -624,6 +695,9 @@ type StrictServerInterface interface {
 	// Handles triggered alerts from the alerting backend
 	// (POST /api/v1alpha1/alerts/webhook)
 	HandleAlertWebhook(ctx context.Context, request HandleAlertWebhookRequestObject) (HandleAlertWebhookResponseObject, error)
+	// Query runtime topology
+	// (POST /api/v1alpha1/metrics/runtime-topology)
+	QueryRuntimeTopology(ctx context.Context, request QueryRuntimeTopologyRequestObject) (QueryRuntimeTopologyResponseObject, error)
 	// Health check
 	// (GET /healthz)
 	Health(ctx context.Context, request HealthRequestObject) (HealthResponseObject, error)
@@ -836,6 +910,37 @@ func (sh *strictHandler) HandleAlertWebhook(w http.ResponseWriter, r *http.Reque
 	}
 }
 
+// QueryRuntimeTopology operation middleware
+func (sh *strictHandler) QueryRuntimeTopology(w http.ResponseWriter, r *http.Request) {
+	var request QueryRuntimeTopologyRequestObject
+
+	var body QueryRuntimeTopologyJSONRequestBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		sh.options.RequestErrorHandlerFunc(w, r, fmt.Errorf("can't decode JSON body: %w", err))
+		return
+	}
+	request.Body = &body
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.QueryRuntimeTopology(ctx, request.(QueryRuntimeTopologyRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "QueryRuntimeTopology")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(QueryRuntimeTopologyResponseObject); ok {
+		if err := validResponse.VisitQueryRuntimeTopologyResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
 // Health operation middleware
 func (sh *strictHandler) Health(w http.ResponseWriter, r *http.Request) {
 	var request HealthRequestObject
@@ -863,42 +968,64 @@ func (sh *strictHandler) Health(w http.ResponseWriter, r *http.Request) {
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+xa3W/bOBL/VwjeAXsHKHY+tg/1W5rmtjm0TTdpbh/a4DAWxxa3EqmQVFJv4P/9wA/Z",
-	"kkU5Thpns7i8tI5IzQxn5jdf4i1NZVFKgcJoOrqlOs2wAPfzMEdlzqocz/CqQm3ss1LJEpXh6HakUjBu",
-	"uBTdJRQwzpHZnwx1qnjp99HfMjQZKmIyJGA5EFXlSLgm9SsJNbMS6YiOpcwRBJ0nlAuD6hryLr3PGZJ6",
-	"lcgJMbxAYiS5qlDNyESuclqS10ZxMbXUreBgpIpTr1ct1UpjnCaKqqCjL3RqaEKnxj7KjfvHrV7RhAq8",
-	"opcR7iZTqDOZszj7xTK5hrzCtVIE2qIqxqgs7RsumLyJE/ZrD9PZPKEKryqurIm/0KXpAsOGxRrqbZ51",
-	"qQk5/h1TY6Ut0AADAzFPC056wXvUdFqiOMqkQkkWm8nFydvFuWhCJ1IVYOiIVhVnMUdAcc2VFMWGjBrb",
-	"781KQIFxBnbFWeVOv7U7dQnpGkJuuUuNHJ3FCJZKWltscvaw9Z7nXvEbp4TmOVoidOyRtP0g5kJaVsrr",
-	"o+1ABRrF0/ip/FobAOHZGDQyrzfdQHlaVv+tNEytwAUWUs0Wf44rNkUTAfrK0YNA3TN093lMLM6WNOJu",
-	"TAWNuK1LKTS+BO6XwN3wwpew+/8Ydv9akbIbE+Nh7jccZ1J+6490BWrHruc4brFtpxtPMmYnbcBUOk7L",
-	"r/WRqtWhqzRF7RSklFQbHT4clYupDernM5H2HxfSOqp3JfRrxMA3FMT+6AuFqUIwLp5XJat/iTQDMXW/",
-	"GeZon8ZiYg7aWBGRHZqesMgL1AaKstaVfYXomUhjKreivYH0Gwp20oOOsV8mJ2/JPywsJkoWRI61zSxj",
-	"nnMzq7f8czN82+fv5ZSnkPfxzP2y42nxviHl+zrQimG0U6yFO/A8aoCY9xzVcfkcQaXZeSpLvDvUbxCk",
-	"1wfGO6Lc3YWhpxSrcI4tdvpBwNAA76k4HOxq4FvVfoeizC35D1xrLqakFoNMOOZMk5+0AWU+8wJ/IiAY",
-	"+QkFc39FM5klfyQZruOeSoZNL0VF7H88bQt0+uZ85z97Ox929vdjrAw3OW54yOA/Y2B1L28RDZXJpOJ/",
-	"eJeSaswZQ1H3bgLycyfc8T0i1Ttjyg8uIWiro3NUwSZtC+VgUKSzT6927V/cYOEe/13hhI7o34bLmcQw",
-	"DCSGHaonBgu6lAGUgpmPQJ72623Sfv34tAsE8d7Tf3ziypv9SFbCPD71kNUmVX62VT6VeBpOMc8Or/5q",
-	"657egVgIDT2oFMwX7CHEd2o3m2t37I4Y3NeVZXazpeqLMiMJfse0Mk3oK1x0j5kxZTR363Z+WKfIaE7x",
-	"Cc7Hyt4cp8wPKEEbLPsoY9miadXA0KAquED32DdXdlMpuTDa7lBoKiUG5HgwHZC9IiGvioTs2X8Odu2v",
-	"jG7YxzePniz8oK3TyzvdapnRpMDTCR19WW+Gs2DVbsidJ+vfjAfq+eVSpBWQdHx9UcdtWOY5q2tHkFiw",
-	"bmx01z3HmfjGehMGshrHGu0Y0vuV2i2ayuo9L7gfnT9urEvLKoSZ7RC/qNuix85itsfbllI89e3pxdPf",
-	"imoiTa0bj01kGMgZSF1G8RMK2uj5PyM4gqv+zzU5/HRCdIkpn/AUXHvHcMIFaocIS1VBaojJwBAIrbom",
-	"wKA0qEhRaUO4LTdtVf9VGOkmclMFBskNN5mj0pDkNNSrA+LGEnX1mkKeO47aZblFeP0qfCiu+bqa1yzm",
-	"CHrRupVKXnOGjIxnfl2yKsfBV1uM5jzFEBSDag5LSDMk+4NdW8aqnI5cTtOj4fDm5mYAbnkg1XQY3tXD",
-	"9ydHxx/Pj3f2B7uDzBR5o4CmnfPVXWOwLDkM6jr8dEITeo1KewvsDXYHu2EMKaDkdEQPBruDA5rQEkzm",
-	"PGcIJR9e7w3DiYc+39lAInWkQf51vb5qwy3bBT/j5FLYTtW/HsSmi6rvjWSz2snQV0tQlnnwmOHv2k8M",
-	"vENv6O6tOmjeTopGVege+HTm9LC/u7slEULOdDK0lVnbz+qcIyPL4jF3aP/5EWVqt6QRYU7ENeScEVXr",
-	"zPLfezr+F812zzE/eDrm/1o0l/OEvnpatftWlvhelvhmdu6alqIAi8U26GyNAFNtS7saSJd2ewAy5GUG",
-	"e0M/5xyqKg9lQRTNR26QRkC0PpiIWAjsQNm/u/iWsyU0d77xbwTlvcflH5tsRkx5uNRhmFA+Q0S/fjr+",
-	"DX1ArhDYjOB3buui5wiyGgut+WgA2qH/anAHzoa39r+PUODcQy1HE+kL3rrnDwOdf7cNui0lsQd6fpi9",
-	"P0PP//lP8XwhDZnISrBn6fS1L651+oROMZI8fkGz4sR95XPHjX9B83Q+3LppsN5YysqN1y/u+xdxX+eC",
-	"d/huCQoKNKi0m1bd47s6tztso0Trz/K0DvB0tQZJGsdencddJrSsIgC6cB8vH5YI/LvPs/r603NQ+Cr8",
-	"7ED87PBTe+CDap768kBvd/EOBMtRE6P4dIpqcftimScg2LfXzT2J5k2KH/D0LvQDJTKWbEZSEGRs4Tgj",
-	"/z4//Uj8GCwhoAnjkwkqFKYjsSYFzIhGwRqbSpjlEpge0OhM7Ynxs3oFpRc7waAkc0p/gc+d8HmQg0fx",
-	"lSHkJvvDSh2ttY4yTL85in7nymWMTcdv79zLP1pxtT8xLK+MLG8GeCFnm9zz6mr+3AtPuCY1HWf8gx8Q",
-	"0l9masm4kmFHJJVCoL+CFK6vrL0gs6RUicc675LSiqN5o6fWCxouFMx56YiGh7c9M8ZQ2kK+HIAvy5p6",
-	"kDRPbvuzagECpm4QHyMR3LlLoSl77MVwiPnl/H8BAAD//5Kfq/vrMQAA",
+	"H4sIAAAAAAAC/+w823LbNtqvguGfmSYztGQn7UV05zr+E+/kVNvZXlSeLUR+EtGQAAOAdlSPZ/oQfcI+",
+	"yQ4OJEESlCjZcpxZ3yQ0QXwAvvMJug4iluWMApUimFwHIkogw/rxMAUuT4sUTuFLAUKqdzlnOXBJQH8R",
+	"MRoTSRjtDgHFsxRi9RiDiDjJzXfBrwnIBDiSCSCsVkC8SAERgcopYSCXOQSTYMZYCpgGN2FAqAR+idMu",
+	"vPMEUDmK2BxJkgGSDH0pgC/RnLVXqsELyQldKOhq41gy7odejiqohQA/TKBFFkx+CxYyCIOFVK9Sqf/R",
+	"o1+CMKDwJbjwrC4TDiJhaexfvhpGlzgtYOUuLGxaZDPgCvYVoTG78gM2Y9vh7CYMOHwpCFck/i2oSWcX",
+	"dCjmoNc9a40JNvsDIql2m4HEMZbYx2mWST+RHjR9yIEeJYwDQ9XH6NPJq+pcQRjMGc+wDCZBUZDYxwhA",
+	"LwlnNBu4kPP5xktRnIF/ATWiqbKWb9WXIsfRCkB6uAsNHZ36AOacKVoMObv9dMNzt/hGI8E9R2MLHXqE",
+	"TT7wsZBgBTf4aDJQBpKTyH8qM9YUAPtuhgXEBm/CkfIoL/5TCLxQG84gY3xZ/Tkr4gVIj6C3jm431D1D",
+	"9zsjE9XZQkfv+lDg6G2RMyrgUXE/Km6HCx/V7v+i2v2+NGVXJ/rV3K8wSxj73K/pMhB6uZ7j6MEmna4M",
+	"SB+dhMSyEH5YZqwPVIkOUUQRCI0gzhkfdHh7VEIXSqmfLWnUf1wclVq9u0MzhiT+DBSphz5VGHHAUuvz",
+	"Io/LJxolmC70cwwpqLc+nZhiIdUWIT6UPWqRZCAkzvISV2oKEksa+VCutvYzjj4DjU96pGNmhtHJK/RU",
+	"icWcswyxmVCWZUZSIpflJ8+Gybd6/5YtSITTvjVTM6zXVPI+EPKmDNQijNCIVeKOSeolgI97jkq9fAaY",
+	"R8lZxHJYr+oHKOnVinGNllvvGBpIPg/nWMlOvxDEIDHp8Ti02JWCr1D7FWd5qsC/I0IQukDlNtCcQBoL",
+	"9IOQmMtzksEPCNMY/QA01n95LZkCf8RiWLV6xGJwuRQ4Uv+RqLmhDz+f7f37YO/d3vPnvqUkkSkMPKTl",
+	"nxmOy1heSTQuZMI4+dOwFOMzEsdAy9iN4vRMb+54A031Rsr8nTYIQuHoDLilSZNCKZZAo+XHn/bVX0RC",
+	"pl8/4TAPJsH/jeucxNgmJMYdqCcSsqDeA+YcL40GMrBf7hL2y7uHnQGmbw38uwfODdmPWEHl3UO3Vm1e",
+	"pKc7Xaeg97OSj7Pt1F+U39ObELOqoUcqaWwcdqviO76bsrV76gufuK9yy9THCqpxyiRD8BWiQrqiz6GK",
+	"HhMpc6/tFk37sAqRXptiDJzRlb02jstbIEFIyPsgQ96AqdAQgwSeEQr6tQmu1Ec5I1QK9QUHWXA6Qsej",
+	"xQgdZCH6KQvRgfrnxb56SoKBcbx79LDigyZOL9ayVW3RGIUP82Dy22oynFqqdlXuTbh6pl9R31zUW2oJ",
+	"SYfXKz9uoJunqS40QKSEdTDRdfTsX8QE1kMWYMXMF2j7JL0fqV2nKS/ekoyY1Pnd6rooL6ya2Q3wT2VY",
+	"dNdWTMV4u0KKgb47vBj4O0GNl9MKqpj2nOUsZYvlcewLVA9p6SbGSHI8n5MIzVN2ZTxIjAyzIqqcSskQ",
+	"RhLzBUj9YmQSqg7H+lIMZxLPUkAkBirJnACvMkkQL2CEjhi9VEOMTqYUob0607M3Lfb3X0D19wT9/uRa",
+	"8OjICSZu7EdPrmNlrp2B3w20BZZwhZddWAj9bscmT67t03ucwVqI7f3BV+PPTtCK/VUfPbkuH98wIRXM",
+	"fnu8ljtaJLbMYsMhySKWGr/BWOl+01wlazZY7D2L4RTmmhc1T2w7v2XydIapcicsaOdAF+tZ/V2NvRa3",
+	"LxYcFK3Rm/Pzjza5JBC7tJln68hCbLOgI2R9ZmMLBMIcppRQJCBiNBYhyrCMEhXYjXFOxpcHYwtzrN2E",
+	"kabuquhkrQ1phxybTHg5cEIrOBgwo+3xD5iyyr3ezpJ2+UlTnCiKZ4SWqfsM57lidDcNsQGPVtKsw2cj",
+	"uhtMPy6nhIFVMhtMfm1n3FRMpFVUMAk+ExrrGsUwT27VsdY5cyv3tfHUCh/aG1y5sa74OlUAbZEq00VM",
+	"wpEbcEhaeOiKyAQRKRAuJT8upd4nm1H/2sohdFbHGaCn2kbmLEYpnkH6bOTT5OuLHM3Khg/o2rqD5gZH",
+	"09fnuNiFcRmUifMftqwwDEfguvKFU7MYbVwi1ohziDSkCLyKqX3+Vak07oFl13Lf+mKZ45x4IbZZrVKJ",
+	"347Thp3NR/mB5C3VnUchWZ2+G9o6XukgWpQG5nskRdg47UDCKP9xByb/FOa3tPqnML+V4T+F+Q5tf+N8",
+	"W9jwxu62mb3WCWjssCN2pzAHDjSyIWnLKegRvu/I3t/Svg/uINjYCH8jm34vNtxlyzUc17bp23LcQzPX",
+	"m6j4Jn5OaJQWsYqbEzDIsIkjIhR2MIrJXGNQlrTdzlUbTstem91SHg0DvgEhW7a5ucbrEqiWCBgtRqHp",
+	"RqMg9RPHFOSzIaK+yqY/NJPsVK7aONcDaMZi09bz8cPZeZkywWme4DpxYpG/5yDfKXOgrBASEcNutSoL",
+	"UX3aUBfSmw0F6J+//p7Sjj9GRDlvrz1pT6jl4hEyvX7qIDidUldCQ0TmSCiKclB4jKRQT0Vqqj8QL0Ag",
+	"mWCJJCuiRD86EHxctXmJD1U90cPqHRZ1TVU3x0Uqg4nkBYR9jZmswro9GBtrVV8bfcQKKUgMzVTalFoU",
+	"j9Ars5DGjlpr5CY/G22deiErRWKbPZZibdOvjtHVux++l29WttyMsC35dXftLx4OEue6YtiS57Ygcfvp",
+	"CCn1K4wwaTZhNF3WnEMlUayudMCUXiVESYWtOlxh0QmgbC/qP3/9rRuYdHOgXTFimYLDWTalGAnIMcey",
+	"NDte0VLbGVx38RVPPCUdZTW2Bqozlt6GhyzDfLkhtDM7q8MK9v0Agp/VCzfp/c728CLzekboosOoo1XK",
+	"bJhuWgAFRUXb3Te0au9I1zai4q2su1vxdNFrJTVntttdYuMam/bfwGmoPQesq3VtqScCHX48QSKHiMxJ",
+	"hHXvZAxzQrXJUPpKOQmRNPYDV6UKHONcArdmMMtTUMZqSrXqk7DQQqDTDLLZ2vvBNoMZg1b+hSKcpnpF",
+	"oe1L1bswpYa25bpa1cuqSVdUfZE5Z5dEeX6zpRlncZFaAUxJBFZ/WNQc5jhKAD0f7QdhUHAVUidS5mIy",
+	"Hl9dXY2wHh4xvhjbuWL89uTo+P3Z8d7z0f4okVnqdKcFnfOVLZk2b4EOLboOP54EYXAJXBgKHIz2R/u2",
+	"x5/inAST4MVof/RC8TCWiWZfb0VHV+mZz8f5ZTW+SsLVvXjmAgFh9CQup5fplqrA8jOLlyWT2aAB53lq",
+	"OWb8hzDtuEYlDKwlN5qMbprioCyhfmHUucbD8/39HW3Bmhe9h47C0VhTOCcQo7p0lGoV+eMd7qnZ7+nZ",
+	"zAm9xCmJS5fGrH9wf+t/cnsp9eIv7m/x/686N2/C4Kf7RbuNsU2jKDKdojeugWwKnS4XL4RS6qUgXajP",
+	"m3GGuUQw5kVqe2680nyku9RVqO/eRqI+FdgRZTO3uii1I2nuXKAdJMoHd7u+79qAh5SHNQ5t+/8DlOiX",
+	"97e+gw+ccsDxEsFXIqR4kEJWykLj8oEVtENzJWeNnI2v1X+6u8aIWgrSE1a80u+3Ezoztyl0OzJiW3K+",
+	"vdjyADn/x2/C+ZRJNGeFqWU8OKYveXEl06s4wWM8XoNsMXGf+9xh49cg74+HG9d4VxOLq33D5SP7fifs",
+	"q1lwDe/mmOMMJHChi4gbXFol6gsVKAXlndegVPBB2wcJnWO3I/GLMMgLjwB90jcDtzMEZu7D9L6+uQ2y",
+	"Vy4fnBA/OPkpOXArn6e8mdsbXbzBNE5BIMnJYgG8utpc2wls6dvL5gaEe035FpzeFX3uVmwiTNFMieMS",
+	"/evsw3tk0mAhwsKp67V3LFCGl0gAjd3iH16mDMfCqeq6ObV7lp/2/e5e2bEERYlG+qP4rBWfrRh8vXz1",
+	"1Qj7Je1UX8EyOdWUXNrG77LmUFUT5owjXLUd6Ir1glwCdSuCkynFKCVCKpOoE//oaY2/sCw5ibDuDqgy",
+	"qs90RaSerosRU/q0KnjYcnlZrrK3LNwbGeJZiABHicnudhvIpvRpKbQRK6gMq/vA+g/bFI5y4BFQSVIQ",
+	"z3RVrFAwuh3wU1PhKfvgT6rrG7oJ3l5tU3QVbpb508krocs1OoeN0xQ4ImJK4WsOkVpIMpTh3HynKK9e",
+	"JEWG6Z4Kg/VNEV3UNQlkT4q0VbLYkXnvKWzfs5Lqq8d5hLJTkXvMnD5mTtdnTtsdEb0p1ARwKpM/deeL",
+	"L+Q9SkAJcwLIfNn6wYmhVZA3evJtA99mGbL+WYz61w/MJpdDfsumi94zs3lEBCrhaAq/uMUmzQ+2NPbY",
+	"CnQmKGKUgvmZFfsTHSt/BKSGVNC7Om8NqWXvDdEjxQUOD1lyXmig9uV1T6nHZhhcq1lHl3Uf8nV/cJNh",
+	"ihe6HuoDYb2KLgR3776J9hA3Fzf/DQAA//9PgkDFz1IAAA==",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/observability-metrics-prometheus/internal/handlers.go
+++ b/observability-metrics-prometheus/internal/handlers.go
@@ -120,9 +120,9 @@ func (h *MetricsHandler) QueryMetrics(ctx context.Context, request gen.QueryMetr
 	endTime := request.Body.EndTime
 
 	switch request.Body.Metric {
-	case gen.Resource:
+	case gen.MetricsQueryRequestMetricResource:
 		return h.queryResourceMetrics(ctx, labelFilter, sumByClause, groupLeftClause, startTime, endTime, step)
-	case gen.Http:
+	case gen.MetricsQueryRequestMetricHttp:
 		return h.queryHTTPMetrics(ctx, labelFilter, sumByClause, groupLeftClause, startTime, endTime, step)
 	default:
 		return badRequestMetrics(fmt.Sprintf("unknown metric type: %s", request.Body.Metric)), nil
@@ -393,7 +393,7 @@ func (h *MetricsHandler) UpdateAlertRule(ctx context.Context, request gen.Update
 			Detail: strPtr(fmt.Sprintf("metadata.name %q must match ruleName %q", params.Name, request.RuleName)),
 		}, nil
 	}
-	
+
 	newRule, err := prometheus.BuildPrometheusRule(params, h.alertNamespace)
 	if err != nil {
 		return gen.UpdateAlertRule400JSONResponse{
@@ -671,11 +671,11 @@ func mapPrometheusRuleToAlertRuleResponse(pr *monitoringv1.PrometheusRule, ruleN
 	operator, threshold := extractPromOperatorAndThreshold(expr)
 	enabled := true
 	resp.Condition = &struct {
-		Enabled   *bool                                  `json:"enabled,omitempty"`
-		Interval  *string                                `json:"interval,omitempty"`
+		Enabled   *bool                                   `json:"enabled,omitempty"`
+		Interval  *string                                 `json:"interval,omitempty"`
 		Operator  *gen.AlertRuleResponseConditionOperator `json:"operator,omitempty"`
-		Threshold *float32                               `json:"threshold,omitempty"`
-		Window    *string                                `json:"window,omitempty"`
+		Threshold *float32                                `json:"threshold,omitempty"`
+		Window    *string                                 `json:"window,omitempty"`
 	}{
 		Enabled: &enabled,
 	}
@@ -846,6 +846,255 @@ func badRequestMetrics(detail string) gen.QueryMetrics400JSONResponse {
 
 func serverErrorMetrics(detail string) gen.QueryMetrics500JSONResponse {
 	return gen.QueryMetrics500JSONResponse{
+		Title:  errorTitle(gen.InternalServerError),
+		Detail: strPtr(detail),
+	}
+}
+
+// ----------------------------
+// Runtime topoloy
+// ----------------------------
+
+// QueryRuntimeTopology returns the live HTTP traffic topology (nodes + edges
+// with aggregated metrics) for a project in a given environment.
+//
+// Current implementation scope (minimal scaffolding):
+//   - component -> component edges via Hubble's hubble_http_requests_total,
+//     aggregated by (source component UID, destination component UID).
+//   - request count only — error count and latency percentiles are TODO.
+//   - gateway -> component and component -> external edges are TODO.
+//   - per-node aggregates are TODO.
+func (h *MetricsHandler) QueryRuntimeTopology(
+	ctx context.Context,
+	request gen.QueryRuntimeTopologyRequestObject,
+) (gen.QueryRuntimeTopologyResponseObject, error) {
+	if h.promClient == nil {
+		return badOrServerErrorRuntimeTopology500("Prometheus client not configured"), nil
+	}
+	if request.Body == nil {
+		return badOrServerErrorRuntimeTopology400("request body is required"), nil
+	}
+
+	scope := request.Body.SearchScope
+	if scope.Namespace == "" {
+		return badOrServerErrorRuntimeTopology400("searchScope.namespace is required"), nil
+	}
+	projectUID := derefString(scope.ProjectUid)
+	environmentUID := derefString(scope.EnvironmentUid)
+	if projectUID == "" {
+		return badOrServerErrorRuntimeTopology400("searchScope.projectUid is required"), nil
+	}
+	if environmentUID == "" {
+		return badOrServerErrorRuntimeTopology400("searchScope.environmentUid is required"), nil
+	}
+	componentUIDFilter := derefString(scope.ComponentUid)
+
+	startTime := request.Body.StartTime
+	endTime := request.Body.EndTime
+	durationSec := endTime.Sub(startTime).Seconds()
+	if durationSec <= 0 {
+		return badOrServerErrorRuntimeTopology400("endTime must be after startTime"), nil
+	}
+
+	durationStr := fmt.Sprintf("%.0fs", durationSec)
+
+	// Filter by project + environment UIDs. Component UID filter is applied in
+	// buildEdgeMetricMap so edges touching the component on either side are included.
+	labelFilter := prometheus.BuildRuntimeTopologyLabelFilter(scope.Namespace, "", projectUID, environmentUID)
+
+	type runtimeTopologyQuerySpec struct {
+		name    string
+		queryFn func(string) string
+		dest    *map[edgeKey]float64
+	}
+
+	var (
+		mu              sync.Mutex
+		firstErr        error
+		requestCountMap = map[edgeKey]float64{}
+		errorCountMap   = map[edgeKey]float64{}
+		avgLatencyMap   = map[edgeKey]float64{}
+		p50LatencyMap   = map[edgeKey]float64{}
+		p90LatencyMap   = map[edgeKey]float64{}
+		p99LatencyMap   = map[edgeKey]float64{}
+	)
+
+	queries := []runtimeTopologyQuerySpec{
+		{"requestCount", func(f string) string {
+			return prometheus.BuildRuntimeTopologyComponentEdgeRequestCountQuery(durationStr, f)
+		}, &requestCountMap},
+		{"errorCount", func(f string) string {
+			return prometheus.BuildRuntimeTopologyComponentEdgeErrorCountQuery(durationStr, f)
+		}, &errorCountMap},
+		{"avgLatency", func(f string) string {
+			return prometheus.BuildRuntimeTopologyComponentEdgeMeanLatencyQuery(durationStr, f)
+		}, &avgLatencyMap},
+		{"p50Latency", func(f string) string {
+			return prometheus.BuildRuntimeTopologyComponentEdgeLatencyPercentileQuery("0.5", durationStr, f)
+		}, &p50LatencyMap},
+		{"p90Latency", func(f string) string {
+			return prometheus.BuildRuntimeTopologyComponentEdgeLatencyPercentileQuery("0.9", durationStr, f)
+		}, &p90LatencyMap},
+		{"p99Latency", func(f string) string {
+			return prometheus.BuildRuntimeTopologyComponentEdgeLatencyPercentileQuery("0.99", durationStr, f)
+		}, &p99LatencyMap},
+	}
+
+	var wg sync.WaitGroup
+	for _, q := range queries {
+		wg.Add(1)
+		go func(q runtimeTopologyQuerySpec) {
+			defer wg.Done()
+			query := q.queryFn(labelFilter)
+			h.logger.Debug("Runtime topology query", "name", q.name, "query", query)
+			resp, err := h.promClient.QueryInstant(ctx, query, endTime)
+			if err != nil {
+				h.logger.Error("Runtime topology sub-query failed", "metric", q.name, "error", err)
+				mu.Lock()
+				if firstErr == nil {
+					firstErr = fmt.Errorf("sub-query %q failed: %w", q.name, err)
+				}
+				mu.Unlock()
+				return
+			}
+			m := buildEdgeMetricMap(resp.Data.Result, componentUIDFilter)
+			mu.Lock()
+			*q.dest = m
+			mu.Unlock()
+		}(q)
+	}
+	wg.Wait()
+
+	if firstErr != nil {
+		h.logger.Error("Runtime topology query failed", "error", firstErr)
+		return badOrServerErrorRuntimeTopology500(fmt.Sprintf("query failed: %v", firstErr)), nil
+	}
+
+	edges := buildRuntimeTopologyEdges(
+		scope.Namespace, projectUID,
+		requestCountMap, errorCountMap, avgLatencyMap, p50LatencyMap, p90LatencyMap, p99LatencyMap,
+	)
+
+	response := gen.RuntimeTopologyResponse{
+		Edges: &edges,
+		// TODO: populate Nodes once per-node aggregate queries are implemented.
+		Nodes: nil,
+		Summary: gen.RuntimeTopologySummary{
+			StartTime:   startTime,
+			EndTime:     endTime,
+			GeneratedAt: time.Now().UTC(),
+		},
+	}
+	return runtimeTopologyOKResponse(response), nil
+}
+
+// edgeKey identifies a directed HTTP edge between two components. UIDs are the
+// stable identity; names come from the same pod labels and are carried for the response.
+type edgeKey struct {
+	srcUID  string
+	dstUID  string
+	srcName string
+	dstName string
+}
+
+// buildEdgeMetricMap converts Prometheus instant query results into a map from
+// edge key to metric value. UIDs are required; names are included when present.
+func buildEdgeMetricMap(
+	series []prometheus.TimeSeries,
+	componentUIDFilter string,
+) map[edgeKey]float64 {
+	m := make(map[edgeKey]float64, len(series))
+	for _, ts := range series {
+		srcUID := ts.Metric[prometheus.RuntimeTopologySrcComponentUIDLabel]
+		dstUID := ts.Metric[prometheus.RuntimeTopologyDstComponentUIDLabel]
+		if srcUID == "" || dstUID == "" {
+			continue
+		}
+		if componentUIDFilter != "" && srcUID != componentUIDFilter && dstUID != componentUIDFilter {
+			continue
+		}
+		srcName := ts.Metric[prometheus.RuntimeTopologySrcComponentNameLabel]
+		dstName := ts.Metric[prometheus.RuntimeTopologyDstComponentNameLabel]
+		points := prometheus.ConvertTimeSeriesToTimeValuePoints(ts)
+		if len(points) == 0 || points[0].Value <= 0 {
+			continue
+		}
+		m[edgeKey{srcUID, dstUID, srcName, dstName}] += points[0].Value
+	}
+	return m
+}
+
+// buildRuntimeTopologyEdges assembles RuntimeTopologyEdge values from per-metric
+// maps. Request count drives which edges exist; other maps default to zero when absent.
+func buildRuntimeTopologyEdges(
+	namespace string,
+	projectUID string,
+	requestCountMap, errorCountMap, avgLatencyMap, p50LatencyMap, p90LatencyMap, p99LatencyMap map[edgeKey]float64,
+) []gen.RuntimeTopologyEdge {
+	edges := make([]gen.RuntimeTopologyEdge, 0, len(requestCountMap))
+	for key, requestCount := range requestCountMap {
+		if requestCount <= 0 {
+			continue
+		}
+
+		ns := namespace
+		proj := projectUID
+		errorCount := errorCountMap[key]
+		avgLatency := avgLatencyMap[key]
+		p50Latency := p50LatencyMap[key]
+		p90Latency := p90LatencyMap[key]
+		p99Latency := p99LatencyMap[key]
+
+		var source, target gen.RuntimeTopologyNodeRef
+		_ = source.FromRuntimeTopologyNodeRefComponent(gen.RuntimeTopologyNodeRefComponent{
+			Kind:         gen.RuntimeTopologyNodeRefComponentKindComponent,
+			Component:    key.srcName,
+			ComponentUid: key.srcUID,
+			ProjectUid:   &proj,
+			Namespace:    &ns,
+		})
+		_ = target.FromRuntimeTopologyNodeRefComponent(gen.RuntimeTopologyNodeRefComponent{
+			Kind:         gen.RuntimeTopologyNodeRefComponentKindComponent,
+			Component:    key.dstName,
+			ComponentUid: key.dstUID,
+			ProjectUid:   &proj,
+			Namespace:    &ns,
+		})
+		edges = append(edges, gen.RuntimeTopologyEdge{
+			Id:       fmt.Sprintf("%s->%s", key.srcUID, key.dstUID),
+			Source:   source,
+			Target:   target,
+			Protocol: gen.RuntimeTopologyEdgeProtocolHttp,
+			Metrics: &gen.RuntimeTopologyMetrics{
+				RequestCount:             &requestCount,
+				UnsuccessfulRequestCount: &errorCount,
+				MeanLatency:              &avgLatency,
+				LatencyP50:               &p50Latency,
+				LatencyP90:               &p90Latency,
+				LatencyP99:               &p99Latency,
+			},
+		})
+	}
+	return edges
+}
+
+// runtimeTopologyOKResponse wraps the 200 response so the strict-server
+// codegen accepts the value. Unlike MetricsQueryResponse (which is a oneOf
+// union), RuntimeTopologyResponse is a plain object — but we keep a thin
+// helper for symmetry.
+func runtimeTopologyOKResponse(r gen.RuntimeTopologyResponse) gen.QueryRuntimeTopology200JSONResponse {
+	return gen.QueryRuntimeTopology200JSONResponse(r)
+}
+
+func badOrServerErrorRuntimeTopology400(detail string) gen.QueryRuntimeTopology400JSONResponse {
+	return gen.QueryRuntimeTopology400JSONResponse{
+		Title:  errorTitle(gen.BadRequest),
+		Detail: strPtr(detail),
+	}
+}
+
+func badOrServerErrorRuntimeTopology500(detail string) gen.QueryRuntimeTopology500JSONResponse {
+	return gen.QueryRuntimeTopology500JSONResponse{
 		Title:  errorTitle(gen.InternalServerError),
 		Detail: strPtr(detail),
 	}

--- a/observability-metrics-prometheus/internal/handlers.go
+++ b/observability-metrics-prometheus/internal/handlers.go
@@ -852,16 +852,16 @@ func serverErrorMetrics(detail string) gen.QueryMetrics500JSONResponse {
 }
 
 // ----------------------------
-// Runtime topoloy
+// Runtime topology
 // ----------------------------
 
 // QueryRuntimeTopology returns the live HTTP traffic topology (nodes + edges
 // with aggregated metrics) for a project in a given environment.
 //
-// Current implementation scope (minimal scaffolding):
+// Current implementation scope:
 //   - component -> component edges via Hubble's hubble_http_requests_total,
 //     aggregated by (source component UID, destination component UID).
-//   - request count only — error count and latency percentiles are TODO.
+//   - request count, error count, mean latency, and p50/p90/p99 percentiles.
 //   - gateway -> component and component -> external edges are TODO.
 //   - per-node aggregates are TODO.
 func (h *MetricsHandler) QueryRuntimeTopology(
@@ -903,9 +903,10 @@ func (h *MetricsHandler) QueryRuntimeTopology(
 	labelFilter := prometheus.BuildRuntimeTopologyLabelFilter(scope.Namespace, "", projectUID, environmentUID)
 
 	type runtimeTopologyQuerySpec struct {
-		name    string
-		queryFn func(string) string
-		dest    *map[edgeKey]float64
+		name      string
+		queryFn   func(string) string
+		dest      *map[edgeKey]float64
+		namesDest *map[edgeKey]edgeNames // only set for the request-count query
 	}
 
 	var (
@@ -917,27 +918,28 @@ func (h *MetricsHandler) QueryRuntimeTopology(
 		p50LatencyMap   = map[edgeKey]float64{}
 		p90LatencyMap   = map[edgeKey]float64{}
 		p99LatencyMap   = map[edgeKey]float64{}
+		namesMap        = map[edgeKey]edgeNames{}
 	)
 
 	queries := []runtimeTopologyQuerySpec{
 		{"requestCount", func(f string) string {
 			return prometheus.BuildRuntimeTopologyComponentEdgeRequestCountQuery(durationStr, f)
-		}, &requestCountMap},
+		}, &requestCountMap, &namesMap},
 		{"errorCount", func(f string) string {
 			return prometheus.BuildRuntimeTopologyComponentEdgeErrorCountQuery(durationStr, f)
-		}, &errorCountMap},
+		}, &errorCountMap, nil},
 		{"avgLatency", func(f string) string {
 			return prometheus.BuildRuntimeTopologyComponentEdgeMeanLatencyQuery(durationStr, f)
-		}, &avgLatencyMap},
+		}, &avgLatencyMap, nil},
 		{"p50Latency", func(f string) string {
 			return prometheus.BuildRuntimeTopologyComponentEdgeLatencyPercentileQuery("0.5", durationStr, f)
-		}, &p50LatencyMap},
+		}, &p50LatencyMap, nil},
 		{"p90Latency", func(f string) string {
 			return prometheus.BuildRuntimeTopologyComponentEdgeLatencyPercentileQuery("0.9", durationStr, f)
-		}, &p90LatencyMap},
+		}, &p90LatencyMap, nil},
 		{"p99Latency", func(f string) string {
 			return prometheus.BuildRuntimeTopologyComponentEdgeLatencyPercentileQuery("0.99", durationStr, f)
-		}, &p99LatencyMap},
+		}, &p99LatencyMap, nil},
 	}
 
 	var wg sync.WaitGroup
@@ -957,9 +959,12 @@ func (h *MetricsHandler) QueryRuntimeTopology(
 				mu.Unlock()
 				return
 			}
-			m := buildEdgeMetricMap(resp.Data.Result, componentUIDFilter)
+			m, names := buildEdgeMetricMap(resp.Data.Result, componentUIDFilter)
 			mu.Lock()
 			*q.dest = m
+			if q.namesDest != nil {
+				*q.namesDest = names
+			}
 			mu.Unlock()
 		}(q)
 	}
@@ -972,6 +977,7 @@ func (h *MetricsHandler) QueryRuntimeTopology(
 
 	edges := buildRuntimeTopologyEdges(
 		scope.Namespace, projectUID,
+		namesMap,
 		requestCountMap, errorCountMap, avgLatencyMap, p50LatencyMap, p90LatencyMap, p99LatencyMap,
 	)
 
@@ -988,22 +994,30 @@ func (h *MetricsHandler) QueryRuntimeTopology(
 	return runtimeTopologyOKResponse(response), nil
 }
 
-// edgeKey identifies a directed HTTP edge between two components. UIDs are the
-// stable identity; names come from the same pod labels and are carried for the response.
+// edgeKey identifies a directed HTTP edge between two components by UID only.
+// UIDs are the stable identity across all parallel metric queries.
 type edgeKey struct {
-	srcUID  string
-	dstUID  string
+	srcUID string
+	dstUID string
+}
+
+// edgeNames carries display names for an edge, derived from pod labels. Names
+// are sourced from the request-count query only so all metric maps share the
+// same UID-keyed identity.
+type edgeNames struct {
 	srcName string
 	dstName string
 }
 
 // buildEdgeMetricMap converts Prometheus instant query results into a map from
-// edge key to metric value. UIDs are required; names are included when present.
+// edge key (UIDs only) to metric value, and a secondary map of display names.
+// UIDs are required; names are best-effort from pod labels.
 func buildEdgeMetricMap(
 	series []prometheus.TimeSeries,
 	componentUIDFilter string,
-) map[edgeKey]float64 {
+) (map[edgeKey]float64, map[edgeKey]edgeNames) {
 	m := make(map[edgeKey]float64, len(series))
+	names := make(map[edgeKey]edgeNames, len(series))
 	for _, ts := range series {
 		srcUID := ts.Metric[prometheus.RuntimeTopologySrcComponentUIDLabel]
 		dstUID := ts.Metric[prometheus.RuntimeTopologyDstComponentUIDLabel]
@@ -1013,22 +1027,27 @@ func buildEdgeMetricMap(
 		if componentUIDFilter != "" && srcUID != componentUIDFilter && dstUID != componentUIDFilter {
 			continue
 		}
-		srcName := ts.Metric[prometheus.RuntimeTopologySrcComponentNameLabel]
-		dstName := ts.Metric[prometheus.RuntimeTopologyDstComponentNameLabel]
 		points := prometheus.ConvertTimeSeriesToTimeValuePoints(ts)
 		if len(points) == 0 || points[0].Value <= 0 {
 			continue
 		}
-		m[edgeKey{srcUID, dstUID, srcName, dstName}] += points[0].Value
+		key := edgeKey{srcUID, dstUID}
+		m[key] += points[0].Value
+		names[key] = edgeNames{
+			srcName: ts.Metric[prometheus.RuntimeTopologySrcComponentNameLabel],
+			dstName: ts.Metric[prometheus.RuntimeTopologyDstComponentNameLabel],
+		}
 	}
-	return m
+	return m, names
 }
 
 // buildRuntimeTopologyEdges assembles RuntimeTopologyEdge values from per-metric
 // maps. Request count drives which edges exist; other maps default to zero when absent.
+// namesMap carries display names sourced from the request-count query (UID-stable).
 func buildRuntimeTopologyEdges(
 	namespace string,
 	projectUID string,
+	namesMap map[edgeKey]edgeNames,
 	requestCountMap, errorCountMap, avgLatencyMap, p50LatencyMap, p90LatencyMap, p99LatencyMap map[edgeKey]float64,
 ) []gen.RuntimeTopologyEdge {
 	edges := make([]gen.RuntimeTopologyEdge, 0, len(requestCountMap))
@@ -1044,18 +1063,19 @@ func buildRuntimeTopologyEdges(
 		p50Latency := p50LatencyMap[key]
 		p90Latency := p90LatencyMap[key]
 		p99Latency := p99LatencyMap[key]
+		n := namesMap[key]
 
 		var source, target gen.RuntimeTopologyNodeRef
 		_ = source.FromRuntimeTopologyNodeRefComponent(gen.RuntimeTopologyNodeRefComponent{
 			Kind:         gen.RuntimeTopologyNodeRefComponentKindComponent,
-			Component:    key.srcName,
+			Component:    n.srcName,
 			ComponentUid: key.srcUID,
 			ProjectUid:   &proj,
 			Namespace:    &ns,
 		})
 		_ = target.FromRuntimeTopologyNodeRefComponent(gen.RuntimeTopologyNodeRefComponent{
 			Kind:         gen.RuntimeTopologyNodeRefComponentKindComponent,
-			Component:    key.dstName,
+			Component:    n.dstName,
 			ComponentUid: key.dstUID,
 			ProjectUid:   &proj,
 			Namespace:    &ns,

--- a/observability-metrics-prometheus/internal/handlers_integration_test.go
+++ b/observability-metrics-prometheus/internal/handlers_integration_test.go
@@ -126,7 +126,7 @@ func TestQueryResourceMetrics_Success(t *testing.T) {
 	handler := NewMetricsHandler(promClient, nil, nil, "test-ns", testLogger())
 
 	body := gen.MetricsQueryRequest{
-		Metric:    gen.Resource,
+		Metric:    gen.MetricsQueryRequestMetricResource,
 		StartTime: time.Now().Add(-1 * time.Hour),
 		EndTime:   time.Now(),
 		SearchScope: gen.ComponentSearchScope{
@@ -157,7 +157,7 @@ func TestQueryHTTPMetrics_Success(t *testing.T) {
 	handler := NewMetricsHandler(promClient, nil, nil, "test-ns", testLogger())
 
 	body := gen.MetricsQueryRequest{
-		Metric:    gen.Http,
+		Metric:    gen.MetricsQueryRequestMetricHttp,
 		StartTime: time.Now().Add(-1 * time.Hour),
 		EndTime:   time.Now(),
 		SearchScope: gen.ComponentSearchScope{
@@ -222,7 +222,7 @@ func TestQueryMetrics_PrometheusError(t *testing.T) {
 	handler := NewMetricsHandler(promClient, nil, nil, "test-ns", testLogger())
 
 	body := gen.MetricsQueryRequest{
-		Metric:    gen.Resource,
+		Metric:    gen.MetricsQueryRequestMetricResource,
 		StartTime: time.Now().Add(-1 * time.Hour),
 		EndTime:   time.Now(),
 		SearchScope: gen.ComponentSearchScope{
@@ -291,7 +291,7 @@ func TestQueryMetrics_WithCustomStep(t *testing.T) {
 
 	step := "10m"
 	body := gen.MetricsQueryRequest{
-		Metric:    gen.Resource,
+		Metric:    gen.MetricsQueryRequestMetricResource,
 		StartTime: time.Now().Add(-1 * time.Hour),
 		EndTime:   time.Now(),
 		Step:      &step,

--- a/observability-metrics-prometheus/internal/handlers_test.go
+++ b/observability-metrics-prometheus/internal/handlers_test.go
@@ -96,7 +96,7 @@ func TestQueryMetrics_MissingNamespace(t *testing.T) {
 	defer mockServer.Close()
 
 	body := gen.MetricsQueryRequest{
-		Metric:      gen.Resource,
+		Metric:      gen.MetricsQueryRequestMetricResource,
 		StartTime:   time.Now().Add(-1 * time.Hour),
 		EndTime:     time.Now(),
 		SearchScope: gen.ComponentSearchScope{Namespace: ""},
@@ -117,7 +117,7 @@ func TestQueryMetrics_InvalidStep(t *testing.T) {
 
 	invalidStep := "invalid"
 	body := gen.MetricsQueryRequest{
-		Metric:      gen.Resource,
+		Metric:      gen.MetricsQueryRequestMetricResource,
 		StartTime:   time.Now().Add(-1 * time.Hour),
 		EndTime:     time.Now(),
 		Step:        &invalidStep,
@@ -139,7 +139,7 @@ func TestQueryMetrics_NegativeStep(t *testing.T) {
 
 	negStep := "-5m"
 	body := gen.MetricsQueryRequest{
-		Metric:      gen.Resource,
+		Metric:      gen.MetricsQueryRequestMetricResource,
 		StartTime:   time.Now().Add(-1 * time.Hour),
 		EndTime:     time.Now(),
 		Step:        &negStep,

--- a/observability-metrics-prometheus/internal/prometheus/client.go
+++ b/observability-metrics-prometheus/internal/prometheus/client.go
@@ -113,6 +113,28 @@ func (c *Client) QueryRangeTimeSeries(ctx context.Context, query string, start, 
 	return tsResp, nil
 }
 
+// QueryInstant executes a PromQL instant query at the given time and returns results
+// in the same TimeSeriesResponse format as QueryRangeTimeSeries.
+func (c *Client) QueryInstant(ctx context.Context, query string, t time.Time) (*TimeSeriesResponse, error) {
+	c.logger.Debug("Executing Prometheus instant query", "time", t)
+
+	result, warnings, err := c.api.Query(ctx, query, t)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute instant query: %w", err)
+	}
+
+	if len(warnings) > 0 {
+		c.logger.Warn("Prometheus instant query returned warnings", "warnings", warnings)
+	}
+
+	tsResp := convertToTimeSeriesResponse(result)
+
+	c.logger.Debug("Prometheus instant query executed successfully",
+		"series_count", len(tsResp.Data.Result))
+
+	return tsResp, nil
+}
+
 func convertToTimeSeriesResponse(result model.Value) *TimeSeriesResponse {
 	tsResp := &TimeSeriesResponse{
 		Status: "success",

--- a/observability-metrics-prometheus/internal/prometheus/queries.go
+++ b/observability-metrics-prometheus/internal/prometheus/queries.go
@@ -14,6 +14,9 @@ const (
 	LabelProjectUID     = "openchoreo.dev/project-uid"
 	LabelEnvironmentUID = "openchoreo.dev/environment-uid"
 	LabelNamespace      = "openchoreo.dev/namespace"
+	LabelComponent      = "openchoreo.dev/component"
+	LabelProject        = "openchoreo.dev/project"
+	LabelEnvironment    = "openchoreo.dev/environment"
 )
 
 // prometheusLabelName converts a Kubernetes label name to a Prometheus metric label name.
@@ -271,4 +274,143 @@ func Build90thPercentileHTTPRequestLatencyQuery(labelFilter, sumByClause, groupL
 // Build99thPercentileHTTPRequestLatencyQuery builds a PromQL query for 99th percentile HTTP request latency.
 func Build99thPercentileHTTPRequestLatencyQuery(labelFilter, sumByClause, groupLeftClause string) string {
 	return buildHTTPRequestLatencyPercentileQuery("0.99", labelFilter, sumByClause, groupLeftClause)
+}
+
+// ----------------------------
+// Runtime topology queries
+// ----------------------------
+
+// Output label names used by runtime topology queries to carry the resolved
+// OpenChoreo component names and UIDs after the kube_pod_labels join.
+const (
+	RuntimeTopologySrcComponentNameLabel = "src_component"
+	RuntimeTopologyDstComponentNameLabel = "dst_component"
+	RuntimeTopologySrcComponentUIDLabel  = "src_component_uid"
+	RuntimeTopologyDstComponentUIDLabel  = "dst_component_uid"
+)
+
+// BuildRuntimeTopologyLabelFilter builds a Prometheus label filter for runtime
+// topology queries using UID labels (same convention as BuildLabelFilter).
+func BuildRuntimeTopologyLabelFilter(namespace, componentUID, projectUID, environmentUID string) string {
+	namespaceLabel := prometheusLabelName(LabelNamespace)
+	componentLabel := prometheusLabelName(LabelComponentUID)
+	projectLabel := prometheusLabelName(LabelProjectUID)
+	environmentLabel := prometheusLabelName(LabelEnvironmentUID)
+
+	filter := fmt.Sprintf("%s=%q", namespaceLabel, namespace)
+	if componentUID != "" {
+		filter = fmt.Sprintf("%s,%s=%q", filter, componentLabel, componentUID)
+	}
+	if projectUID != "" {
+		filter = fmt.Sprintf("%s,%s=%q", filter, projectLabel, projectUID)
+	}
+	if environmentUID != "" {
+		filter = fmt.Sprintf("%s,%s=%q", filter, environmentLabel, environmentUID)
+	}
+	return filter
+}
+
+// buildHubblePodMappingExprWithSide returns a PromQL expression that joins
+// kube_pod_labels (filtered by labelFilter) onto Hubble's per-side keys.
+// `side` is either "source" or "destination". The resulting series carries
+// both a name label (`outputNameLabel`) and a UID label (`outputUIDLabel`)
+// for the OpenChoreo component.
+func buildHubblePodMappingExprWithSide(side, outputNameLabel, outputUIDLabel, labelFilter string) string {
+	nsLabel := side + "_namespace"
+	podLabel := side + "_pod"
+	componentNameLabel := prometheusLabelName(LabelComponent)
+	componentUIDLabel := prometheusLabelName(LabelComponentUID)
+	return fmt.Sprintf(`label_replace(
+            label_replace(
+                label_replace(
+                    label_replace(
+                        kube_pod_labels{job="kube-state-metrics",%s},
+                        "%s", "$1", "namespace", "(.*)"
+                    ),
+                    "%s", "$1", "pod", "(.*)"
+                ),
+                "%s", "$1", "%s", "(.*)"
+            ),
+            "%s", "$1", "%s", "(.*)"
+        )`, labelFilter, nsLabel, podLabel, outputNameLabel, componentNameLabel, outputUIDLabel, componentUIDLabel)
+}
+
+// buildRuntimeTopologyIncreaseQuery builds a PromQL sum-by expression that
+// aggregates the total increase of a Hubble metric over the given duration by
+// (src_component, dst_component, src_component_uid, dst_component_uid).
+// extraMatcher is an optional additional Hubble label selector.
+// duration must be a valid PromQL duration string (e.g. "3600s").
+func buildRuntimeTopologyIncreaseQuery(metric, extraMatcher, labelFilter, duration string) string {
+	src := RuntimeTopologySrcComponentNameLabel
+	dst := RuntimeTopologyDstComponentNameLabel
+	srcUID := RuntimeTopologySrcComponentUIDLabel
+	dstUID := RuntimeTopologyDstComponentUIDLabel
+	srcMapping := buildHubblePodMappingExprWithSide("source", src, srcUID, labelFilter)
+	dstMapping := buildHubblePodMappingExprWithSide("destination", dst, dstUID, labelFilter)
+
+	// Join dst side first (server reporter), then join src side.
+	withDst := fmt.Sprintf(
+		`increase(%s{reporter="server"%s}[%s])
+            * on(destination_namespace, destination_pod) group_left(%s, %s) %s`,
+		metric, extraMatcher, duration, dst, dstUID, dstMapping)
+
+	return fmt.Sprintf(`
+    sum by (%s, %s, %s, %s) (
+        (%s)
+        * on(source_namespace, source_pod) group_left(%s, %s) %s
+    )`, src, dst, srcUID, dstUID, withDst, src, srcUID, srcMapping)
+}
+
+// BuildRuntimeTopologyComponentEdgeRequestCountQuery builds a PromQL instant query
+// returning the total HTTP request count per (src_component_uid, dst_component_uid)
+// edge over the given duration window.
+func BuildRuntimeTopologyComponentEdgeRequestCountQuery(duration, labelFilter string) string {
+	return buildRuntimeTopologyIncreaseQuery("hubble_http_requests_total", "", labelFilter, duration) + "\n    > 0"
+}
+
+// BuildRuntimeTopologyComponentEdgeErrorCountQuery builds a PromQL instant query
+// returning the total 4xx/5xx error count per (src_component_uid, dst_component_uid)
+// edge over the given duration window.
+func BuildRuntimeTopologyComponentEdgeErrorCountQuery(duration, labelFilter string) string {
+	return buildRuntimeTopologyIncreaseQuery(
+		"hubble_http_requests_total", `,status=~"^[45]..?$"`, labelFilter, duration,
+	) + "\n    > 0"
+}
+
+// BuildRuntimeTopologyComponentEdgeMeanLatencyQuery builds a PromQL instant query
+// for mean HTTP request latency per (src_component_uid, dst_component_uid) edge
+// over the given duration window. Result is in seconds.
+func BuildRuntimeTopologyComponentEdgeMeanLatencyQuery(duration, labelFilter string) string {
+	durationSum := buildRuntimeTopologyIncreaseQuery("hubble_http_request_duration_seconds_sum", "", labelFilter, duration)
+	requestCount := buildRuntimeTopologyIncreaseQuery("hubble_http_requests_total", "", labelFilter, duration)
+	return fmt.Sprintf("(%s\n    /\n%s)\n    >= 0", durationSum, requestCount)
+}
+
+// buildRuntimeTopologyBucketQuery returns the histogram bucket increase expression
+// keyed by (src_component, dst_component, src_component_uid, dst_component_uid, le).
+func buildRuntimeTopologyBucketQuery(duration, labelFilter string) string {
+	src := RuntimeTopologySrcComponentNameLabel
+	dst := RuntimeTopologyDstComponentNameLabel
+	srcUID := RuntimeTopologySrcComponentUIDLabel
+	dstUID := RuntimeTopologyDstComponentUIDLabel
+	srcMapping := buildHubblePodMappingExprWithSide("source", src, srcUID, labelFilter)
+	dstMapping := buildHubblePodMappingExprWithSide("destination", dst, dstUID, labelFilter)
+
+	withDst := fmt.Sprintf(
+		`increase(hubble_http_request_duration_seconds_bucket{reporter="server"}[%s])
+            * on(destination_namespace, destination_pod) group_left(%s, %s) %s`,
+		duration, dst, dstUID, dstMapping)
+
+	return fmt.Sprintf(`
+    sum by (%s, %s, %s, %s, le) (
+        (%s)
+        * on(source_namespace, source_pod) group_left(%s, %s) %s
+    )`, src, dst, srcUID, dstUID, withDst, src, srcUID, srcMapping)
+}
+
+// BuildRuntimeTopologyComponentEdgeLatencyPercentileQuery builds a PromQL instant
+// query using histogram_quantile for the given quantile (e.g. "0.5", "0.9", "0.99")
+// over the given duration window. Result is in seconds.
+func BuildRuntimeTopologyComponentEdgeLatencyPercentileQuery(quantile, duration, labelFilter string) string {
+	return fmt.Sprintf("histogram_quantile(%s,\n%s)\n    >= 0", quantile, buildRuntimeTopologyBucketQuery(duration, labelFilter))
 }


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat: add observability-logs-opensearch module
  fix: handle opensearch startup delay in init script
  docs: update observability-logs-opensearch module installation guide
  chore(deps): bump fluent-bit version in observability-logs-openobserve module

See: https://github.com/openchoreo/openchoreo/blob/main/docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
This pull request introduces a new API endpoint for querying runtime topology, updates the Helm chart version to `0.6.0`, and expands label allowlisting for metrics. It also includes several documentation improvements and minor code refactoring for clarity and compatibility.

**API Additions:**

* Added a new `POST /api/v1alpha1/metrics/runtime-topology` endpoint with corresponding request/response types and handler logic in `server.gen.go` to support querying runtime topology. [[1]](diffhunk://#diff-1b59754b320ec77348dd1ba01cece76e6b2631d9beaffa329d5eecf8f0d794f8R45-R47) [[2]](diffhunk://#diff-1b59754b320ec77348dd1ba01cece76e6b2631d9beaffa329d5eecf8f0d794f8R179-R192) [[3]](diffhunk://#diff-1b59754b320ec77348dd1ba01cece76e6b2631d9beaffa329d5eecf8f0d794f8R333) [[4]](diffhunk://#diff-1b59754b320ec77348dd1ba01cece76e6b2631d9beaffa329d5eecf8f0d794f8R595-R647) [[5]](diffhunk://#diff-1b59754b320ec77348dd1ba01cece76e6b2631d9beaffa329d5eecf8f0d794f8R698-R700) [[6]](diffhunk://#diff-1b59754b320ec77348dd1ba01cece76e6b2631d9beaffa329d5eecf8f0d794f8R913-R943)

**Helm Chart Updates:**

* Bumped the chart and app version to `0.6.0` in `Chart.yaml` and updated all installation instructions in `README.md` to use the new version. [[1]](diffhunk://#diff-eadc59792294d2b5f86647ce9b9dacdfbf8df5ec0fba252d2f479571bf4bd601L8-R9) [[2]](diffhunk://#diff-cd9a22f94b880d9966ed711708447660bf86443fe08e4db574cb1480d5db3ba4L30-R30) [[3]](diffhunk://#diff-cd9a22f94b880d9966ed711708447660bf86443fe08e4db574cb1480d5db3ba4L42-R42) [[4]](diffhunk://#diff-cd9a22f94b880d9966ed711708447660bf86443fe08e4db574cb1480d5db3ba4L56-R56)
* Expanded `metricLabelsAllowlist` for `pods` to include additional labels (`openchoreo.dev/component`, `openchoreo.dev/project`, `openchoreo.dev/environment`) in `values.yaml`.

**Documentation Improvements:**

* Improved table formatting and consistency in `README.md` for configuration and compatibility sections. [[1]](diffhunk://#diff-cd9a22f94b880d9966ed711708447660bf86443fe08e4db574cb1480d5db3ba4L68-R68) [[2]](diffhunk://#diff-cd9a22f94b880d9966ed711708447660bf86443fe08e4db574cb1480d5db3ba4L121-R126)

**Code Maintenance:**

* Refactored metric type case statements in `handlers.go` to use explicit enum values for clarity and maintainability.

**Swagger Spec:**

* Updated the embedded Swagger specification to reflect the new API endpoint and changes.

## Approach
> Summarize the solution and implementation details.

## Related Issues
https://github.com/openchoreo/openchoreo/issues/3111

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
Adapter spec from: https://github.com/openchoreo/openchoreo.github.io/pull/606
Observer implementation: https://github.com/openchoreo/openchoreo/pull/3451


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added runtime topology query capability to visualize component-to-component HTTP interactions with request counts, error rates, and latency metrics.

* **Documentation**
  * Updated Prometheus observability module documentation with Helm chart 0.6.0 details and compatibility guidance; clarified configuration options.

* **Chores**
  * Prometheus module version bumped to 0.6.0.
  * Enhanced metric label allowlist for improved component observability tracking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openchoreo/community-modules/pull/102)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->