### PR TITLE
fix: rename agent ClusterComponentType to ai-agent

### DIFF
--- a/agent-sandbox/README.md
+++ b/agent-sandbox/README.md
@@ -8,7 +8,7 @@ This module installs the [kubernetes-sigs/agent-sandbox](https://github.com/kube
 
 - Installs the upstream `kubernetes-sigs/agent-sandbox` controller and CRDs on the data plane cluster via a Helm pre-install hook
 - Grants the data plane `cluster-agent` service account permissions to manage `SandboxTemplate`, `SandboxClaim`, `SandboxWarmPool`, and `Sandbox` resources
-- The core OpenChoreo `agent` ClusterComponentType renders the sandbox resources; this module provides the upstream controller that fulfills them on the data plane
+- Registers the `ai-agent` ClusterComponentType (`proxy/ai-agent`) that renders sandbox resources via the standard OpenChoreo pipeline; this module provides the upstream controller that fulfills them on the data plane
 
 ## Upstream CRDs installed
 
@@ -72,8 +72,9 @@ kubectl get clusterrole openchoreo-agent-sandbox-access
 | `dataPlaneNamespace` | `openchoreo-data-plane` | Data plane namespace (for RBAC binding) |
 | `dataPlaneServiceAccount` | `cluster-agent-dataplane` | Data plane SA for RBAC |
 | `upstream.install` | `true` | Install upstream controller via pre-install Job |
-| `upstream.version` | `v0.4.3` | Upstream release version |
-| `upstream.manifestURL` | `""` | Override manifest URL (auto-built from version if empty) |
+| `upstream.version` | `v0.4.6` | Upstream release version |
+| `upstream.manifestURL` | `""` | Override core manifest URL (auto-built from version if empty) |
+| `upstream.extensionsManifestURL` | `""` | Override extensions manifest URL (auto-built from version if empty) |
 
 ## Uninstall
 

--- a/agent-sandbox/helm/Chart.yaml
+++ b/agent-sandbox/helm/Chart.yaml
@@ -21,4 +21,4 @@ sources:
 annotations:
   openchoreo.dev/module-category: AI
   openchoreo.dev/upstream-controller: "kubernetes-sigs/agent-sandbox"
-  openchoreo.dev/upstream-version: "v0.4.3"
+  openchoreo.dev/upstream-version: "v0.4.6"

--- a/agent-sandbox/helm/Chart.yaml
+++ b/agent-sandbox/helm/Chart.yaml
@@ -5,8 +5,8 @@ description: |
   enabling SandboxTemplate, SandboxClaim, and SandboxWarmPool support for
   OpenChoreo agent workloads with kernel-level isolation (runc/gvisor/kata).
 type: application
-version: 0.1.0
-appVersion: "0.1.0"
+version: 0.1.1
+appVersion: "0.1.1"
 keywords:
   - openchoreo
   - agent

--- a/agent-sandbox/helm/templates/agent-clustercomponenttype.yaml
+++ b/agent-sandbox/helm/templates/agent-clustercomponenttype.yaml
@@ -1,7 +1,7 @@
 apiVersion: openchoreo.dev/v1alpha1
 kind: ClusterComponentType
 metadata:
-  name: agent
+  name: ai-agent
   annotations:
     openchoreo.dev/description: "An AI agent workload with kernel-level sandbox isolation via kubernetes-sigs/agent-sandbox"
 spec:

--- a/agent-sandbox/helm/templates/agent-clustercomponenttype.yaml
+++ b/agent-sandbox/helm/templates/agent-clustercomponenttype.yaml
@@ -3,6 +3,7 @@ kind: ClusterComponentType
 metadata:
   name: ai-agent
   annotations:
+    openchoreo.dev/display-name: "AI Agent"
     openchoreo.dev/description: "An AI agent workload with kernel-level sandbox isolation via kubernetes-sigs/agent-sandbox"
 spec:
   workloadType: proxy

--- a/agent-sandbox/helm/values.yaml
+++ b/agent-sandbox/helm/values.yaml
@@ -17,7 +17,7 @@ upstream:
   # manifests before the rest of the chart is deployed.
   install: true
   # version: the kubernetes-sigs/agent-sandbox release tag to install.
-  version: "v0.4.3"
+  version: "v0.4.6"
   # manifestURL: override the full URL for the core manifest; leave empty
   # to auto-build from the version.
   manifestURL: ""


### PR DESCRIPTION
## Summary
- Renames the `agent` ClusterComponentType to `ai-agent`
- Component reference changes from `proxy/agent` to `proxy/ai-agent`

### Related
- Original module PR: openchoreo/community-modules#94

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Renamed registered component identifier from "agent" to "ai-agent".
  * Bumped module/chart upstream version from v0.4.3 to v0.4.6 and chart version to 0.1.1; updated default upstream chart reference.

* **Documentation**
  * README updated to reflect ai-agent registration and added config options to override upstream manifest URLs (manifestURL and extensionsManifestURL).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openchoreo/community-modules/pull/104)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->