### PR TITLE
feat: add OpenCost based FinOps module

### DIFF
--- a/finops-opencost/README.md
+++ b/finops-opencost/README.md
@@ -1,0 +1,53 @@
+# FinOps Module with OpenCost
+
+This module provides FinOps capabilities for OpenChoreo using [OpenCost](https://opencost.io/), an open source cost monitoring tool for Kubernetes.
+
+This OpenCost based FinOps module integrates with OpenChoreo through the FinOps agent by making use of the Model Context Protocol (MCP).
+
+## Prerequisites
+
+- A running Kubernetes cluster
+- [Helm](https://helm.sh/) v3+
+- [OpenChoreo](https://openchoreo.dev) installed with the **observability plane** enabled (for Prometheus integration)
+- An OpenChoreo metrics module - E.g. [Prometheus metrics module](https://github.com/openchoreo/community-modules/tree/main/observability-metrics-prometheus) 
+
+## Installation
+
+OpenCost is installed via its official Helm chart. For full documentation, refer to the [OpenCost Helm installation guide](https://opencost.io/docs/installation/helm).
+
+### Add the OpenCost Helm repository
+
+```bash
+helm repo add opencost https://opencost.github.io/opencost-helm-chart
+helm repo update
+```
+
+### Install OpenCost
+
+```bash
+helm upgrade --install opencost opencost/opencost \
+  --namespace opencost \
+  --create-namespace \
+  --version 2.5.14 \
+  -f values.yaml
+```
+
+## Sample values file
+
+A sample [`values.yaml`](./values.yaml) is provided with this module. If you are following the [OpenChoreo try-it-out guide](https://openchoreo.dev/docs/category/try-it-out/), you can use this sample values file as-is to install OpenCost integrated with the OpenChoreo observability plane.
+
+The sample values configure OpenCost to:
+
+- Use the OpenChoreo observability plane Prometheus (`openchoreo-observability-prometheus` in the `openchoreo-observability-plane` namespace) as its metrics source.
+- Use `k3d-local-cluster` as the default cluster ID (matching the try-it-out cluster).
+- Apply a custom pricing model.
+- Expose metrics via a `ServiceMonitor` for Prometheus scraping.
+- Disable the OpenCost UI (the FinOps agent consumes data via MCP).
+
+## Verification
+
+Verify that OpenCost is running:
+
+```bash
+kubectl get pods -n openchoreo-observability-plane | grep opencost
+```

--- a/finops-opencost/values.yaml
+++ b/finops-opencost/values.yaml
@@ -1,0 +1,42 @@
+opencost:
+  prometheus:
+    internal:
+      namespaceName: openchoreo-observability-plane
+      serviceName: openchoreo-observability-prometheus
+      port: 9091
+
+  dataRetention:
+    dailyResolutionDays: 30  # default: 15
+
+  exporter:
+    defaultClusterId: k3d-local-cluster
+    replicas: 1
+    resources:
+      requests:
+        cpu: "10m"
+        memory: "60Mi"
+      limits:
+        cpu: "50m"
+        memory: "100Mi"
+    persistence:
+      enabled: false
+
+  customPricing:
+    enabled: true
+    costModel:
+      description: Modified prices based on your internal pricing
+      CPU: 0.03
+      RAM: 0.004
+      storage: 0.00005
+
+  metrics:
+    kubeStateMetrics:
+      emitKsmV1Metrics: true
+      emitKsmV1MetricsOnly: false
+    serviceMonitor:
+      enabled: true
+      additionalLabels:
+        release: prometheus
+
+  ui:
+    enabled: false


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat: add observability-logs-opensearch module
  fix: handle opensearch startup delay in init script
  docs: update observability-logs-opensearch module installation guide
  chore(deps): bump fluent-bit version in observability-logs-openobserve module

See: https://github.com/openchoreo/openchoreo/blob/main/docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
Add OpenCost based FinOps module for OpenChoreo

## Approach
Adds a README with deployment instructions and a sample helm values file for use with OpenChoreo Try out guides

## Related Issues
https://github.com/openchoreo/openchoreo/issues/3323

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
