### PR TITLE
refactor: change the OpenCost namespace and use the values file URL for installation

### DIFF
--- a/finops-opencost/README.md
+++ b/finops-opencost/README.md
@@ -26,10 +26,9 @@ helm repo update
 
 ```bash
 helm upgrade --install opencost opencost/opencost \
-  --namespace opencost \
-  --create-namespace \
+  --namespace openchoreo-observability-plane \
   --version 2.5.14 \
-  -f values.yaml
+  -f https://raw.githubusercontent.com/openchoreo/community-modules/main/finops-opencost/values.yaml
 ```
 
 ## Sample values file


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat: add observability-logs-opensearch module
  fix: handle opensearch startup delay in init script
  docs: update observability-logs-opensearch module installation guide
  chore(deps): bump fluent-bit version in observability-logs-openobserve module

See: https://github.com/openchoreo/openchoreo/blob/main/docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
Update the OpenCost helm install command to deploy OpenCost in the Observability Plane namespace and use the values file committed to this repository for installation

## Approach
- Changed the namespace name from `opencost` to `openchoreo-observability-plane`
- Changed the helm value file path to the GitHub URL of the file
## Related Issues
https://github.com/openchoreo/openchoreo/issues/3323

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Helm installation example to deploy OpenCost into the `openchoreo-observability-plane` namespace with simplified command syntax.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openchoreo/community-modules/pull/109)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->