### PR TITLE
fix: enable serviceMonitor in Cilium module README

### DIFF
--- a/networking-cilium/README.md
+++ b/networking-cilium/README.md
@@ -38,7 +38,7 @@ hubble:
       - drop
       - tcp
     serviceMonitor:
-      enabled: false
+      enabled: true
 
 envoy:
   enabled: true


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat: add observability-logs-opensearch module
  fix: handle opensearch startup delay in init script
  docs: update observability-logs-opensearch module installation guide
  chore(deps): bump fluent-bit version in observability-logs-openobserve module

See: https://github.com/openchoreo/openchoreo/blob/main/docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
This pull request makes a small change to the `networking-cilium/README.md` file, enabling the `serviceMonitor` by default. This will allow monitoring tools like Prometheus to automatically discover and scrape metrics from Cilium services.

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
