### PR TITLE
docs(ai-gateway-agentgateway): add sample RBAC commands for cluster-agent

### DIFF
--- a/ai-gateway-agentgateway/README.md
+++ b/ai-gateway-agentgateway/README.md
@@ -166,9 +166,39 @@ maps to the OpenBao secret path `secret/<apiKeyRef>` with property `value`.
 > [!TIP]
 > When a component with these traits is deployed, the cluster-agent in the data
 > plane needs permissions to create Agent Gateway CRs (`AgentgatewayBackend`,
-> `AgentgatewayPolicy`, `HTTPRoute`, etc.). Follow the
+> `AgentgatewayPolicy`, etc.). Follow the
 > [cluster-agent RBAC guide](https://openchoreo.dev/docs/platform-engineer-guide/cluster-agent-rbac/)
 > to add the required permissions.
+>
+> For example:
+>
+> ```bash
+> kubectl apply -f - <<EOF
+> apiVersion: rbac.authorization.k8s.io/v1
+> kind: ClusterRole
+> metadata:
+>   name: cluster-agent-custom-permissions
+> rules:
+>   - apiGroups: ["agentgateway.dev"]
+>     resources: ["agentgatewaybackends", "agentgatewaypolicies"]
+>     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+> EOF
+>
+> kubectl apply -f - <<EOF
+> apiVersion: rbac.authorization.k8s.io/v1
+> kind: ClusterRoleBinding
+> metadata:
+>   name: cluster-agent-custom-permissions
+> roleRef:
+>   apiGroup: rbac.authorization.k8s.io
+>   kind: ClusterRole
+>   name: cluster-agent-custom-permissions
+> subjects:
+>   - kind: ServiceAccount
+>     name: cluster-agent-dataplane
+>     namespace: openchoreo-data-plane
+> EOF
+> ```
 
 ## Samples
 


### PR DESCRIPTION
## Purpose

The AI Gateway module README mentions that the cluster-agent in the data plane needs additional RBAC permissions to manage Agent Gateway CRs, but only links out to the RBAC guide. This PR adds copy-pasteable sample commands so users can quickly grant the missing permissions.

## Approach

- Add a "For example:" section under the existing tip in `ai-gateway-agentgateway/README.md`
- Include sample `kubectl apply` commands for a `ClusterRole` and `ClusterRoleBinding` granting the cluster-agent permissions on `agentgatewaybackends` and `agentgatewaypolicies`

## Related Issues

N/A

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added RBAC configuration examples demonstrating required permissions for cluster-agent components to create Agent Gateway resources.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openchoreo/community-modules/pull/113?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->