### PR TITLE
fix(observability-tracing-openobserve): return empty result when stream not yet created

### DIFF
--- a/observability-tracing-openobserve/helm/Chart.yaml
+++ b/observability-tracing-openobserve/helm/Chart.yaml
@@ -5,8 +5,8 @@ apiVersion: v2
 name: observability-tracing-openobserve
 description: A Helm chart for OpenChoreo Tracing Module for OpenObserve
 type: application
-version: 0.2.2
-appVersion: "0.2.2"
+version: 0.2.3
+appVersion: "0.2.3"
 keywords:
   - openobserve
   - openchoreo

--- a/observability-tracing-openobserve/internal/openobserve/client.go
+++ b/observability-tracing-openobserve/internal/openobserve/client.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -14,6 +15,32 @@ import (
 	"strings"
 	"time"
 )
+
+// openObserveStreamNotFoundCode is the OpenObserve error code returned when
+// a search target stream has not yet been created (lazy stream creation).
+// Surfaced as HTTP 400 with body {"code":20002,"message":"Search stream not found: ..."}.
+const openObserveStreamNotFoundCode = 20002
+
+// ErrStreamNotFound is returned by executeSearchQuery when OpenObserve reports
+// the search stream does not yet exist. Callers should treat this as an empty
+// result set, not a retrieval failure.
+var ErrStreamNotFound = errors.New("openobserve stream not found")
+
+// isStreamNotFound parses an OpenObserve error envelope and returns true when
+// code == openObserveStreamNotFoundCode.
+func isStreamNotFound(body []byte) bool {
+	if len(body) == 0 {
+		return false
+	}
+
+	var envelope struct {
+		Code int `json:"code"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return false
+	}
+	return envelope.Code == openObserveStreamNotFoundCode
+}
 
 // Scope holds the filtering scope for trace queries.
 type Scope struct {
@@ -157,6 +184,9 @@ func (c *Client) executeSearchQuery(ctx context.Context, queryJSON []byte) (*Ope
 	}
 
 	if resp.StatusCode != http.StatusOK {
+		if isStreamNotFound(body) {
+			return nil, ErrStreamNotFound
+		}
 		c.logger.Error("OpenObserve returned error",
 			slog.Int("statusCode", resp.StatusCode),
 			slog.String("body", string(body)))
@@ -184,6 +214,9 @@ func (c *Client) GetTraces(ctx context.Context, params TracesQueryParams) (*Trac
 	}
 
 	openObserveResp, err := c.executeSearchQuery(ctx, queryJSON)
+	if errors.Is(err, ErrStreamNotFound) {
+		return &TracesResult{Traces: []TraceEntry{}, Total: 0, TookMs: 0}, nil
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -264,6 +297,13 @@ func (c *Client) GetTraces(ctx context.Context, params TracesQueryParams) (*Trac
 		return nil, fmt.Errorf("failed to generate traces count query: %w", err)
 	}
 	countResp, err := c.executeSearchQuery(ctx, countQueryJSON)
+	if errors.Is(err, ErrStreamNotFound) {
+		return &TracesResult{
+			Traces: traces,
+			Total:  len(traces),
+			TookMs: openObserveResp.Took,
+		}, nil
+	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute traces count query: %w", err)
 	}
@@ -283,6 +323,9 @@ func (c *Client) GetSpans(ctx context.Context, params TracesQueryParams) (*Spans
 	}
 
 	openObserveResp, err := c.executeSearchQuery(ctx, queryJSON)
+	if errors.Is(err, ErrStreamNotFound) {
+		return &SpansResult{Spans: []SpanEntry{}, Total: 0, TookMs: 0}, nil
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -299,6 +342,13 @@ func (c *Client) GetSpans(ctx context.Context, params TracesQueryParams) (*Spans
 		return nil, fmt.Errorf("failed to generate spans count query: %w", err)
 	}
 	countResp, err := c.executeSearchQuery(ctx, countQueryJSON)
+	if errors.Is(err, ErrStreamNotFound) {
+		return &SpansResult{
+			Spans:  spans,
+			Total:  len(spans),
+			TookMs: openObserveResp.Took,
+		}, nil
+	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute spans count query: %w", err)
 	}
@@ -318,6 +368,9 @@ func (c *Client) GetSpanDetail(ctx context.Context, params TracesQueryParams) (*
 	}
 
 	openObserveResp, err := c.executeSearchQuery(ctx, queryJSON)
+	if errors.Is(err, ErrStreamNotFound) {
+		return nil, fmt.Errorf("span not found: traceId=%s, spanId=%s", params.TraceID, params.SpanID)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/observability-tracing-openobserve/internal/openobserve/client_test.go
+++ b/observability-tracing-openobserve/internal/openobserve/client_test.go
@@ -1044,3 +1044,140 @@ func TestIsStreamNotFound(t *testing.T) {
 		})
 	}
 }
+
+func TestGetSpanDetail_StreamNotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(`{"code":20002,"message":"Search stream not found: default"}`))
+	}))
+	defer server.Close()
+
+	client := newTestClient(server.URL)
+	_, err := client.GetSpanDetail(context.Background(), TracesQueryParams{
+		TraceID: "trace-1",
+		SpanID:  "span-1",
+	})
+	if err == nil {
+		t.Fatal("expected error for stream not found")
+	}
+	if !strings.Contains(err.Error(), "span not found") {
+		t.Errorf("expected 'span not found' error, got: %v", err)
+	}
+}
+
+func TestGetTraces_StreamNotFound_CountQueryOnly(t *testing.T) {
+	startNs := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC).UnixNano()
+	endNs := time.Date(2025, 1, 1, 12, 0, 1, 0, time.UTC).UnixNano()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if isCountQuery(r) {
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte(`{"code":20002,"message":"Search stream not found: default"}`))
+			return
+		}
+		resp := OpenObserveResponse{
+			Took: 5,
+			Hits: []map[string]interface{}{
+				{
+					"trace_id":       "trace-1",
+					"span_id":        "span-1",
+					"operation_name": "op-1",
+					"start_time":     json.Number(fmt.Sprintf("%d", startNs)),
+					"end_time":       json.Number(fmt.Sprintf("%d", endNs)),
+					"duration":       json.Number(fmt.Sprintf("%d", endNs-startNs)),
+					"service.name":   "svc-1",
+				},
+				{
+					"trace_id":       "trace-2",
+					"span_id":        "span-2",
+					"operation_name": "op-2",
+					"start_time":     json.Number(fmt.Sprintf("%d", startNs)),
+					"end_time":       json.Number(fmt.Sprintf("%d", endNs)),
+					"duration":       json.Number(fmt.Sprintf("%d", endNs-startNs)),
+					"service.name":   "svc-2",
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := newTestClient(server.URL)
+	result, err := client.GetTraces(context.Background(), TracesQueryParams{
+		Scope:     Scope{Namespace: "ns"},
+		StartTime: time.Unix(0, startNs),
+		EndTime:   time.Unix(0, endNs),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if len(result.Traces) != 2 {
+		t.Errorf("expected 2 traces, got %d", len(result.Traces))
+	}
+	if result.Total != len(result.Traces) {
+		t.Errorf("expected Total == len(Traces) (%d), got %d",
+			len(result.Traces), result.Total)
+	}
+}
+
+func TestGetSpans_StreamNotFound_CountQueryOnly(t *testing.T) {
+	startNs := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC).UnixNano()
+	endNs := time.Date(2025, 1, 1, 12, 0, 1, 0, time.UTC).UnixNano()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if isCountQuery(r) {
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte(`{"code":20002,"message":"Search stream not found: default"}`))
+			return
+		}
+		resp := OpenObserveResponse{
+			Took: 3,
+			Hits: []map[string]interface{}{
+				{
+					"span_id":        "span-1",
+					"operation_name": "op-1",
+					"span_kind":      "SERVER",
+					"start_time":     json.Number(fmt.Sprintf("%d", startNs)),
+					"end_time":       json.Number(fmt.Sprintf("%d", endNs)),
+					"duration":       json.Number(fmt.Sprintf("%d", endNs-startNs)),
+				},
+				{
+					"span_id":        "span-2",
+					"operation_name": "op-2",
+					"span_kind":      "CLIENT",
+					"start_time":     json.Number(fmt.Sprintf("%d", startNs)),
+					"end_time":       json.Number(fmt.Sprintf("%d", endNs)),
+					"duration":       json.Number(fmt.Sprintf("%d", endNs-startNs)),
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := newTestClient(server.URL)
+	result, err := client.GetSpans(context.Background(), TracesQueryParams{
+		TraceID:   "trace-1",
+		Scope:     Scope{Namespace: "ns"},
+		StartTime: time.Unix(0, startNs),
+		EndTime:   time.Unix(0, endNs),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if len(result.Spans) != 2 {
+		t.Errorf("expected 2 spans, got %d", len(result.Spans))
+	}
+	if result.Total != len(result.Spans) {
+		t.Errorf("expected Total == len(Spans) (%d), got %d",
+			len(result.Spans), result.Total)
+	}
+}

--- a/observability-tracing-openobserve/internal/openobserve/client_test.go
+++ b/observability-tracing-openobserve/internal/openobserve/client_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -964,5 +965,82 @@ func TestParseSpanDetail_NoExtraAttributes(t *testing.T) {
 	}
 	if len(detail.ResourceAttributes) != 0 {
 		t.Errorf("expected 0 resource attributes, got %d: %v", len(detail.ResourceAttributes), detail.ResourceAttributes)
+	}
+}
+
+func TestExecuteSearchQuery_StreamNotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(`{"code":20002,"message":"Search stream not found: default"}`))
+	}))
+	defer server.Close()
+
+	client := newTestClient(server.URL)
+	_, err := client.executeSearchQuery(context.Background(), []byte(`{}`))
+	if !errors.Is(err, ErrStreamNotFound) {
+		t.Fatalf("expected ErrStreamNotFound, got %v", err)
+	}
+}
+
+func TestGetTraces_StreamNotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(`{"code":20002,"message":"Search stream not found: default"}`))
+	}))
+	defer server.Close()
+
+	client := newTestClient(server.URL)
+	result, err := client.GetTraces(context.Background(), TracesQueryParams{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil empty result")
+	}
+	if len(result.Traces) != 0 || result.Total != 0 {
+		t.Fatalf("expected empty result, got %+v", result)
+	}
+}
+
+func TestGetSpans_StreamNotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(`{"code":20002,"message":"Search stream not found: default"}`))
+	}))
+	defer server.Close()
+
+	client := newTestClient(server.URL)
+	result, err := client.GetSpans(context.Background(), TracesQueryParams{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil empty result")
+	}
+	if len(result.Spans) != 0 || result.Total != 0 {
+		t.Fatalf("expected empty result, got %+v", result)
+	}
+}
+
+func TestIsStreamNotFound(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{"matching code", `{"code":20002,"message":"..."}`, true},
+		{"other code", `{"code":20001,"message":"..."}`, false},
+		{"no code field", `{"message":"foo"}`, false},
+		{"empty body", ``, false},
+		{"malformed json", `{not json`, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isStreamNotFound([]byte(tc.body))
+			if got != tc.want {
+				t.Fatalf("isStreamNotFound(%q) = %v, want %v", tc.body, got, tc.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Purpose

Moves the OpenObserve empty-stream handling from the observer interface (`openchoreo/openchoreo`) into this adapter, per @akila-i's review feedback on openchoreo/openchoreo#3439. The observer interface stays adapter-agnostic; OpenObserve-specific codes (20002 = "stream not found") live in the adapter that actually knows them.

Refs:
- openchoreo/openchoreo#3435 (root bug report)
- openchoreo/openchoreo#3439 (sibling PR in the main repo, being re-pointed at this)

## Bug

When a component has never emitted spans, OpenObserve responds to a search with HTTP 400 and body `{"code":20002,"message":"Search stream not found: default"}` because the search stream is created lazily on first write. The adapter's `executeSearchQuery` currently treats any non-200 as a hard failure, so "no data yet" surfaces as HTTP 500 to the API client through the observer interface.

## Approach

Single file edit on the adapter side, plus tests. All changes are confined to `observability-tracing-openobserve/internal/openobserve/`.

- New constant `openObserveStreamNotFoundCode = 20002` and a small `isStreamNotFound([]byte) bool` helper that parses the OpenObserve error envelope. Tolerant: empty body, malformed JSON, or JSON without `code` all return false, so existing error paths are unchanged for everything except this one specific OpenObserve response.
- New exported sentinel `ErrStreamNotFound` (Go convention for "expected non-error state", like `sql.ErrNoRows`).
- `executeSearchQuery` returns the sentinel when the body indicates code 20002.
- Each public client method (`GetTraces`, `GetSpans`, `GetSpanDetail`) translates the sentinel into the appropriate zero-value result and `nil` error. For `GetTraces`/`GetSpans`, if only the count query returns the sentinel (rare), the search results are returned with `Total = len(results)` rather than failing.

## Tests

Four new tests in `client_test.go`:

- `TestExecuteSearchQuery_StreamNotFound` - asserts the sentinel is returned for a 400+code:20002 response.
- `TestGetTraces_StreamNotFound` - asserts the public API returns an empty `*TracesResult` and `nil` error.
- `TestGetSpans_StreamNotFound` - symmetric for spans.
- `TestIsStreamNotFound` - table-driven test for the parser (matching code, other code, missing code, empty body, malformed JSON).

All pass; existing tests unaffected; `go vet` clean.

## What this doesn't change

- The observer interface in `openchoreo/openchoreo`. The companion PR there (#3439) can now be closed in favor of this one - the OpenObserve-specific behavior lives where it should.
- The metrics or logs adapters. The same pattern likely applies if those streams are also lazy, but I kept this PR scoped to tracing for reviewability. Happy to follow up with symmetric PRs against `observability-logs-openobserve` and `observability-metrics-*` if you'd like.

This contribution was developed with AI assistance (Claude Code).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when a configured search stream is missing: trace and span list queries now return empty results (with preserved timing/total metadata) instead of failing, and span detail requests return a consistent "span not found" response.

* **Tests**
  * Added unit tests covering missing-stream scenarios, varied response bodies, and mixed count/list outcomes.

* **Chores**
  * Bumped chart version and appVersion for the observability tracing package.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openchoreo/community-modules/pull/114?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->