### PR TITLE
feat: add script for reindexing trace indices to 0.4.1 mapping

### DIFF
--- a/observability-tracing-opensearch/README.md
+++ b/observability-tracing-opensearch/README.md
@@ -147,12 +147,19 @@ helm upgrade --install observability-tracing-opensearch \
   --set opentelemetryCollectorCustomizations.http.observabilityPlaneVirtualHost="opentelemetry.<gateway-domain>"
 ```
 
+## Upgrades
+
+If you are upgrading from a version before 0.4.0, reindex the older tracing data to work with newer queries
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/openchoreo/community-modules/refs/heads/main/observability-tracing-opensearch/scripts/upgrade-to-0-4-1.sh | bash
+```
 
 ## Compatibility
 
 > **Note:** The Helm chart versions specified in the installation commands above are for the latest module version compatible with the development version of OpenChoreo. Refer to the compatibility table below to determine the appropriate module version for your OpenChoreo installation.
 
 | Module Version | OpenChoreo Version |
-|----------------|--------------------|
+| -------------- | ------------------ |
 | v0.4.x         | v1.1.x             |
 | v0.3.x         | v1.0.x             |

--- a/observability-tracing-opensearch/scripts/upgrade-to-0-4-1.sh
+++ b/observability-tracing-opensearch/scripts/upgrade-to-0-4-1.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # Reindex existing trace indices onto the 0.4.1 mapping
 # Run AFTER `helm upgrade … observability-tracing-opensearch 0.4.1`
 
@@ -64,7 +65,9 @@ reindex() {
   local total created failures
   total=$(json_num "$resp" total)
   created=$(json_num "$resp" created)
-  failures=$(printf '%s' "$resp" | grep -o '"failures":\[[^]]*\]' | grep -o '{' | wc -l | tr -d ' ')
+  # `grep -o '{'` exits 1 when failures is an empty array; under pipefail that
+  # would abort the script on a successful reindex, so swallow the non-match.
+  failures=$(printf '%s' "$resp" | grep -o '"failures":\[[^]]*\]' | { grep -o '{' || true; } | wc -l | tr -d ' ')
   if [ "${failures:-0}" != "0" ]; then
     fail "$src -> $dst  ($failures failures)"
     printf '%s\n' "$resp"

--- a/observability-tracing-opensearch/scripts/upgrade-to-0-4-1.sh
+++ b/observability-tracing-opensearch/scripts/upgrade-to-0-4-1.sh
@@ -1,0 +1,93 @@
+# Reindex existing trace indices onto the 0.4.1 mapping
+# Run AFTER `helm upgrade … observability-tracing-opensearch 0.4.1`
+
+set -u
+
+NS=openchoreo-observability-plane
+OS_SECRET=opensearch-admin-credentials
+LOCAL_PORT=9200
+
+C_BOLD=$'\033[1m'; C_DIM=$'\033[2m'; C_GREEN=$'\033[32m'; C_YELLOW=$'\033[33m'; C_RED=$'\033[31m'; C_RESET=$'\033[0m'
+step()  { printf '\n%s== %s ==%s\n' "$C_BOLD" "$1" "$C_RESET"; }
+info()  { printf '  %s%s%s\n' "$C_DIM" "$1" "$C_RESET"; }
+ok()    { printf '  %s✓%s %s\n' "$C_GREEN" "$C_RESET" "$1"; }
+warn()  { printf '  %s!%s %s\n' "$C_YELLOW" "$C_RESET" "$1"; }
+fail()  { printf '  %s✗%s %s\n' "$C_RED" "$C_RESET" "$1"; }
+
+# Extract a numeric field from a JSON blob without depending on jq.
+json_num() { printf '%s' "$1" | sed -n 's/.*"'"$2"'":\([0-9]*\).*/\1/p' | head -1; }
+
+step "Stopping trace ingestion"
+kubectl scale deployment/opentelemetry-collector -n "$NS" --replicas=0 >/dev/null
+kubectl rollout status deployment/opentelemetry-collector -n "$NS" --timeout=60s >/dev/null
+ok "opentelemetry-collector scaled to 0"
+
+step "Port-forwarding svc/opensearch -> localhost:$LOCAL_PORT"
+kubectl port-forward -n "$NS" svc/opensearch "$LOCAL_PORT:9200" >/dev/null 2>&1 &
+PF_PID=$!
+trap 'kill "$PF_PID" 2>/dev/null' EXIT
+for _ in {1..30}; do
+  curl -sS -k "https://localhost:$LOCAL_PORT" >/dev/null 2>&1 && break
+  sleep 1
+done
+ok "tunnel ready (pid $PF_PID)"
+
+PASS=$(kubectl get secret -n "$NS" "$OS_SECRET" -o jsonpath='{.data.password}' | base64 -d)
+OS() { curl -sS -k -u "admin:$PASS" -H 'Content-Type: application/json' "$@"; }
+
+reindex() {
+  local src=$1 dst=$2
+  local resp
+  resp=$(OS -XPOST "https://localhost:$LOCAL_PORT/_reindex?wait_for_completion=true&refresh=true" \
+              -d "{\"source\":{\"index\":\"$src\"},\"dest\":{\"index\":\"$dst\"}}")
+  local total created failures
+  total=$(json_num "$resp" total)
+  created=$(json_num "$resp" created)
+  failures=$(printf '%s' "$resp" | grep -o '"failures":\[[^]]*\]' | grep -o '{' | wc -l | tr -d ' ')
+  if [ "${failures:-0}" != "0" ]; then
+    fail "$src -> $dst  ($failures failures)"
+    printf '%s\n' "$resp"
+    return 1
+  fi
+  ok "$src -> $dst  (${created:-0}/${total:-0} docs)"
+}
+
+delete_idx() {
+  local idx=$1
+  local resp
+  resp=$(OS -XDELETE "https://localhost:$LOCAL_PORT/$idx")
+  if printf '%s' "$resp" | grep -q '"acknowledged":true'; then
+    ok "deleted $idx"
+  else
+    warn "delete $idx -> $resp"
+  fi
+}
+
+step "Listing trace indices"
+mapfile -t INDICES < <(OS "https://localhost:$LOCAL_PORT/_cat/indices/otel-traces-*?h=index" | awk '{print $1}' | grep -v -- '-reindex-tmp$')
+if [ "${#INDICES[@]}" -eq 0 ]; then
+  warn "no otel-traces-* indices found, nothing to do"
+else
+  info "${#INDICES[@]} index/indices to migrate: ${INDICES[*]}"
+fi
+
+for IDX in "${INDICES[@]}"; do
+  TMP="${IDX}-reindex-tmp"
+  step "Migrating $IDX"
+  OS -XDELETE "https://localhost:$LOCAL_PORT/$TMP" >/dev/null
+  reindex "$IDX" "$TMP" || continue
+  delete_idx "$IDX"
+  reindex "$TMP" "$IDX" || continue
+  delete_idx "$TMP"
+done
+
+step "Closing port-forward"
+kill "$PF_PID" 2>/dev/null && ok "stopped pid $PF_PID"
+trap - EXIT
+
+step "Resuming trace ingestion"
+kubectl scale deployment/opentelemetry-collector -n "$NS" --replicas=1 >/dev/null
+kubectl rollout status deployment/opentelemetry-collector -n "$NS" --timeout=120s >/dev/null
+ok "opentelemetry-collector back to 1 replica"
+
+printf '\n%sDone.%s\n' "$C_BOLD" "$C_RESET"

--- a/observability-tracing-opensearch/scripts/upgrade-to-0-4-1.sh
+++ b/observability-tracing-opensearch/scripts/upgrade-to-0-4-1.sh
@@ -1,7 +1,7 @@
 # Reindex existing trace indices onto the 0.4.1 mapping
 # Run AFTER `helm upgrade … observability-tracing-opensearch 0.4.1`
 
-set -u
+set -euo pipefail
 
 NS=openchoreo-observability-plane
 OS_SECRET=opensearch-admin-credentials
@@ -17,6 +17,20 @@ fail()  { printf '  %s✗%s %s\n' "$C_RED" "$C_RESET" "$1"; }
 # Extract a numeric field from a JSON blob without depending on jq.
 json_num() { printf '%s' "$1" | sed -n 's/.*"'"$2"'":\([0-9]*\).*/\1/p' | head -1; }
 
+# Capture original replica count so cleanup can restore the deployment to its
+# prior state regardless of whether the script exits cleanly or partway through.
+ORIG_REPLICAS=$(kubectl get deployment/opentelemetry-collector -n "$NS" -o jsonpath='{.spec.replicas}' 2>/dev/null || echo 1)
+ORIG_REPLICAS=${ORIG_REPLICAS:-1}
+
+PF_PID=""
+cleanup() {
+  if [ -n "${PF_PID:-}" ]; then
+    kill "$PF_PID" 2>/dev/null || true
+  fi
+  kubectl scale deployment/opentelemetry-collector -n "$NS" --replicas="$ORIG_REPLICAS" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
 step "Stopping trace ingestion"
 kubectl scale deployment/opentelemetry-collector -n "$NS" --replicas=0 >/dev/null
 kubectl rollout status deployment/opentelemetry-collector -n "$NS" --timeout=60s >/dev/null
@@ -25,11 +39,18 @@ ok "opentelemetry-collector scaled to 0"
 step "Port-forwarding svc/opensearch -> localhost:$LOCAL_PORT"
 kubectl port-forward -n "$NS" svc/opensearch "$LOCAL_PORT:9200" >/dev/null 2>&1 &
 PF_PID=$!
-trap 'kill "$PF_PID" 2>/dev/null' EXIT
+PF_READY=0
 for _ in {1..30}; do
-  curl -sS -k "https://localhost:$LOCAL_PORT" >/dev/null 2>&1 && break
+  if curl -sS -k "https://localhost:$LOCAL_PORT" >/dev/null 2>&1; then
+    PF_READY=1
+    break
+  fi
   sleep 1
 done
+if [ "$PF_READY" -ne 1 ]; then
+  fail "port-forward to svc/opensearch never became ready"
+  exit 1
+fi
 ok "tunnel ready (pid $PF_PID)"
 
 PASS=$(kubectl get secret -n "$NS" "$OS_SECRET" -o jsonpath='{.data.password}' | base64 -d)
@@ -59,12 +80,13 @@ delete_idx() {
   if printf '%s' "$resp" | grep -q '"acknowledged":true'; then
     ok "deleted $idx"
   else
-    warn "delete $idx -> $resp"
+    fail "delete $idx -> $resp"
+    return 1
   fi
 }
 
 step "Listing trace indices"
-mapfile -t INDICES < <(OS "https://localhost:$LOCAL_PORT/_cat/indices/otel-traces-*?h=index" | awk '{print $1}' | grep -v -- '-reindex-tmp$')
+mapfile -t INDICES < <(OS "https://localhost:$LOCAL_PORT/_cat/indices/otel-traces-*?h=index" | awk '{print $1}' | grep -v -- '-reindex-tmp$' || true)
 if [ "${#INDICES[@]}" -eq 0 ]; then
   warn "no otel-traces-* indices found, nothing to do"
 else
@@ -74,20 +96,31 @@ fi
 for IDX in "${INDICES[@]}"; do
   TMP="${IDX}-reindex-tmp"
   step "Migrating $IDX"
-  OS -XDELETE "https://localhost:$LOCAL_PORT/$TMP" >/dev/null
+  OS -XDELETE "https://localhost:$LOCAL_PORT/$TMP" >/dev/null || true
   reindex "$IDX" "$TMP" || continue
+  # delete_idx returns non-zero on failure; with set -e this aborts the script
+  # before we proceed to recreate the live index from $TMP.
   delete_idx "$IDX"
-  reindex "$TMP" "$IDX" || continue
+  # After this point the original index no longer exists. If the second reindex
+  # fails we must abort instead of skipping: continuing would leave the live
+  # index missing and ingestion would resume against an empty target.
+  if ! reindex "$TMP" "$IDX"; then
+    fail "second reindex failed for $IDX; live index missing, leaving $TMP intact for recovery"
+    exit 1
+  fi
   delete_idx "$TMP"
 done
 
 step "Closing port-forward"
-kill "$PF_PID" 2>/dev/null && ok "stopped pid $PF_PID"
-trap - EXIT
+if kill "$PF_PID" 2>/dev/null; then
+  ok "stopped pid $PF_PID"
+fi
+PF_PID=""
 
 step "Resuming trace ingestion"
-kubectl scale deployment/opentelemetry-collector -n "$NS" --replicas=1 >/dev/null
+kubectl scale deployment/opentelemetry-collector -n "$NS" --replicas="$ORIG_REPLICAS" >/dev/null
 kubectl rollout status deployment/opentelemetry-collector -n "$NS" --timeout=120s >/dev/null
-ok "opentelemetry-collector back to 1 replica"
+ok "opentelemetry-collector back to $ORIG_REPLICAS replica(s)"
 
+trap - EXIT
 printf '\n%sDone.%s\n' "$C_BOLD" "$C_RESET"


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat: add observability-logs-opensearch module
  fix: handle opensearch startup delay in init script
  docs: update observability-logs-opensearch module installation guide
  chore(deps): bump fluent-bit version in observability-logs-openobserve module

See: https://github.com/openchoreo/openchoreo/blob/main/docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
This pull request introduces a new migration script to safely reindex existing OpenSearch trace indices to the new 0.4.1 mapping. The script automates the process, including stopping ingestion, port-forwarding, performing the reindex, and resuming ingestion, to minimize downtime and user intervention.

Key changes:

**Migration Automation:**
* Added `upgrade-to-0-4-1.sh` script to automate the reindexing of `otel-traces-*` indices for OpenSearch 0.4.1, including steps to stop and resume trace ingestion, port-forward to OpenSearch, and handle index migration with error checking.

**User Experience and Safety:**
* Script provides clear step-by-step output, handles failures gracefully, and ensures resources like port-forwards are cleaned up even on exit.

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated upgrade script to migrate OpenSearch trace indices to the 0.4.1 mapping. The process safely pauses ingestion, performs reindexing with checks, and restores normal operation when complete, leaving recoverable artifacts if a reindex step fails. Completion and progress are reported to the operator.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openchoreo/community-modules/pull/117?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->