### PR TITLE
docs: rename module catalogue to openchoreo ecosystem in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,6 @@ Community modules are pluggable integrations that extend [OpenChoreo](https://op
 
 ## Getting Started
 
-Browse the available modules in the [OpenChoreo Module Catalogue](https://openchoreo.dev/modules/) and follow the installation instructions for each module.
+Browse the available modules in the [OpenChoreo Ecosystem](https://openchoreo.dev/ecosystem/) and follow the installation instructions for each module.
 
 For a deeper understanding of how modules work and how to add a new OpenChoreo module, see the [modules overview](https://openchoreo.dev/docs/platform-engineer-guide/modules/overview/) documentation.


### PR DESCRIPTION
## Purpose
- Rename "OpenChoreo Module Catalogue" to "OpenChoreo Ecosystem" in the Getting Started section                                                                                
- Update the link from `/modules/` to `/ecosystem/`    


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated "Getting Started" guidance in the README to direct users to the OpenChoreo Ecosystem page for module installation instructions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openchoreo/community-modules/pull/126?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->