### PR TITLE
feat: Add charts for publishing metrics to moesif

### DIFF
--- a/observability-metrics-moesif/README.md
+++ b/observability-metrics-moesif/README.md
@@ -241,3 +241,4 @@ helm uninstall observability-metrics-moesif \
 # Remove the namespace (not deleted automatically by Helm):
 kubectl delete namespace openchoreo-observability-plane
 ```
+

--- a/observability-metrics-moesif/README.md
+++ b/observability-metrics-moesif/README.md
@@ -1,0 +1,218 @@
+# Observability Metrics Module for Moesif
+
+This module collects Ballerina application metrics from pod stdout using a
+Fluent Bit DaemonSet and publishes them as Action events to the Moesif
+collector API (`/v1/actions/batch`).
+
+## Prerequisites
+
+- A running Kubernetes cluster
+- Ballerina applications deployed with `metricsLogsEnabled = true` in their
+  `Config.toml` (the Ballerina runtime emits metric log lines to stdout when
+  this is set)
+- A Moesif account with a **master key** and **Collector Application ID**
+  from [Moesif](https://www.moesif.com/)
+
+## How It Works
+
+Each Ballerina pod writes structured metric log lines to stdout whenever it
+handles an HTTP request or an FTP file event. Each line is tagged with
+`logger="metrics"` and contains fields such as `http.method`, `http.url`,
+`http.status_code_group`, and `response_time_seconds`.
+
+The Fluent Bit DaemonSet deployed by this chart:
+
+1. **Tails** `/var/log/containers/*.log` on every node
+2. **Enriches** records with pod metadata (labels and annotations) via the
+   Kubernetes filter
+3. **Filters** records, keeping only lines that contain `logger="metrics"`
+4. **Transforms** each line using a Lua script that parses the logfmt fields
+   and builds a Moesif Actions event (`action_name`, `request`, `metadata`)
+5. **Routes** each record by rewriting the Fluent Bit tag to the pod's
+   `moesif-app-id` annotation value (the Collector Application ID JWT), so
+   that `header_tag` can set `X-Moesif-Application-Id` dynamically per pod
+6. **Publishes** events in JSON batch format to `POST /v1/actions/batch`
+
+### Authentication headers sent per request
+
+| Header | Source | Purpose |
+|--------|--------|---------|
+| `X-Api-Token` | `moesif.masterKey` value | Cluster-level master key |
+| `X-Moesif-Org-Id` | `moesif.orgId` value | Org identifier |
+| `X-Moesif-App-Id` | `moesif.appId` value | App identifier |
+| `X-Moesif-Application-Id` | Pod annotation `moesif-app-id` | Per-pod collector auth (JWT); set dynamically via Fluent Bit `header_tag` |
+
+## Application Pod Requirements
+
+Each Ballerina pod that should have its metrics collected must carry two
+annotations in its pod template:
+
+```yaml
+metadata:
+  annotations:
+    moesif-org-id: "<YOUR_ORG_ID>"            # numeric, e.g. "586:761"
+    moesif-app-id: "<COLLECTOR_APP_ID_JWT>"   # Moesif Collector Application ID
+```
+
+> **Why annotations and not labels?**
+> Kubernetes label values are limited to 63 characters and may not contain
+> `:`. The Moesif Collector Application ID is a ~134-character JWT that
+> contains `:`, so it must be stored as an annotation.
+
+## Installation
+
+### Step 1 — Create a Kubernetes Secret for the master key (recommended)
+
+```bash
+kubectl create secret generic moesif-master-key-values \
+  --from-literal=masterKey="<YOUR_MASTER_KEY>" \
+  --namespace openchoreo-observability-plane
+```
+
+You can then reference the secret value at install time with
+`--set moesif.masterKey="$(kubectl get secret ...)"`, or supply it directly
+via `--set` (see Step 2).
+
+### Step 2 — Install the Helm chart
+
+```bash
+helm upgrade --install observability-metrics-moesif \
+  ./observability-metrics-moesif/helm \
+  --create-namespace \
+  --namespace openchoreo-observability-plane \
+  --set moesif.masterKey="<YOUR_MASTER_KEY>" \
+  --set moesif.orgId="<YOUR_ORG_ID>" \
+  --set moesif.appId="<YOUR_APP_ID>"
+```
+
+### Step 3 — Annotate your application pods
+
+Add the two required annotations to each Ballerina deployment's pod template:
+
+```bash
+kubectl patch deployment <your-deployment> \
+  --type=json \
+  -p='[
+    {"op":"add","path":"/spec/template/metadata/annotations/moesif-org-id","value":"<ORG_ID>"},
+    {"op":"add","path":"/spec/template/metadata/annotations/moesif-app-id","value":"<COLLECTOR_APP_ID_JWT>"}
+  ]'
+```
+
+Or declare them directly in the pod template:
+
+```yaml
+# your-deployment.yaml
+spec:
+  template:
+    metadata:
+      annotations:
+        moesif-org-id: "586:761"
+        moesif-app-id: "eyJhcHAiOiI0ODc6OTkxIi..."
+```
+
+## Configuration Options
+
+Create a `values.yaml` file for repeatable installs:
+
+```yaml
+# values.yaml
+moesif:
+  masterKey: "<YOUR_MASTER_KEY>"
+  orgId: "586:761"
+  appId: "487:991"
+  host: api.moesif.net
+  uri: /v1/actions/batch
+  flush: 5
+
+fluentBit:
+  image:
+    repository: fluent/fluent-bit
+    tag: latest
+```
+
+Then install with:
+
+```bash
+helm upgrade --install observability-metrics-moesif \
+  ./observability-metrics-moesif/helm \
+  --create-namespace \
+  --namespace openchoreo-observability-plane \
+  -f values.yaml
+```
+
+### Configuration Parameters
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `namespace` | Namespace where Fluent Bit is deployed | `openchoreo-observability-plane` |
+| `moesif.masterKey` | Cluster-level master key sent as `X-Api-Token` | `""` |
+| `moesif.orgId` | Org ID sent as `X-Moesif-Org-Id` | `""` |
+| `moesif.appId` | App ID sent as `X-Moesif-App-Id` | `""` |
+| `moesif.host` | Moesif API host | `api.moesif.net` |
+| `moesif.port` | Moesif API port | `443` |
+| `moesif.uri` | Collector endpoint path | `/v1/actions/batch` |
+| `moesif.flush` | Fluent Bit flush interval in seconds | `5` |
+| `fluentBit.image.repository` | Fluent Bit image repository | `fluent/fluent-bit` |
+| `fluentBit.image.tag` | Fluent Bit image tag | `latest` |
+| `fluentBit.resources` | CPU/memory resource requests and limits | see `values.yaml` |
+
+## Troubleshooting
+
+### Check Fluent Bit logs
+
+```bash
+kubectl -n openchoreo-observability-plane logs -f ds/fluent-bit
+```
+
+A healthy pipeline shows:
+
+```
+[info] [filter:kubernetes:kubernetes.0] connectivity OK
+[info] [input:emitter:moesif_emitter] initializing
+[info] [output:http:http.1] api.moesif.net:443, HTTP status=201
+```
+
+### Check that metric lines appear in pod stdout
+
+```bash
+kubectl logs -l app=<your-app> | grep 'logger="metrics"'
+```
+
+### Check that pod annotations are set correctly
+
+```bash
+kubectl get pods -l app=<your-app> \
+  -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.metadata.annotations.moesif-app-id}{"\n"}{end}'
+```
+
+If `moesif-app-id` is empty, Fluent Bit's `rewrite_tag` will not fire for
+that pod's records and they will be silently dropped by the `null` output.
+
+### Common HTTP status codes from Moesif
+
+| Status | Meaning |
+|--------|---------|
+| `201` | Events accepted |
+| `400` | Payload shape wrong — check the Lua transform output |
+| `401` | `X-Moesif-Application-Id` missing or invalid — check the `moesif-app-id` annotation |
+
+### Enable debug logging
+
+Set `log_level: debug` in the Fluent Bit service config to see detailed
+record processing. Edit the `moesif-master-key` Secret's `fluent-bit.yaml`
+key and restart the DaemonSet:
+
+```bash
+kubectl rollout restart daemonset/fluent-bit \
+  -n openchoreo-observability-plane
+```
+
+## Uninstalling
+
+```bash
+helm uninstall observability-metrics-moesif \
+  --namespace openchoreo-observability-plane
+
+# Remove the namespace (not deleted automatically by Helm):
+kubectl delete namespace openchoreo-observability-plane
+```

--- a/observability-metrics-moesif/README.md
+++ b/observability-metrics-moesif/README.md
@@ -61,17 +61,36 @@ metadata:
 
 ## Installation
 
-### Step 1 — Create a Kubernetes Secret for the master key (recommended)
+### Step 1 — Store the master key in a Kubernetes Secret (recommended)
+
+The Helm chart creates its own Secret (`moesif-master-key`) that holds the
+full Fluent Bit pipeline config. This step stores just the raw key value in a
+separate Secret so you can retrieve it at install time without hardcoding it
+in shell history.
 
 ```bash
-kubectl create secret generic moesif-master-key-values \
+kubectl create secret generic moesif-master-key \
   --from-literal=masterKey="<YOUR_MASTER_KEY>" \
-  --namespace openchoreo-observability-plane
+  --namespace openchoreo-observability-plane \
+  --dry-run=client -o yaml | kubectl apply -f -
 ```
 
-You can then reference the secret value at install time with
-`--set moesif.masterKey="$(kubectl get secret ...)"`, or supply it directly
-via `--set` (see Step 2).
+You can then read it back and pass it to `helm upgrade --install`:
+
+```bash
+helm upgrade --install observability-metrics-moesif \
+  ./observability-metrics-moesif/helm \
+  --create-namespace \
+  --namespace openchoreo-observability-plane \
+  --set moesif.masterKey="$(kubectl get secret moesif-master-key \
+    -n openchoreo-observability-plane \
+    -o jsonpath='{.data.masterKey}' | base64 -d)" \
+  --set moesif.orgId="<YOUR_ORG_ID>" \
+  --set moesif.appId="<YOUR_APP_ID>"
+```
+
+Or supply the key directly via `--set` without a pre-created Secret (see
+Step 2).
 
 ### Step 2 — Install the Helm chart
 
@@ -166,7 +185,7 @@ kubectl -n openchoreo-observability-plane logs -f ds/fluent-bit
 
 A healthy pipeline shows:
 
-```
+```text
 [info] [filter:kubernetes:kubernetes.0] connectivity OK
 [info] [input:emitter:moesif_emitter] initializing
 [info] [output:http:http.1] api.moesif.net:443, HTTP status=201
@@ -199,8 +218,14 @@ that pod's records and they will be silently dropped by the `null` output.
 ### Enable debug logging
 
 Set `log_level: debug` in the Fluent Bit service config to see detailed
-record processing. Edit the `moesif-master-key` Secret's `fluent-bit.yaml`
-key and restart the DaemonSet:
+record processing. The full pipeline config lives in the `moesif-master-key`
+Secret (created by `helm install`) under the `fluent-bit.yaml` key. Edit it
+and restart the DaemonSet:
+
+```bash
+kubectl edit secret moesif-master-key \
+  -n openchoreo-observability-plane
+```
 
 ```bash
 kubectl rollout restart daemonset/fluent-bit \

--- a/observability-metrics-moesif/helm/Chart.yaml
+++ b/observability-metrics-moesif/helm/Chart.yaml
@@ -1,0 +1,21 @@
+# Copyright 2026 The OpenChoreo Authors
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v2
+name: observability-metrics-moesif
+description: >
+  A Helm chart that deploys a Fluent Bit DaemonSet to capture Ballerina
+  application metrics from pod stdout, filter lines tagged with
+  logger="metrics", and publish them as Action events to the Moesif
+  collector API (/v1/actions/batch).
+type: application
+version: 0.1.0
+keywords:
+  - moesif
+  - observability
+  - metrics
+  - fluent-bit
+  - ballerina
+maintainers:
+  - name: Moesif Team
+home: https://github.com/openchoreo/community-modules

--- a/observability-metrics-moesif/helm/files/parsers.conf
+++ b/observability-metrics-moesif/helm/files/parsers.conf
@@ -1,0 +1,6 @@
+[PARSER]
+    Name        docker
+    Format      json
+    Time_Key    time
+    Time_Format %Y-%m-%dT%H:%M:%S.%L
+    Time_Keep   On

--- a/observability-metrics-moesif/helm/files/transform.lua
+++ b/observability-metrics-moesif/helm/files/transform.lua
@@ -1,0 +1,101 @@
+-- Parse key="value" and key=value pairs from a Ballerina logfmt line.
+-- Field names may contain dots and hyphens (e.g. http.status_code_group).
+local function parse_logfmt(line)
+    local fields = {}
+    -- Quoted values first so they take priority over unquoted matches.
+    for k, v in line:gmatch('([%w%.%-%_]+)="([^"]*)"') do
+        fields[k] = v
+    end
+    -- Unquoted values (end at first whitespace character).
+    for k, v in line:gmatch('([%w%.%-%_]+)=([^%s"]+)') do
+        if not fields[k] then
+            fields[k] = v
+        end
+    end
+    return fields
+end
+
+-- Structural logfmt fields that exist on every line but carry no metric
+-- signal — excluded from the metadata payload sent to Moesif.
+local EXCLUDE = {
+    time=true, level=true, module=true, message=true, logger=true
+}
+
+function transform(tag, timestamp, record)
+    local log_line = record["log"]
+    if not log_line then
+        return -1, 0, 0
+    end
+
+    -- Trim trailing newline added by Docker JSON log format.
+    log_line = log_line:gsub("%s+$", "")
+
+    local f = parse_logfmt(log_line)
+
+    -- Safety check: only process metric log lines.
+    if f["logger"] ~= "metrics" then
+        return -1, 0, 0
+    end
+
+    -- Read app ID from pod annotation for rewrite_tag routing.
+    local k8s         = record["kubernetes"] or {}
+    local annotations = k8s["annotations"] or {}
+    local app_id      = annotations["moesif-app-id"] or ""
+
+    local method = f["http.method"]
+    local url    = f["http.url"]
+
+    -- action_name: "METHOD /path" for HTTP services; function name for others
+    -- (e.g. FTP listener emits src.function.name="onFileChange").
+    local action_name
+    if method and method ~= "" and url and url ~= "" then
+        action_name = method .. " " .. url
+    else
+        action_name = f["src.function.name"] or f["entrypoint.function.name"] or "unknown"
+    end
+
+    -- request.uri / request.verb: fall back to function-level identifiers when
+    -- HTTP fields are absent (e.g. FTP client calls, event handler invocations).
+    local req_uri
+    if url and url ~= "" then
+        req_uri = "https://" .. (f["src.object.name"] or "service") .. url
+    else
+        local svc = f["entrypoint.service.name"] or f["src.object.name"] or "service"
+        local fn  = f["src.function.name"] or "invoke"
+        req_uri   = svc .. "/" .. fn
+    end
+
+    local req_verb = method or f["src.function.name"] or "INVOKE"
+
+    -- Build metadata dynamically: include every parsed logfmt field whose
+    -- value is non-empty. Dots and hyphens in key names are normalised to
+    -- underscores for consistent JSON output across HTTP and FTP metrics.
+    local metadata = {}
+    for k, v in pairs(f) do
+        if not EXCLUDE[k] and v ~= "" then
+            local norm = k:gsub("[%.%-]", "_")
+            if k == "response_time_seconds" then
+                metadata[norm] = tonumber(v)
+            else
+                metadata[norm] = v
+            end
+        end
+    end
+
+    -- moesif_app_id must be at the top level so rewrite_tag can read it
+    -- via $moesif_app_id and use it as the new Fluent Bit tag. The tag is
+    -- then copied into X-Moesif-Application-Id by header_tag in the output.
+    -- record_modifier removes it from the top level before the record is sent.
+    local new_record = {
+        action_name   = action_name,
+        moesif_app_id = app_id,
+        request       = {
+            time = f["time"],
+            uri  = req_uri,
+            verb = req_verb,
+        },
+        metadata = metadata,
+    }
+
+    return 1, timestamp, new_record
+end

--- a/observability-metrics-moesif/helm/files/transform.lua
+++ b/observability-metrics-moesif/helm/files/transform.lua
@@ -1,17 +1,68 @@
 -- Parse key="value" and key=value pairs from a Ballerina logfmt line.
 -- Field names may contain dots and hyphens (e.g. http.status_code_group).
+--
+-- A character-by-character parser is used instead of gmatch patterns because
+-- Ballerina's logfmt encoder escapes special characters inside quoted values
+-- (e.g. \" for a literal double-quote, \\ for a literal backslash). The
+-- previous regex pattern [^"]* stopped at the first " regardless of whether
+-- it was preceded by a backslash, silently truncating any value that contained
+-- an escaped quote.
 local function parse_logfmt(line)
     local fields = {}
-    -- Quoted values first so they take priority over unquoted matches.
-    for k, v in line:gmatch('([%w%.%-%_]+)="([^"]*)"') do
-        fields[k] = v
-    end
-    -- Unquoted values (end at first whitespace character).
-    for k, v in line:gmatch('([%w%.%-%_]+)=([^%s"]+)') do
-        if not fields[k] then
-            fields[k] = v
+    local pos    = 1
+    local len    = #line
+
+    while pos <= len do
+        -- Skip whitespace between pairs.
+        while pos <= len and line:sub(pos, pos) == " " do
+            pos = pos + 1
+        end
+        if pos > len then break end
+
+        -- Read key name (up to '=' or whitespace).
+        local key_start = pos
+        while pos <= len and line:sub(pos, pos) ~= "=" and line:sub(pos, pos) ~= " " do
+            pos = pos + 1
+        end
+        local key = line:sub(key_start, pos - 1)
+        if key == "" then break end
+
+        if pos > len or line:sub(pos, pos) ~= "=" then
+            fields[key] = ""
+        else
+            pos = pos + 1  -- consume '='
+            if pos <= len and line:sub(pos, pos) == '"' then
+                -- Quoted value: walk character by character so that escape
+                -- sequences (\" and \\) inside the value are handled correctly.
+                pos = pos + 1  -- consume opening '"'
+                local parts = {}
+                while pos <= len do
+                    local c = line:sub(pos, pos)
+                    if c == "\\" and pos < len then
+                        local nc = line:sub(pos + 1, pos + 1)
+                        -- Unescape \" -> " and \\ -> \; keep other sequences as-is.
+                        parts[#parts + 1] = (nc == '"' or nc == "\\") and nc or (c .. nc)
+                        pos = pos + 2
+                    elseif c == '"' then
+                        pos = pos + 1  -- consume closing '"'
+                        break
+                    else
+                        parts[#parts + 1] = c
+                        pos = pos + 1
+                    end
+                end
+                fields[key] = table.concat(parts)
+            else
+                -- Unquoted value: read until the next whitespace.
+                local val_start = pos
+                while pos <= len and line:sub(pos, pos) ~= " " do
+                    pos = pos + 1
+                end
+                fields[key] = line:sub(val_start, pos - 1)
+            end
         end
     end
+
     return fields
 end
 
@@ -56,13 +107,16 @@ function transform(tag, timestamp, record)
 
     -- request.uri / request.verb: fall back to function-level identifiers when
     -- HTTP fields are absent (e.g. FTP client calls, event handler invocations).
+    -- Use the protocol field from the log line (e.g. "http") rather than
+    -- hardcoding "https", and apply it consistently to both URI forms.
+    local protocol = f["protocol"] or "http"
     local req_uri
     if url and url ~= "" then
-        req_uri = "https://" .. (f["src.object.name"] or "service") .. url
+        req_uri = protocol .. "://" .. (f["src.object.name"] or "service") .. url
     else
         local svc = f["entrypoint.service.name"] or f["src.object.name"] or "service"
         local fn  = f["src.function.name"] or "invoke"
-        req_uri   = svc .. "/" .. fn
+        req_uri   = protocol .. "://" .. svc .. "/" .. fn
     end
 
     local req_verb = method or f["src.function.name"] or "INVOKE"
@@ -75,7 +129,7 @@ function transform(tag, timestamp, record)
         if not EXCLUDE[k] and v ~= "" then
             local norm = k:gsub("[%.%-]", "_")
             if k == "response_time_seconds" then
-                metadata[norm] = tonumber(v)
+                metadata[norm] = tonumber(v) or 0
             else
                 metadata[norm] = v
             end

--- a/observability-metrics-moesif/helm/templates/_helpers.tpl
+++ b/observability-metrics-moesif/helm/templates/_helpers.tpl
@@ -1,0 +1,11 @@
+{{/*
+Copyright 2026 The OpenChoreo Authors
+SPDX-License-Identifier: Apache-2.0
+*/}}
+
+{{- define "observability-metrics-moesif.labels" -}}
+app.kubernetes.io/name: {{ .Chart.Name }}
+app.kubernetes.io/version: {{ .Chart.Version }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+{{- end }}

--- a/observability-metrics-moesif/helm/templates/fluent-bit/configmap.yaml
+++ b/observability-metrics-moesif/helm/templates/fluent-bit/configmap.yaml
@@ -1,0 +1,18 @@
+# Copyright 2026 The OpenChoreo Authors
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fluent-bit-config
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "observability-metrics-moesif.labels" . | nindent 4 }}
+data:
+  # Docker JSON log parser — used by the Tail input to decode container logs.
+  parsers.conf: |
+{{ .Files.Get "files/parsers.conf" | indent 4 }}
+  # Lua script that parses Ballerina logfmt metric lines and builds
+  # the Moesif Actions event structure (action_name, request, metadata).
+  transform.lua: |
+{{ .Files.Get "files/transform.lua" | indent 4 }}

--- a/observability-metrics-moesif/helm/templates/fluent-bit/daemonset.yaml
+++ b/observability-metrics-moesif/helm/templates/fluent-bit/daemonset.yaml
@@ -1,0 +1,74 @@
+# Copyright 2026 The OpenChoreo Authors
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: fluent-bit
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: fluent-bit
+    {{- include "observability-metrics-moesif.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      app: fluent-bit
+  template:
+    metadata:
+      labels:
+        app: fluent-bit
+    spec:
+      serviceAccountName: fluent-bit
+      tolerations:
+        # Run on every node, including control-plane nodes.
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
+      containers:
+        - name: fluent-bit
+          image: "{{ .Values.fluentBit.image.repository }}:{{ .Values.fluentBit.image.tag }}"
+          # Explicitly use the YAML config path. The default entrypoint uses
+          # fluent-bit.conf (classic format). YAML format is required because
+          # '#' in the master key would be treated as a comment in classic
+          # format, silently truncating the key value.
+          command: ["/fluent-bit/bin/fluent-bit"]
+          args: ["-c", "/fluent-bit/etc/fluent-bit.yaml"]
+          resources:
+            {{- toYaml .Values.fluentBit.resources | nindent 12 }}
+          volumeMounts:
+            # Mount /var/log at the same host path so that the symlinks in
+            # /var/log/containers/ -> /var/log/pods/ resolve correctly inside
+            # the container.
+            - name: varlog
+              mountPath: /var/log
+            # Mount /var/lib/docker/containers so the second symlink hop
+            # /var/log/pods/*/N.log -> /var/lib/docker/containers/ID/*-json.log
+            # also resolves correctly (Docker-based runtimes only).
+            - name: dockercontainers
+              mountPath: /var/lib/docker/containers
+              readOnly: true
+            # Full Fluent Bit YAML pipeline (including master key) from Secret.
+            - name: moesif-secret
+              mountPath: /fluent-bit/etc/fluent-bit.yaml
+              subPath: fluent-bit.yaml
+              readOnly: true
+            # Parsers and Lua transform from ConfigMap (no credentials).
+            - name: fluent-bit-config
+              mountPath: /fluent-bit/etc/parsers.conf
+              subPath: parsers.conf
+            - name: fluent-bit-config
+              mountPath: /fluent-bit/scripts/transform.lua
+              subPath: transform.lua
+      volumes:
+        - name: varlog
+          hostPath:
+            path: /var/log
+        - name: dockercontainers
+          hostPath:
+            path: /var/lib/docker/containers
+        - name: fluent-bit-config
+          configMap:
+            name: fluent-bit-config
+        - name: moesif-secret
+          secret:
+            secretName: moesif-master-key

--- a/observability-metrics-moesif/helm/templates/fluent-bit/daemonset.yaml
+++ b/observability-metrics-moesif/helm/templates/fluent-bit/daemonset.yaml
@@ -36,17 +36,21 @@ spec:
           resources:
             {{- toYaml .Values.fluentBit.resources | nindent 12 }}
           volumeMounts:
-            # Mount /var/log at the same host path so that the symlinks in
-            # /var/log/containers/ -> /var/log/pods/ resolve correctly inside
-            # the container.
+            # Read-only: Fluent Bit only tails logs from this path.
+            # Mounting read-only prevents the container from writing into
+            # node logs, eliminating the hostPath write-access risk.
             - name: varlog
               mountPath: /var/log
-            # Mount /var/lib/docker/containers so the second symlink hop
-            # /var/log/pods/*/N.log -> /var/lib/docker/containers/ID/*-json.log
-            # also resolves correctly (Docker-based runtimes only).
+              readOnly: true
+            # Read-only: same reason as above.
             - name: dockercontainers
               mountPath: /var/lib/docker/containers
               readOnly: true
+            # Writable emptyDir for the Fluent Bit offset database.
+            # Tracks the read position per log file across pod restarts.
+            # Cannot live in /var/log now that mount is read-only.
+            - name: fluentbit-db
+              mountPath: /fluent-bit/db
             # Full Fluent Bit YAML pipeline (including master key) from Secret.
             - name: moesif-secret
               mountPath: /fluent-bit/etc/fluent-bit.yaml
@@ -66,6 +70,8 @@ spec:
         - name: dockercontainers
           hostPath:
             path: /var/lib/docker/containers
+        - name: fluentbit-db
+          emptyDir: {}
         - name: fluent-bit-config
           configMap:
             name: fluent-bit-config

--- a/observability-metrics-moesif/helm/templates/fluent-bit/daemonset.yaml
+++ b/observability-metrics-moesif/helm/templates/fluent-bit/daemonset.yaml
@@ -27,6 +27,12 @@ spec:
       containers:
         - name: fluent-bit
           image: "{{ .Values.fluentBit.image.repository }}:{{ .Values.fluentBit.image.tag }}"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault
           # Explicitly use the YAML config path. The default entrypoint uses
           # fluent-bit.conf (classic format). YAML format is required because
           # '#' in the master key would be treated as a comment in classic

--- a/observability-metrics-moesif/helm/templates/fluent-bit/namespace.yaml
+++ b/observability-metrics-moesif/helm/templates/fluent-bit/namespace.yaml
@@ -1,0 +1,9 @@
+# Copyright 2026 The OpenChoreo Authors
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.namespace }}
+  labels:
+    {{- include "observability-metrics-moesif.labels" . | nindent 4 }}

--- a/observability-metrics-moesif/helm/templates/fluent-bit/rbac.yaml
+++ b/observability-metrics-moesif/helm/templates/fluent-bit/rbac.yaml
@@ -1,0 +1,36 @@
+# Copyright 2026 The OpenChoreo Authors
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: fluent-bit
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "observability-metrics-moesif.labels" . | nindent 4 }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: fluent-bit
+  labels:
+    {{- include "observability-metrics-moesif.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "namespaces", "nodes"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: fluent-bit
+  labels:
+    {{- include "observability-metrics-moesif.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: fluent-bit
+subjects:
+  - kind: ServiceAccount
+    name: fluent-bit
+    namespace: {{ .Values.namespace }}

--- a/observability-metrics-moesif/helm/templates/fluent-bit/secret.yaml
+++ b/observability-metrics-moesif/helm/templates/fluent-bit/secret.yaml
@@ -29,7 +29,7 @@ stringData:
           tag: "kube.*"
           path: /var/log/containers/*.log
           multiline.parser: "docker, cri"
-          db: /var/log/flb_kube.db
+          db: /fluent-bit/db/flb_kube.db
           mem_buf_limit: 5MB
           skip_long_lines: on
           refresh_interval: 10

--- a/observability-metrics-moesif/helm/templates/fluent-bit/secret.yaml
+++ b/observability-metrics-moesif/helm/templates/fluent-bit/secret.yaml
@@ -1,0 +1,104 @@
+# Copyright 2026 The OpenChoreo Authors
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: moesif-master-key
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "observability-metrics-moesif.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  master-key: {{ .Values.moesif.masterKey | quote }}
+
+  # The full Fluent Bit pipeline is stored here because the output block must
+  # carry the master key. YAML format is used so that '#' characters inside the
+  # master key are preserved — classic .conf format treats '#' as an inline
+  # comment, silently truncating any key that contains it.
+  fluent-bit.yaml: |
+    service:
+      flush: {{ .Values.moesif.flush }}
+      daemon: off
+      log_level: info
+      parsers_file: /fluent-bit/etc/parsers.conf
+
+    pipeline:
+      inputs:
+        - name: tail
+          tag: "kube.*"
+          path: /var/log/containers/*.log
+          multiline.parser: "docker, cri"
+          db: /var/log/flb_kube.db
+          mem_buf_limit: 5MB
+          skip_long_lines: on
+          refresh_interval: 10
+
+      filters:
+        # Enrich records with pod metadata (labels, annotations).
+        # Annotations are required so the Lua filter can read moesif-app-id.
+        - name: kubernetes
+          match: "kube.*"
+          kube_url: https://kubernetes.default.svc:443
+          kube_ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+          kube_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          kube_tag_prefix: kube.var.log.containers.
+          merge_log: on
+          keep_log: on
+          labels: on
+          annotations: on
+
+        # Keep only Ballerina metric log lines (logger="metrics").
+        - name: grep
+          match: "kube.*"
+          regex: 'log logger="metrics"'
+
+        # Parse logfmt fields and build the Moesif Actions event payload.
+        # Adds moesif_app_id at the top level for rewrite_tag to consume.
+        - name: lua
+          match: "kube.*"
+          script: /fluent-bit/scripts/transform.lua
+          call: transform
+
+        # Retag each record with the pod's Moesif Collector Application ID
+        # (read from the moesif-app-id annotation). header_tag in the HTTP
+        # output copies this tag into X-Moesif-Application-Id per request.
+        # Records from pods without the annotation stay tagged as kube.* and
+        # are dropped by the null output below.
+        - name: rewrite_tag
+          match: "kube.*"
+          rule: "$moesif_app_id ^.+$ $moesif_app_id false"
+          emitter_name: moesif_emitter
+
+        # Remove the temporary top-level moesif_app_id field before the record
+        # is serialised (the value is only needed for the tag rewrite above).
+        - name: record_modifier
+          match: "*"
+          remove_key: moesif_app_id
+
+      outputs:
+        # Drop any kube.* records that were not retagged (pods that have no
+        # moesif-app-id annotation and therefore no valid application ID).
+        - name: "null"
+          match: "kube.*"
+
+        # Publish events to the Moesif Actions batch endpoint.
+        # Match * catches only the retagged records (tag = application ID).
+        # header_tag sets X-Moesif-Application-Id from the tag value, making
+        # authentication dynamic per pod without any hardcoded credential.
+        - name: http
+          match: "*"
+          host: {{ .Values.moesif.host }}
+          port: {{ .Values.moesif.port }}
+          uri: {{ .Values.moesif.uri }}
+          format: json
+          json_date_key: "false"
+          tls: on
+          tls.verify: on
+          header:
+            - "Content-Type application/json"
+            - "X-Api-Token {{ .Values.moesif.masterKey }}"
+            - "X-Moesif-Org-Id {{ .Values.moesif.orgId }}"
+            - "X-Moesif-App-Id {{ .Values.moesif.appId }}"
+          header_tag: X-Moesif-Application-Id
+          retry_limit: 3

--- a/observability-metrics-moesif/helm/templates/fluent-bit/secret.yaml
+++ b/observability-metrics-moesif/helm/templates/fluent-bit/secret.yaml
@@ -100,5 +100,11 @@ stringData:
             - "X-Api-Token {{ .Values.moesif.masterKey }}"
             - "X-Moesif-Org-Id {{ .Values.moesif.orgId }}"
             - "X-Moesif-App-Id {{ .Values.moesif.appId }}"
+          # X-Moesif-Application-Id is required by the current /v1/actions/batch
+          # endpoint for authentication. X-Api-Token / X-Moesif-Org-Id /
+          # X-Moesif-App-Id are included now so the pipeline is ready when
+          # Moesif adds master-key support to the actions endpoint.
+          # X-Moesif-Application-Id is set dynamically per pod via rewrite_tag
+          # + header_tag.
           header_tag: X-Moesif-Application-Id
           retry_limit: 3

--- a/observability-metrics-moesif/helm/values.yaml
+++ b/observability-metrics-moesif/helm/values.yaml
@@ -1,0 +1,36 @@
+# Copyright 2026 The OpenChoreo Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Kubernetes namespace where Fluent Bit and its RBAC are installed.
+namespace: openchoreo-observability-plane
+
+fluentBit:
+  image:
+    repository: fluent/fluent-bit
+    tag: latest
+  resources:
+    limits:
+      memory: 200Mi
+    requests:
+      cpu: 100m
+      memory: 100Mi
+
+moesif:
+  # Cluster-level master key sent as X-Api-Token on every request.
+  # Store this value in a Kubernetes Secret rather than committing it here.
+  masterKey: ""
+
+  # Numeric org and app IDs sent as X-Moesif-Org-Id / X-Moesif-App-Id headers.
+  # These are cluster-level defaults; individual pods override them via the
+  # moesif-app-id annotation, which Fluent Bit uses dynamically for the
+  # X-Moesif-Application-Id collector authentication header.
+  orgId: ""
+  appId: ""
+
+  # Moesif collector endpoint
+  host: api.moesif.net
+  port: 443
+  uri: /v1/actions/batch
+
+  # Fluent Bit flush interval (seconds)
+  flush: 5

--- a/observability-metrics-moesif/helm/values.yaml
+++ b/observability-metrics-moesif/helm/values.yaml
@@ -7,7 +7,7 @@ namespace: openchoreo-observability-plane
 fluentBit:
   image:
     repository: fluent/fluent-bit
-    tag: latest
+    tag: 5.0.5
   resources:
     limits:
       memory: 200Mi
@@ -21,9 +21,8 @@ moesif:
   masterKey: ""
 
   # Numeric org and app IDs sent as X-Moesif-Org-Id / X-Moesif-App-Id headers.
-  # These are cluster-level defaults; individual pods override them via the
-  # moesif-app-id annotation, which Fluent Bit uses dynamically for the
-  # X-Moesif-Application-Id collector authentication header.
+  # Included alongside X-Api-Token so the pipeline is ready when Moesif adds
+  # master-key support to the /v1/actions/batch endpoint.
   orgId: ""
   appId: ""
 

--- a/observability-metrics-moesif/module.yaml
+++ b/observability-metrics-moesif/module.yaml
@@ -1,0 +1,8 @@
+# Copyright 2026 The OpenChoreo Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Module manifest used by the CI workflow to discover Docker images to build.
+# Each entry defines the image name, build context, Dockerfile path, and the
+# corresponding field in helm/values.yaml to update with the published image URI.
+
+images: []


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat: add observability-logs-opensearch module
  fix: handle opensearch startup delay in init script
  docs: update observability-logs-opensearch module installation guide
  chore(deps): bump fluent-bit version in observability-logs-openobserve module

See: https://github.com/openchoreo/openchoreo/blob/main/docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
These helm charts will provide deployment of daemon set fluent-bit per each node to publish metrics data to moesif. 

## Approach
Fluent-bit reads the stdouts of each pod and filter the metrics logs provided by Ballerina application. Then it will be published to moesif with provided `master key` (added as a secret to the node) as a static variable and `Org Id` & `App Id` as dynamic variables for each pod.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Observability Metrics Module for Moesif with complete Helm chart for deploying metrics collection to Kubernetes clusters.

* **Documentation**
  * Added comprehensive README with installation instructions, configuration options, troubleshooting guide, and usage examples.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openchoreo/community-modules/pull/127?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->