### PR TITLE
fix: fix test timestamps in metrics-cloudwatch module

### DIFF
--- a/observability-metrics-aws-cloudwatch/README.md
+++ b/observability-metrics-aws-cloudwatch/README.md
@@ -443,7 +443,7 @@ helm upgrade --install observability-metrics-aws-cloudwatch \
   oci://ghcr.io/openchoreo/helm-charts/observability-metrics-aws-cloudwatch \
   --create-namespace \
   --namespace "$NS" \
-  --version 0.2.2 \
+  --version 0.2.3 \
   --set region="$AWS_REGION" \
   --set adapter.alerting.webhookAuth.enabled=true \
   --set adapter.alerting.webhookAuth.sharedSecret="$WEBHOOK_SHARED_SECRET"
@@ -458,7 +458,7 @@ helm upgrade --install observability-metrics-aws-cloudwatch \
   oci://ghcr.io/openchoreo/helm-charts/observability-metrics-aws-cloudwatch \
   --create-namespace \
   --namespace "$NS" \
-  --version 0.2.2 \
+  --version 0.2.3 \
   --set region="$AWS_REGION" \
   --set opentelemetry-collector.enabled=false \
   --set kubeStateMetrics.enabled=false \
@@ -476,7 +476,7 @@ helm upgrade --install observability-metrics-aws-cloudwatch \
   oci://ghcr.io/openchoreo/helm-charts/observability-metrics-aws-cloudwatch \
   --create-namespace \
   --namespace "$NS" \
-  --version 0.2.2 \
+  --version 0.2.3 \
   --set region="$AWS_REGION" \
   --set adapter.enabled=false
 ```
@@ -612,7 +612,7 @@ kubectl -n "$NS" rollout restart deployment/metrics-adapter-aws-cloudwatch
 kubectl -n "$NS" delete job metrics-aws-cloudwatch-retention --ignore-not-found
 helm upgrade observability-metrics-aws-cloudwatch \
   oci://ghcr.io/openchoreo/helm-charts/observability-metrics-aws-cloudwatch \
-  --namespace "$NS" --version 0.2.2 --reuse-values
+  --namespace "$NS" --version 0.2.3 --reuse-values
 ```
 
 **Observability plane cluster** — restart only the adapter:
@@ -629,7 +629,7 @@ kubectl -n "$NS" rollout restart daemonset/metrics-opentelemetry-collector-agent
 kubectl -n "$NS" delete job metrics-aws-cloudwatch-retention --ignore-not-found
 helm upgrade observability-metrics-aws-cloudwatch \
   oci://ghcr.io/openchoreo/helm-charts/observability-metrics-aws-cloudwatch \
-  --namespace "$NS" --version 0.2.2 --reuse-values
+  --namespace "$NS" --version 0.2.3 --reuse-values
 ```
 
 #### Verify Pod Identity injection
@@ -757,7 +757,7 @@ helm upgrade --install observability-metrics-aws-cloudwatch \
   oci://ghcr.io/openchoreo/helm-charts/observability-metrics-aws-cloudwatch \
   --create-namespace \
   --namespace "$NS" \
-  --version 0.2.2 \
+  --version 0.2.3 \
   --set region="$AWS_REGION" \
   --set awsCredentials.create=true \
   --set awsCredentials.name=metrics-aws-cloudwatch-aws-credentials \
@@ -786,7 +786,7 @@ helm upgrade --install observability-metrics-aws-cloudwatch \
   oci://ghcr.io/openchoreo/helm-charts/observability-metrics-aws-cloudwatch \
   --create-namespace \
   --namespace "$NS" \
-  --version 0.2.2 \
+  --version 0.2.3 \
   --set region="$AWS_REGION" \
   --set awsCredentials.create=true \
   --set awsCredentials.name=metrics-aws-cloudwatch-aws-credentials \
@@ -808,7 +808,7 @@ helm upgrade --install observability-metrics-aws-cloudwatch \
   oci://ghcr.io/openchoreo/helm-charts/observability-metrics-aws-cloudwatch \
   --create-namespace \
   --namespace "$NS" \
-  --version 0.2.2 \
+  --version 0.2.3 \
   --set region="$AWS_REGION" \
   --set awsCredentials.create=true \
   --set awsCredentials.name=metrics-aws-cloudwatch-aws-credentials \
@@ -1131,7 +1131,7 @@ kubectl -n "$NS" delete job metrics-aws-cloudwatch-retention --ignore-not-found
 # 2. Re-fire the post-upgrade hook.
 helm upgrade observability-metrics-aws-cloudwatch \
   oci://ghcr.io/openchoreo/helm-charts/observability-metrics-aws-cloudwatch \
-  --version 0.2.2 --namespace "$NS" --reuse-values
+  --version 0.2.3 --namespace "$NS" --reuse-values
 
 # 3. Watch the new Job complete.
 kubectl -n "$NS" get job metrics-aws-cloudwatch-retention -w

--- a/observability-metrics-aws-cloudwatch/helm/Chart.yaml
+++ b/observability-metrics-aws-cloudwatch/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: observability-metrics-aws-cloudwatch
 description: A Helm chart for OpenChoreo Metrics Module for AWS CloudWatch
 type: application
-version: 0.2.2
-appVersion: "0.2.2"
+version: 0.2.3
+appVersion: "0.2.3"
 keywords:
   - cloudwatch
   - aws

--- a/observability-metrics-aws-cloudwatch/internal/cloudwatchmetrics/queries_test.go
+++ b/observability-metrics-aws-cloudwatch/internal/cloudwatchmetrics/queries_test.go
@@ -137,7 +137,7 @@ func TestGetResourceMetricsAppliesDefaultStep(t *testing.T) {
 }
 
 func TestGetResourceMetricsNormalizesSubMinuteStep(t *testing.T) {
-	now := time.Date(2026, 5, 4, 12, 0, 0, 0, time.UTC)
+	now := time.Now().UTC()
 	var captured *cloudwatch.GetMetricDataInput
 	api := &stubCloudWatchAPI{
 		getMetricDataFunc: func(in *cloudwatch.GetMetricDataInput) (*cloudwatch.GetMetricDataOutput, error) {
@@ -163,7 +163,7 @@ func TestGetResourceMetricsNormalizesSubMinuteStep(t *testing.T) {
 }
 
 func TestGetResourceMetricsRoundsPeriodToMinuteMultiple(t *testing.T) {
-	now := time.Date(2026, 5, 4, 12, 0, 0, 0, time.UTC)
+	now := time.Now().UTC()
 	var captured *cloudwatch.GetMetricDataInput
 	api := &stubCloudWatchAPI{
 		getMetricDataFunc: func(in *cloudwatch.GetMetricDataInput) (*cloudwatch.GetMetricDataOutput, error) {


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat: add observability-logs-opensearch module
  fix: handle opensearch startup delay in init script
  docs: update observability-logs-opensearch module installation guide
  chore(deps): bump fluent-bit version in observability-logs-openobserve module

See: https://github.com/openchoreo/openchoreo/blob/main/docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
This pull request updates the `observability-metrics-aws-cloudwatch` Helm chart and its documentation to use version 0.2.3, and makes a minor improvement to the test code for metric queries. The most important changes are:

Helm chart version update:

* Bumped the chart version and application version in `Chart.yaml` from `0.2.2` to `0.2.3`.

Documentation updates:

* Updated all `README.md` Helm install and upgrade command examples to reference version `0.2.3` instead of `0.2.2`. [[1]](diffhunk://#diff-fbf2b57634f862d5660c6eecf821ff792713ff1f623d59bb5a7529078c191a8aL446-R446) [[2]](diffhunk://#diff-fbf2b57634f862d5660c6eecf821ff792713ff1f623d59bb5a7529078c191a8aL461-R461) [[3]](diffhunk://#diff-fbf2b57634f862d5660c6eecf821ff792713ff1f623d59bb5a7529078c191a8aL479-R479) [[4]](diffhunk://#diff-fbf2b57634f862d5660c6eecf821ff792713ff1f623d59bb5a7529078c191a8aL615-R615) [[5]](diffhunk://#diff-fbf2b57634f862d5660c6eecf821ff792713ff1f623d59bb5a7529078c191a8aL632-R632) [[6]](diffhunk://#diff-fbf2b57634f862d5660c6eecf821ff792713ff1f623d59bb5a7529078c191a8aL760-R760) [[7]](diffhunk://#diff-fbf2b57634f862d5660c6eecf821ff792713ff1f623d59bb5a7529078c191a8aL789-R789) [[8]](diffhunk://#diff-fbf2b57634f862d5660c6eecf821ff792713ff1f623d59bb5a7529078c191a8aL811-R811) [[9]](diffhunk://#diff-fbf2b57634f862d5660c6eecf821ff792713ff1f623d59bb5a7529078c191a8aL1134-R1134)

Test code improvement:

* Changed hardcoded test timestamps in `queries_test.go` to use the current UTC time with `time.Now().UTC()`, making the tests less brittle and more maintainable. [[1]](diffhunk://#diff-006744cf2a1cd0dc5d484345031172ad3d11cb0272a0c602f954d4151773b649L140-R140) [[2]](diffhunk://#diff-006744cf2a1cd0dc5d484345031172ad3d11cb0272a0c602f954d4151773b649L166-R166)

Fixes continuous failures in the CI pipeline
## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
