### PR TITLE
chore: update versions for unpublished modules

### DIFF
--- a/observability-events-otel-collector/README.md
+++ b/observability-events-otel-collector/README.md
@@ -47,7 +47,7 @@ helm upgrade --install observability-events-otel-collector \
   oci://ghcr.io/openchoreo/helm-charts/observability-events-otel-collector \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.1.0
+  --version 0.1.1
 ```
 
 Out of the box the collector enriches events and prints them to its pod log via
@@ -108,7 +108,7 @@ pipelineExporters:
 ```bash
 helm upgrade --install observability-events-otel-collector \
   oci://ghcr.io/openchoreo/helm-charts/observability-events-otel-collector \
-  --namespace openchoreo-observability-plane --version 0.1.0 \
+  --namespace openchoreo-observability-plane --version 0.1.1 \
   -f opensearch-values.yaml
 ```
 
@@ -196,7 +196,7 @@ persistence:
 ```bash
 helm upgrade --install observability-events-otel-collector \
   oci://ghcr.io/openchoreo/helm-charts/observability-events-otel-collector \
-  --namespace openchoreo-observability-plane --version 0.1.0 --reuse-values \
+  --namespace openchoreo-observability-plane --version 0.1.1 --reuse-values \
   --set persistence.enabled=true \
   --set persistence.storageClassName=<your-storage-class>
 ```

--- a/observability-events-otel-collector/helm/Chart.yaml
+++ b/observability-events-otel-collector/helm/Chart.yaml
@@ -5,8 +5,8 @@ apiVersion: v2
 name: observability-events-otel-collector
 description: A custom OpenTelemetry Collector for OpenChoreo that watches Kubernetes events and enriches them with their involved object's labels, annotations, and owner reference.
 type: application
-version: 0.1.0
-appVersion: "0.1.0"
+version: 0.1.1
+appVersion: "0.1.1"
 keywords:
   - openchoreo
   - observability

--- a/observability-logs-azure-loganalytics/README.md
+++ b/observability-logs-azure-loganalytics/README.md
@@ -155,8 +155,10 @@ projects the federated token (see
 ## Installation on AKS
 
 ```bash
-helm install logs-adapter helm/ \
+helm upgrade --install logs-adapter \
+  oci://ghcr.io/openchoreo/helm-charts/observability-logs-azure-loganalytics \
   --namespace openchoreo-observability-plane --create-namespace \
+  --version 0.1.1 \
   --set azure.subscriptionId="$AZURE_SUBSCRIPTION_ID" \
   --set azure.resourceGroup="$AZURE_RESOURCE_GROUP" \
   --set azure.region="$AZURE_REGION" \

--- a/observability-logs-azure-loganalytics/helm/Chart.yaml
+++ b/observability-logs-azure-loganalytics/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: observability-logs-azure-loganalytics
 description: A Helm chart for OpenChoreo Logs Module for Azure Log Analytics
 type: application
-version: 0.1.0
-appVersion: "0.1.0"
+version: 0.1.1
+appVersion: "0.1.1"
 keywords:
   - azure
   - loganalytics

--- a/observability-logs-opensearch/README.md
+++ b/observability-logs-opensearch/README.md
@@ -63,7 +63,7 @@ helm upgrade --install observability-logs-opensearch \
   oci://ghcr.io/openchoreo/helm-charts/observability-logs-opensearch \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.5.0 \
+  --version 0.5.1 \
   --set adapter.openSearchSecretName="opensearch-admin-credentials" \
   --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials"
 ```
@@ -75,7 +75,7 @@ helm upgrade --install observability-logs-opensearch \
 >   oci://ghcr.io/openchoreo/helm-charts/observability-logs-opensearch \
 >   --create-namespace \
 >   --namespace openchoreo-observability-plane \
->   --version 0.5.0 \
+>   --version 0.5.1 \
 >   --set adapter.openSearchSecretName="opensearch-admin-credentials" \
 >   --set openSearch.enabled=false \
 >   --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials"
@@ -94,7 +94,7 @@ helm upgrade observability-logs-opensearch \
   oci://ghcr.io/openchoreo/helm-charts/observability-logs-opensearch \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.5.0 \
+  --version 0.5.1 \
   --reuse-values \
   --set fluent-bit.enabled=true
 ```
@@ -116,7 +116,7 @@ helm upgrade --install observability-logs-opensearch \
   oci://ghcr.io/openchoreo/helm-charts/observability-logs-opensearch \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.5.0 \
+  --version 0.5.1 \
   --set adapter.openSearchSecretName="opensearch-admin-credentials" \
   --set openSearch.enabled=false \
   --set openSearchCluster.enabled=true \
@@ -144,7 +144,7 @@ helm upgrade --install observability-logs-opensearch \
   oci://ghcr.io/openchoreo/helm-charts/observability-logs-opensearch \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.5.0 \
+  --version 0.5.1 \
   --set adapter.enabled=false \
   --set openSearch.enabled=false \
   --set openSearchCluster.enabled=false \

--- a/observability-logs-opensearch/helm/Chart.yaml
+++ b/observability-logs-opensearch/helm/Chart.yaml
@@ -5,8 +5,8 @@ apiVersion: v2
 name: observability-logs-opensearch
 description: A Helm chart for OpenChoreo Observability Logs module with Fluent Bit and OpenSearch
 type: application
-version: 0.5.0
-appVersion: "0.5.0"
+version: 0.5.1
+appVersion: "0.5.1"
 keywords:
   - opensearch
   - observability


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat: add observability-logs-opensearch module
  fix: handle opensearch startup delay in init script
  docs: update observability-logs-opensearch module installation guide
  chore(deps): bump fluent-bit version in observability-logs-openobserve module

See: https://github.com/openchoreo/openchoreo/blob/main/docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
This pull request updates the Helm chart versions for the `observability-events-otel-collector`, `observability-logs-azure-loganalytics`, and `observability-logs-opensearch` modules, along with their usage instructions in the documentation. These changes ensure that users are directed to use the latest releases and maintain consistency between the chart metadata and installation guides.

**Helm Chart Version Updates:**

* Bumped the version and `appVersion` fields to `0.1.1` in `observability-events-otel-collector/helm/Chart.yaml` and updated all relevant installation commands in the `README.md` to use version `0.1.1`. [[1]](diffhunk://#diff-d2935bf9563b4b939e2fa78e692084ab00232d7bc4fed921ed08e28ccc4bbd1aL8-R9) [[2]](diffhunk://#diff-d5a02dac3791c46440d88d967bf8a4825b732e1abe0afc6149131b651fecac94L50-R50) [[3]](diffhunk://#diff-d5a02dac3791c46440d88d967bf8a4825b732e1abe0afc6149131b651fecac94L111-R111) [[4]](diffhunk://#diff-d5a02dac3791c46440d88d967bf8a4825b732e1abe0afc6149131b651fecac94L199-R199)
* Updated the version and `appVersion` fields to `0.1.1` in `observability-logs-azure-loganalytics/helm/Chart.yaml` and changed the installation command in the `README.md` to use the OCI registry and the new version. [[1]](diffhunk://#diff-10c1e380a460a2c5c74a85fd5b9b2f0b813d073d0ac8fad3c909384a093a2b65L5-R6) [[2]](diffhunk://#diff-27608892b10c7e1a11e449cf28bd6732e7d991eff481a5bb41ecd084bcb42416L158-R161)
* Increased the version and `appVersion` fields to `0.5.1` in `observability-logs-opensearch/helm/Chart.yaml` and updated all relevant installation and upgrade commands in the `README.md` to reference version `0.5.1`. [[1]](diffhunk://#diff-15d27c981ebf6bae2695698eb22a7b3b85603d7b220b0593be584a10890f4b4fL8-R9) [[2]](diffhunk://#diff-fd71e04d0d90a17520142cd2ebf0edd038178bb67aa7a0fb462c2acc38f5ecc6L66-R66) [[3]](diffhunk://#diff-fd71e04d0d90a17520142cd2ebf0edd038178bb67aa7a0fb462c2acc38f5ecc6L78-R78) [[4]](diffhunk://#diff-fd71e04d0d90a17520142cd2ebf0edd038178bb67aa7a0fb462c2acc38f5ecc6L97-R97) [[5]](diffhunk://#diff-fd71e04d0d90a17520142cd2ebf0edd038178bb67aa7a0fb462c2acc38f5ecc6L119-R119) [[6]](diffhunk://#diff-fd71e04d0d90a17520142cd2ebf0edd038178bb67aa7a0fb462c2acc38f5ecc6L147-R147)

Reason:
changes to above modules in the PRs https://github.com/openchoreo/community-modules/pull/134, https://github.com/openchoreo/community-modules/pull/132, https://github.com/openchoreo/community-modules/pull/136 have not been published to to test step failure of another module which was fixed in https://github.com/openchoreo/community-modules/pull/137

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
