### PR TITLE
fix(observability-logs-azure-loganalytics): align resource names with chart name

### DIFF
--- a/observability-logs-azure-loganalytics/README.md
+++ b/observability-logs-azure-loganalytics/README.md
@@ -155,10 +155,10 @@ projects the federated token (see
 ## Installation on AKS
 
 ```bash
-helm upgrade --install logs-adapter \
+helm upgrade --install observability-logs-azure-loganalytics \
   oci://ghcr.io/openchoreo/helm-charts/observability-logs-azure-loganalytics \
   --namespace openchoreo-observability-plane --create-namespace \
-  --version 0.1.1 \
+  --version 0.1.2 \
   --set azure.subscriptionId="$AZURE_SUBSCRIPTION_ID" \
   --set azure.resourceGroup="$AZURE_RESOURCE_GROUP" \
   --set azure.region="$AZURE_REGION" \
@@ -280,7 +280,7 @@ The adapter's startup health check failed against
 `api.loganalytics.io`. Check the boot logs:
 
 ```bash
-kubectl -n openchoreo-observability-plane logs deploy/logs-adapter --tail=20
+kubectl -n openchoreo-observability-plane logs deploy/logs-adapter-azure-loganalytics --tail=100
 ```
 
 Common causes:

--- a/observability-logs-azure-loganalytics/helm/Chart.yaml
+++ b/observability-logs-azure-loganalytics/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: observability-logs-azure-loganalytics
 description: A Helm chart for OpenChoreo Logs Module for Azure Log Analytics
 type: application
-version: 0.1.1
-appVersion: "0.1.1"
+version: 0.1.2
+appVersion: "0.1.2"
 keywords:
   - azure
   - loganalytics

--- a/observability-logs-azure-loganalytics/helm/templates/adapter/deployment.yaml
+++ b/observability-logs-azure-loganalytics/helm/templates/adapter/deployment.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: logs-adapter
+  name: logs-adapter-azure-loganalytics
   namespace: {{ .Release.Namespace }}
   labels:
     app: logs-adapter-azure-loganalytics

--- a/observability-logs-azure-loganalytics/helm/templates/adapter/httproute.yaml
+++ b/observability-logs-azure-loganalytics/helm/templates/adapter/httproute.yaml
@@ -27,6 +27,6 @@ spec:
             type: Exact
             value: /api/v1alpha1/alerts/webhook
       backendRefs:
-        - name: logs-adapter
+        - name: logs-adapter-azure-loganalytics
           port: {{ .Values.adapter.service.port }}
 {{- end }}

--- a/observability-logs-azure-loganalytics/helm/templates/adapter/service.yaml
+++ b/observability-logs-azure-loganalytics/helm/templates/adapter/service.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: logs-adapter
+  name: logs-adapter-azure-loganalytics
   namespace: {{ .Release.Namespace }}
   labels:
     app: logs-adapter-azure-loganalytics


### PR DESCRIPTION
## Summary

- Align the chart's Deployment, Service, and HTTPRoute backendRef with the rest of the chart by using `logs-adapter-azure-loganalytics` everywhere. Previously the Deployment and Service were hardcoded as the shorter name `logs-adapter`, while the ServiceAccount, Secret, ConfigMap, NetworkPolicy, and selector labels already used `logs-adapter-azure-loganalytics`.
- Bump chart version and `appVersion` to `0.1.2`.
- Update the README install command to use `observability-logs-azure-loganalytics` as the Helm release name (matches the chart name, same convention as the CloudWatch module) and update the troubleshooting `kubectl logs deploy/...` reference to the new Deployment name.





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions and troubleshooting commands with enhanced log collection guidance.

* **Chores**
  * Bumped chart version to 0.1.2.

* **Refactor**
  * Improved internal resource naming consistency across adapter components for better clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->