### PR TITLE
feat: add autoscaling-keda module

### DIFF
--- a/autoscaling-keda/CONFIGURATION.md
+++ b/autoscaling-keda/CONFIGURATION.md
@@ -1,0 +1,401 @@
+# Configuration & Architecture
+
+The README covers installation and quick start. This document is the full parameter reference,
+tuning and extension guide, architecture rationale, and troubleshooting reference for the
+`autoscaling-keda` module and its `keda-based-scaling` trait.
+
+---
+
+## Parameter reference
+
+All parameters live under `spec.traits[].parameters` on the component. The trait is named
+`keda-based-scaling`, and the samples use the same value for `instanceName` — per-environment
+overrides in the `ReleaseBinding` are keyed by whatever `instanceName` you pick.
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `enabled` | boolean | `false` | Activates the trait. Nothing is rendered unless this is `true` and the data plane backend is `keda`. |
+| `minReplicas` | integer | `0` | Minimum replica count. `0` enables scale-to-zero. |
+| `maxReplicas` | integer | `10` | Maximum replica count KEDA will scale up to. |
+| `cooldownPeriod` | integer | `300` | Seconds all metrics must stay at zero before KEDA scales down to `minReplicas`. |
+| `trigger.type` | string | `""` | KEDA scaler type (e.g. `cron`, `kafka`). Empty string selects HTTP mode. |
+| `trigger.metadata` | map[string]string | `{}` | Scaler-specific metadata passed verbatim to the `ScaledObject` trigger. |
+| `interceptorNamespace` | string | `keda` | Namespace where the KEDA HTTP Add-on interceptor is installed. |
+| `interceptorService` | string | `keda-add-ons-http-interceptor-proxy` | Service name of the interceptor proxy. |
+| `interceptorPort` | integer | `8080` | Port on `interceptorService` the interceptor listens on. |
+| `interceptorMultiportService` | string | `keda-add-ons-http-interceptor-multiport` | Multiport front Service used for in-cluster wake (the ExternalName target). |
+| `wakeablePorts` | integer[] | `[80, 3000, 5000, 8000, 8080, 8081, 8090, 9000, 9090]` | Ports the multiport Service exposes. An HTTP-mode endpoint must use one of these. |
+| `interceptorScalerService` | string | `keda-add-ons-http-external-scaler` | The HTTP Add-on's external scaler Service (the companion `ScaledObject` pulls metrics from it). |
+| `interceptorScalerPort` | integer | `9090` | Port on `interceptorScalerService`. |
+| `requestRateTargetValue` | integer | `1` | Target requests/second per replica. KEDA scales up when rate exceeds this value. |
+| `requestRateWindow` | string | `"1m"` | Sliding window over which request rate is measured. |
+| `requestRateGranularity` | string | `"1s"` | Bucket granularity inside the window. |
+| `readinessTimeout` | string | `"120s"` | How long the interceptor holds the first request while a pod cold-starts. |
+
+### Per-environment overrides
+
+The trait's `environmentConfigs` schema exposes a subset of the parameters that platform engineers
+can override per environment from the `ReleaseBinding`, without touching the component definition:
+
+```yaml
+# environmentConfigs schema (minReplicas / maxReplicas / cooldownPeriod only)
+environmentConfigs:
+  openAPIV3Schema:
+    type: object
+    properties:
+      minReplicas:
+        type: integer
+        minimum: 0
+      maxReplicas:
+        type: integer
+        minimum: 1
+      cooldownPeriod:
+        type: integer
+        minimum: 0
+```
+
+In the `ReleaseBinding`, set `traitEnvironmentConfigs` keyed by the trait `instanceName`
+(`keda-based-scaling`):
+
+```yaml
+spec:
+  traitEnvironmentConfigs:
+    keda-based-scaling:
+      minReplicas: 1      # never scale to zero in production
+      maxReplicas: 10
+      cooldownPeriod: 600
+```
+
+When any of these fields is present, it wins over the component's `parameters` value for that
+environment. Fields absent from `environmentConfigs` (e.g. `trigger` or any HTTP metric knob)
+cannot be overridden this way — change them on the component.
+
+---
+
+## How HTTP scaling behaves
+
+HTTP mode scales on **request rate over a sliding window**, not instantaneous concurrency. The
+interceptor counts all requests that arrived in the last `requestRateWindow` (default `1m`) at
+`requestRateGranularity` resolution (default `1s`), and divides by the window length to get a
+rate in requests/second.
+
+KEDA scales up when that rate per replica exceeds `requestRateTargetValue` (default `1 req/s`),
+and begins the scale-down countdown only when the rate reaches zero across the full window. That
+means a service receiving even sparse traffic — say, one request every few seconds — holds a
+non-zero rate across the window and does not prematurely scale to zero. It scales down only once
+no request has arrived for the entire window, and then only after `cooldownPeriod` more seconds
+of idle.
+
+**Worked example.** One request per 10 seconds = 0.1 req/s. With `requestRateTargetValue: 1`,
+that rate is below the target, so one replica is sufficient. The rate stays non-zero for 1 minute
+after the last request, then KEDA starts the `cooldownPeriod` countdown before dropping to zero.
+With the defaults (`window: 1m`, `cooldownPeriod: 300`), the service stays awake for roughly
+6 minutes after the last request arrives.
+
+**Cold starts and the 120s timeout.** A cold start on a warmed cluster takes 2-4 seconds. The
+interceptor holds the first request in-flight until a pod passes readiness, bounded by
+`readinessTimeout` (default `120s`). The trait also patches the external `HTTPRoute` to set a
+`request` timeout of `120s` on the route, matching the interceptor's hold time so the gateway
+does not drop the request first. Do not set `readinessTimeout` longer than your gateway's
+absolute route timeout.
+
+The first cold start after a component is deployed can be slower — KEDA registers the new scaler
+against the `InterceptorRoute` during this window, and if the `ScaledObject` reconciles before
+the `InterceptorRoute` exists, KEDA may briefly fall back to a CPU metric. Retry once; subsequent
+cold starts are fast. See Troubleshooting for the fix if it persists.
+
+**`cooldownPeriod` tuning.** Lower values reduce idle cost but increase cold-start frequency.
+For services with a long start time, raise `readinessTimeout` and `cooldownPeriod` together to
+avoid a cycle of scale-down/immediate-scale-up under light traffic.
+
+---
+
+## Extending the module
+
+### Concurrency-based scaling
+
+HTTP mode currently scales on `requestRate` (requests per second over a window). The KEDA HTTP
+Add-on's `InterceptorRoute` also supports `concurrency` as a `scalingMetric`: target concurrent
+in-flight requests per replica. To switch, edit the `InterceptorRoute` template in
+`keda-based-scaling-trait.yaml` and replace the `requestRate` block under `scalingMetric` with
+a `concurrency` block. See the add-on's `InterceptorRoute` reference:
+https://github.com/kedacore/http-add-on/blob/main/docs/ref/v0.14.0/interceptor_route.md
+
+Concurrency is useful when requests are long-lived (e.g. streaming or WebSocket) and rate
+under-counts actual load.
+
+### Any KEDA scaler for workers and event-driven services
+
+`trigger.type` and `trigger.metadata` are passed straight through to the `ScaledObject`, so
+every scaler in the KEDA catalog works: cron, kafka, rabbitmq, prometheus, aws-sqs, azure-servicebus,
+and 70+ others. Full list: https://keda.sh/docs/latest/scalers/
+
+Example — RabbitMQ worker:
+
+```yaml
+parameters:
+  enabled: true
+  minReplicas: 0
+  maxReplicas: 5
+  trigger:
+    type: rabbitmq
+    metadata:
+      queueName: jobs
+      hostFromEnv: RABBITMQ_URL   # injected by a connection binding
+```
+
+For brokered scalers, use `hostFromEnv` pointing at an env var your workload connection already
+injects. Broker credentials stay out of the component definition and out of git.
+
+### Authenticated triggers
+
+KEDA scalers reference credentials through `triggers[].authenticationRef`, pointing at a
+`TriggerAuthentication`/`ClusterTriggerAuthentication` object. The trait does not expose
+`authenticationRef` as a parameter today — to use it, extend the trigger-mode `ScaledObject`
+template in `keda-based-scaling-trait.yaml`. The module's RBAC already lets the cluster-agent
+manage `triggerauthentications`/`clustertriggerauthentications`, so no extra permissions are
+needed. See the KEDA authentication reference:
+https://keda.sh/docs/latest/concepts/authentication/
+
+Where possible, prefer `hostFromEnv`-style metadata (above) over authenticated triggers — it
+needs no extra objects.
+
+### Wakeable ports
+
+The default wakeable ports are `[80, 3000, 5000, 8000, 8080, 8081, 8090, 9000, 9090]`. An
+HTTP-mode endpoint must listen on one of these because the component's Service is turned into
+an ExternalName DNS CNAME — a CNAME cannot remap ports, so the caller-facing port must be a port
+the interceptor already answers on.
+
+To add a port:
+
+1. Add it to `keda-interceptor-multiport.yaml` (the `ports` list on the Service) and re-apply.
+2. Add it to the `wakeablePorts` default in `keda-based-scaling-trait.yaml` and re-apply the
+   trait.
+
+Keep the two in sync. The trait's validation rule checks `ep.port in parameters.wakeablePorts`
+and rejects a component at render time if the endpoint port is not in the list.
+
+### Interceptor installed elsewhere
+
+If the KEDA HTTP Add-on is installed in a namespace other than `keda`, or with non-default
+Service names or ports, set the corresponding parameters on the trait attachment:
+
+```yaml
+parameters:
+  interceptorNamespace: my-keda
+  interceptorService: my-interceptor-proxy
+  interceptorPort: 8080
+  interceptorMultiportService: my-interceptor-multiport
+  interceptorScalerService: my-external-scaler
+  interceptorScalerPort: 9090
+```
+
+These values are per-component, so different components in the same cluster can point at
+different interceptor installations.
+
+### Other component types
+
+The HTTP path requires a specific shape from the component type:
+
+- A Deployment named `${metadata.name}`
+- A Service named `${metadata.componentName}`
+- Exactly one external `HTTPRoute` carrying the `openchoreo.dev/endpoint-visibility: external` label
+
+Any `ClusterComponentType` that produces this shape can allow the trait by adding
+`keda-based-scaling` to its `allowedTraits` list (delete + recreate, as described in the README's
+Install step 3).
+
+The trigger/worker path is simpler: it only needs the Deployment. Any deployment-based component
+type works.
+
+### Other gateways
+
+The HTTP path is kgateway-specific. The trait routes to the interceptor through a
+`gateway.kgateway.dev/Backend` in the component's namespace; this Backend requires no
+cross-namespace `ReferenceGrant` because it is local to the workload namespace.
+
+On another Gateway API implementation, adapt the `creates` entry for the Backend resource and
+the HTTPRoute patch. The equivalent approach is a cross-namespace Service `backendRef` pointing
+at the interceptor, plus a `ReferenceGrant` in the interceptor namespace permitting it.
+
+### Advanced ScaledObject tuning
+
+The trait does not expose every `ScaledObject` field as a parameter. Fields like `fallback`
+(behavior when the scaler is unavailable) and
+`advanced.horizontalPodAutoscalerConfig.behavior` (scale-up/scale-down stabilization windows)
+can be added by editing the `ScaledObject` templates directly in the trait. Full spec reference:
+https://keda.sh/docs/latest/reference/scaledobject-spec/
+
+---
+
+## Architecture
+
+### Backend annotation contract
+
+The trait reads `dataplane.annotations["openchoreo.dev/keda-based-scaling-backend"]` from the
+render context (available from OpenChoreo 1.2 onward). When the value is `keda`, the trait
+renders KEDA objects. When the annotation is absent or set to any other value, the trait is
+completely inert — the component runs at its configured static replica count. No per-environment
+forking is needed: the same component definition runs normally on a plane without KEDA and scales
+to zero on a plane that advertises `keda`.
+
+Annotate the data plane to activate:
+
+```bash
+kubectl annotate clusterdataplane default \
+  openchoreo.dev/keda-based-scaling-backend=keda --overwrite
+```
+
+### Rendering modes
+
+| Mode | Condition | Renders |
+|---|---|---|
+| **HTTP** | `enabled: true`, backend `keda`, `trigger.type == ""`, one external HTTP/GraphQL/WebSocket endpoint | `InterceptorRoute` + companion `ScaledObject`, kgateway `Backend`, pod-backing Service, patches to ExternalName the component's Service and repoint the `HTTPRoute` |
+| **Trigger** | `enabled: true`, backend `keda`, `trigger.type != ""` | `ScaledObject` with the given trigger |
+
+Both modes patch the Deployment to remove `spec.replicas`, handing replica ownership to KEDA.
+If `spec.replicas` remained, server-side apply would reset it on every render and fight the
+autoscaler.
+
+### The 0.14 split model
+
+HTTP scaling uses the KEDA HTTP Add-on 0.14 split model. An `InterceptorRoute`
+(`http.keda.sh/v1beta1`) carries the routing rule (which hosts to intercept, which upstream to
+forward to) and the scaling metric (`requestRate` with target, window, and granularity). A
+companion `ScaledObject` carries the scale target (the Deployment) and the replica bounds
+(`minReplicaCount: 0` is what enables scale-to-zero).
+
+In 0.14, the `InterceptorRoute` controller does **not** create the `ScaledObject` automatically.
+The trait renders both. The `InterceptorRoute` is rendered first so the external scaler has a
+metric spec to report by the time the `ScaledObject` reconciles; if the `ScaledObject` arrives
+first, KEDA may briefly fall back to CPU.
+
+### In-cluster wake: the ExternalName alias mechanism
+
+OpenChoreo connection bindings inject the callee's in-cluster Service URL
+(`http://<component>.<ns>.svc.cluster.local:<port>`). Without intervention that URL goes directly
+to the Deployment pods and is refused while the service sleeps.
+
+In HTTP mode the trait closes that gap:
+
+1. **Component Service → ExternalName.** The component's own Service (named
+   `${metadata.componentName}`) is patched to `type: ExternalName`, with `externalName` pointing
+   at `keda-add-ons-http-interceptor-multiport.<interceptorNamespace>.svc.cluster.local`. An
+   in-cluster call to the injected URL now resolves to the interceptor.
+2. **Pod-backing Service.** A separate ClusterIP Service (`${componentName}-keda-upstream`) is
+   created with the original pod selector and ports. The `InterceptorRoute` forwards here after a
+   pod is ready.
+3. **Host-based routing.** The `InterceptorRoute` registers exactly one `rules[].hosts` entry:
+   the component's FQDN (`<componentName>.<namespace>.svc.cluster.local`). The HTTPRoute patch
+   adds a `urlRewrite.hostname` filter rewriting the outbound Host header to this FQDN, so
+   gateway traffic and in-cluster traffic match the same interceptor rule.
+
+The Service is born as ExternalName on first render, so there is no ClusterIP → ExternalName
+mutation to trip over. If you convert a long-lived component and the data-plane apply rejects the
+in-place Service type change, redeploy the component so the Service is recreated from scratch.
+
+### Why exactly one HTTP endpoint
+
+Two intrinsic constraints force the single-endpoint shape:
+
+**One Service, one Host.** OpenChoreo gives a component a single Service (one DNS name, possibly
+many ports). Connection bindings inject that one name. Every endpoint on the component is reached
+as the same host (`<component>.<ns>.svc.cluster.local`), differing only by port. The KEDA
+interceptor routes purely by the `Host` header — it strips the port first. So it cannot
+distinguish two endpoints on the same component: a second endpoint would be silently forwarded to
+the wrong port. Hence exactly one endpoint.
+
+**A CNAME cannot remap ports.** An ExternalName Service is a DNS CNAME. A caller hitting the
+component on its endpoint port lands on the interceptor on that same port. So the endpoint port
+must be one the interceptor already answers on. The multiport Service (`keda-interceptor-multiport.yaml`)
+fronts the interceptor on a set of common ports precisely to avoid pinning every service to a
+single port. Hence the endpoint port must be in `wakeablePorts`.
+
+A service that does not fit (multiple endpoints, or a port outside `wakeablePorts`) has three
+escape hatches:
+
+- Split extra endpoints into a separate component, each with its own trait attachment.
+- Add the port to `keda-interceptor-multiport.yaml` and `wakeablePorts`.
+- Keep `minReplicas >= 1` on the component (no scale-to-zero, no ExternalName takeover).
+
+---
+
+## Limitations
+
+- **Exactly one external HTTP endpoint per service in HTTP mode.** The interceptor routes by
+  `Host` only (port stripped), and the ExternalName alias is a DNS CNAME that cannot remap ports.
+  See the Architecture section for the full rationale and escape hatches.
+- **The HTTP path is kgateway-specific.** The trait routes to the interceptor through a
+  `gateway.kgateway.dev/Backend`. On a different Gateway API implementation, adapt the Backend
+  resource and the HTTPRoute patch (cross-namespace Service backendRef + `ReferenceGrant` works).
+- **Component types are a 1.2 snapshot.** The `componenttypes/service.yaml` and
+  `componenttypes/worker.yaml` files mirror the stock OpenChoreo 1.2 defaults. If your platform
+  customizes those types, regenerate from your live types instead of applying the committed copies.
+- **Mutually exclusive with HPA-style traits.** Both claim ownership of the Deployment's replica
+  count. Do not attach both an HPA-style trait and `keda-based-scaling` to the same component.
+- **Cilium-signal backend** (`backend: cilium`) is a future path and is not implemented.
+
+---
+
+## Troubleshooting
+
+- **Nothing scales / no KEDA objects rendered.** Confirm the data plane annotation:
+  ```bash
+  kubectl get clusterdataplane default -o jsonpath='{.metadata.annotations}'
+  ```
+  Without `openchoreo.dev/keda-based-scaling-backend=keda` the trait is intentionally inert.
+  Also confirm the trait is attached under `spec.traits` and that the component type allows it:
+  ```bash
+  kubectl get clustercomponenttype service -o jsonpath='{.spec.allowedTraits[*].name}'
+  ```
+
+- **First request returns a 504 or hangs for ~60s.** Usually the KEDA scaling pipeline warming
+  up for a newly-created `InterceptorRoute`/`ScaledObject`, or the interceptor/scaler pods not
+  Ready yet. Wait for the `keda-add-ons-http-*` rollouts and retry — later cold starts complete
+  in a few seconds.
+
+- **HTTP service never wakes / scale-up doesn't work; the HPA shows a `cpu` metric.** The
+  companion `ScaledObject` was reconciled before its `InterceptorRoute` existed, so the external
+  scaler returned an empty metric spec and KEDA fell back to CPU. The trait renders the
+  `InterceptorRoute` first, but if you hit this, re-apply the binding (or delete the
+  `ScaledObject`) so KEDA re-reads the route's metric. Confirm with:
+  ```bash
+  kubectl get scaledobject -n <wl-ns> -o jsonpath='{.items[0].spec.triggers}'
+  ```
+
+- **Every request 504s after ~60s, even though the pod wakes and is Ready.** The interceptor
+  pods are missing the `openchoreo.dev/system-component` label, so the component's NetworkPolicy
+  drops the interceptor's forwards. Re-install the HTTP add-on with the `additionalLabels` flag
+  from the README and check:
+  ```bash
+  kubectl get pods -n keda --show-labels
+  ```
+
+- **Request returns 404 or 503 after scaling to zero.** Check the kgateway `Backend` exists in
+  the workload namespace and the `HTTPRoute` backendRef was repointed at it:
+  ```bash
+  kubectl get backends.gateway.kgateway.dev,httproute -n <wl-ns> -o yaml
+  ```
+
+- **Agent can't create ScaledObjects (RBAC forbidden in cluster-agent logs).** Confirm the RBAC
+  was applied and bound to the right ServiceAccount:
+  ```bash
+  kubectl get clusterrolebinding openchoreo-cluster-agent-keda -o yaml
+  ```
+
+- **In-cluster (service-to-service) calls don't wake the service.** Confirm the callee's Service
+  became an ExternalName:
+  ```bash
+  kubectl get svc <component> -n <wl-ns> -o jsonpath='{.spec.type}'   # should print ExternalName
+  ```
+  Confirm the in-cluster FQDN appears in the `InterceptorRoute` `rules[].hosts`. Then check the
+  multiport front actually selects the interceptor pods:
+  ```bash
+  kubectl get endpoints keda-add-ons-http-interceptor-multiport -n keda
+  ```
+  If that is empty, the selector in `keda-interceptor-multiport.yaml` does not match your
+  add-on's interceptor pod labels. Compare with:
+  ```bash
+  kubectl get svc keda-add-ons-http-interceptor-proxy -n keda -o jsonpath='{.spec.selector}'
+  ```

--- a/autoscaling-keda/README.md
+++ b/autoscaling-keda/README.md
@@ -1,0 +1,256 @@
+# Autoscaling with KEDA
+
+Scale OpenChoreo components on demand with [KEDA](https://keda.sh). HTTP services scale to zero
+when idle and wake on the first request — the KEDA HTTP Add-on interceptor holds it, nothing is
+dropped; in-cluster service-to-service calls wake them too. Workers scale on cron or queue triggers.
+You attach the `keda-based-scaling` trait to a plain service or worker component and set a few
+parameters.
+
+**What's in the module:**
+
+- `keda-based-scaling-trait.yaml` — the `ClusterTrait` that renders the right KEDA objects per
+  data plane
+- `cluster-agent-keda-rbac.yaml` — RBAC so the data-plane cluster-agent can manage KEDA objects
+- `keda-interceptor-multiport.yaml` — a multi-port Service fronting the interceptor for in-cluster
+  wake
+- `componenttypes/service.yaml` + `componenttypes/worker.yaml` — reference examples showing the
+  `keda-based-scaling` entry added to `allowedTraits`; patch your own types rather than applying these
+
+KEDA core and the KEDA HTTP Add-on install from their upstream Helm charts (see Install below) —
+this module provides only the OpenChoreo glue.
+
+---
+
+## How it works
+
+A data plane opts in by carrying the annotation
+`openchoreo.dev/keda-based-scaling-backend: keda`. The trait reads that annotation at render time;
+on planes without it the trait is inert, so a component definition is portable across environments.
+
+| Mode | When | What KEDA creates |
+|------|------|-------------------|
+| **HTTP** | service with one external HTTP endpoint, no `trigger.type` | `InterceptorRoute` + companion `ScaledObject`; gateway and in-cluster traffic both wake the service |
+| **Trigger** | any component with `trigger.type` set | `ScaledObject` with that trigger (cron, kafka, rabbitmq, …) |
+
+Requires OpenChoreo 1.2+. Full architecture, tuning, and extension details: [CONFIGURATION.md](./CONFIGURATION.md).
+
+---
+
+## Prerequisites
+
+- An OpenChoreo 1.2+ control plane and data plane. For a fresh local cluster, follow the
+  [single-cluster k3d guide](https://github.com/openchoreo/openchoreo/blob/main/install/k3d/single-cluster/README.md)
+  through step 5.
+- `kubectl`, `helm`, `jq`, `yq`, and cluster access.
+- The data-plane gateway must be **kgateway** (the OpenChoreo default). For other Gateway API
+  implementations, see [CONFIGURATION.md](./CONFIGURATION.md).
+
+---
+
+## Install
+
+### 1. Install KEDA core, then the HTTP Add-on
+
+KEDA's CRDs must be established before the HTTP Add-on's resources are applied, so install them as
+two separate releases.
+
+```bash
+helm repo add kedacore https://kedacore.github.io/charts && helm repo update kedacore
+
+# KEDA core
+helm upgrade --install keda kedacore/keda --version 2.20.1 \
+  --namespace keda --create-namespace
+kubectl wait --for=condition=Established \
+  crd/scaledobjects.keda.sh crd/triggerauthentications.keda.sh --timeout=120s
+kubectl wait --for=condition=Available deployment/keda-operator -n keda --timeout=180s
+
+# KEDA HTTP Add-on (interceptor + scaler)
+helm upgrade --install keda-add-ons-http kedacore/keda-add-ons-http --version 0.14.1 \
+  --namespace keda \
+  --set 'additionalLabels.openchoreo\.dev/system-component=keda-http-addon'
+kubectl wait --for=condition=Established crd/interceptorroutes.http.keda.sh --timeout=120s
+```
+
+> The `additionalLabels` flag is required. OpenChoreo renders a NetworkPolicy per component that
+> only admits traffic from the same namespace or from pods carrying the
+> `openchoreo.dev/system-component` label. Without it, on any cluster whose CNI enforces
+> NetworkPolicy (k3s/k3d included), the interceptor's forwards are silently dropped and every
+> request times out with a 504 — even though the wake-up itself succeeds.
+
+### 2. Apply the trait and data-plane resources
+
+```bash
+kubectl apply --server-side -f https://raw.githubusercontent.com/openchoreo/community-modules/main/autoscaling-keda/keda-based-scaling-trait.yaml
+
+kubectl apply \
+  -f https://raw.githubusercontent.com/openchoreo/community-modules/main/autoscaling-keda/cluster-agent-keda-rbac.yaml \
+  -f https://raw.githubusercontent.com/openchoreo/community-modules/main/autoscaling-keda/keda-interceptor-multiport.yaml
+```
+
+### 3. Enable the trait on your component types
+
+Patch `keda-based-scaling` into `allowedTraits` on the component types you use. No components
+need to be deleted or recreated — the change takes effect immediately:
+
+```bash
+kubectl patch clustercomponenttype <your-type> --type=json \
+  -p '[{"op":"add","path":"/spec/allowedTraits/-","value":{"kind":"ClusterTrait","name":"keda-based-scaling"}}]'
+```
+
+`componenttypes/service.yaml` and `componenttypes/worker.yaml` in this module are reference
+examples showing the full type definition with the trait included — use them as a guide, not as
+a replacement for your own types. See [CONFIGURATION.md](./CONFIGURATION.md) for the shape
+requirements a component type must satisfy to be compatible with the HTTP scaling path.
+
+### 4. Annotate the data plane
+
+```bash
+kubectl annotate clusterdataplane default \
+  openchoreo.dev/keda-based-scaling-backend=keda --overwrite
+```
+
+### 5. Verify
+
+```bash
+kubectl rollout status deploy/keda-add-ons-http-interceptor -n keda --timeout=180s
+kubectl rollout status deploy/keda-add-ons-http-external-scaler -n keda --timeout=180s
+
+kubectl get clustertrait keda-based-scaling
+kubectl get clustercomponenttype service worker \
+  -o jsonpath='{range .items[*]}{.metadata.name}{": "}{.spec.allowedTraits[*].name}{"\n"}{end}'
+kubectl get clusterrolebinding openchoreo-cluster-agent-keda
+
+# Non-empty Endpoints means the interceptor multiport Service is working:
+kubectl get endpoints keda-add-ons-http-interceptor-multiport -n keda
+```
+
+---
+
+## Quick start
+
+### HTTP service that scales to zero
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/openchoreo/community-modules/main/autoscaling-keda/samples/http-service.yaml
+```
+
+Find the workload namespace OpenChoreo created (re-run if empty — it appears once the
+ReleaseBinding has rendered):
+
+```bash
+WL_NS=$(kubectl get ns -o name | sed 's|namespace/||' | grep '^dp-default-default-development')
+echo "$WL_NS"
+```
+
+Watch it scale to zero (after ~30s of no traffic):
+
+```bash
+kubectl get deploy -n "$WL_NS" -w        # replicas -> 0, then Ctrl-C
+```
+
+Hit it — the interceptor holds the request and wakes a pod:
+
+```bash
+curl http://development-default.openchoreoapis.localhost:19080/greeter-http/
+# Hello from OpenChoreo Autoscaling with KEDA!
+```
+
+```bash
+kubectl get deploy -n "$WL_NS"           # replicas back to 1 right after the request
+```
+
+The very first cold start after deploying can be slow or return a 504 while KEDA registers the new
+scaler — retry once. Subsequent cold starts take ~2-4s; the trait sets a 120s route timeout so the
+gateway holds the request through them.
+
+### Cron worker that scales to zero
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/openchoreo/community-modules/main/autoscaling-keda/samples/cron-worker.yaml
+```
+
+The worker runs at 1 replica inside its cron window (`03:00–04:00 UTC` in the sample) and sits at
+zero the other 23 hours — so right after applying it you see the scaled-to-zero state:
+
+```bash
+WL_NS=$(kubectl get ns -o name | sed 's|namespace/||' | grep '^dp-default-default-development')
+kubectl get scaledobject -n "$WL_NS"
+kubectl get deploy -n "$WL_NS"
+```
+
+To prove scaling quickly, edit the component's `trigger.metadata.start`/`end` to a window starting
+a couple of minutes from now and watch the Deployment go `0 -> 1 -> 0`. Swap `type`/`metadata` for
+any [KEDA scaler](https://keda.sh/docs/latest/scalers/) (`rabbitmq`, `kafka`, `prometheus`, …).
+
+---
+
+## Usage
+
+Attach the trait under `spec.traits` on your component:
+
+```yaml
+spec:
+  componentType:
+    kind: ClusterComponentType
+    name: deployment/service          # or deployment/worker
+  traits:
+    - kind: ClusterTrait
+      name: keda-based-scaling
+      instanceName: keda-based-scaling
+      parameters:
+        enabled: true
+        minReplicas: 0
+        maxReplicas: 5
+        cooldownPeriod: 300           # seconds idle before scaling down
+        trigger:                      # omit for HTTP services; required for workers
+          type: cron
+          metadata:
+            timezone: "Etc/UTC"
+            start: "0 8 * * *"
+            end: "0 20 * * *"
+            desiredReplicas: "1"
+```
+
+Platform engineers can floor the bounds per environment from the `ReleaseBinding`:
+
+```yaml
+spec:
+  traitEnvironmentConfigs:
+    keda-based-scaling:
+      minReplicas: 1        # never scale to zero in production
+      maxReplicas: 10
+```
+
+Full parameter reference, tuning (request rate vs. concurrency), extension points, architecture,
+and troubleshooting are in [CONFIGURATION.md](./CONFIGURATION.md).
+
+---
+
+## Limitations
+
+- **One external HTTP endpoint per service** — the interceptor routes by `Host` only (port
+  stripped), and an ExternalName alias can't remap ports; see CONFIGURATION.md.
+- **HTTP path is kgateway-specific** — uses `gateway.kgateway.dev/Backend`; adapt for other
+  Gateway API implementations per CONFIGURATION.md.
+- **Mutually exclusive with HPA traits** — both claim the Deployment's replica count; don't attach
+  both to the same component.
+
+---
+
+## Uninstall
+
+```bash
+# Detach the trait from your components first (remove the keda-based-scaling entry from
+# spec.traits), then:
+kubectl annotate clusterdataplane default openchoreo.dev/keda-based-scaling-backend-
+kubectl delete \
+  -f https://raw.githubusercontent.com/openchoreo/community-modules/main/autoscaling-keda/keda-interceptor-multiport.yaml \
+  -f https://raw.githubusercontent.com/openchoreo/community-modules/main/autoscaling-keda/cluster-agent-keda-rbac.yaml \
+  -f https://raw.githubusercontent.com/openchoreo/community-modules/main/autoscaling-keda/keda-based-scaling-trait.yaml
+# To revert the component types, remove keda-based-scaling from allowedTraits:
+#   kubectl patch clustercomponenttype service worker --type=json \
+#     -p '[{"op":"remove","path":"/spec/allowedTraits/<index>"}]'
+#   (find the index with: kubectl get clustercomponenttype service -o jsonpath='{.spec.allowedTraits}')
+# optionally:
+# helm uninstall keda-add-ons-http keda -n keda
+```

--- a/autoscaling-keda/cluster-agent-keda-rbac.yaml
+++ b/autoscaling-keda/cluster-agent-keda-rbac.yaml
@@ -1,0 +1,49 @@
+# Copyright 2026 The OpenChoreo Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenChoreo data-plane cluster-agent applies the rendered KEDA objects, but
+# its base ClusterRole does not include the KEDA API groups. This grants the agent
+# ServiceAccount permission to manage the KEDA resources the keda-based-scaling trait
+# renders.
+#
+# The subject below is the standard data-plane agent ServiceAccount
+# (`cluster-agent-dataplane` in `openchoreo-data-plane`). If your data plane uses a
+# different ServiceAccount name or namespace, edit the ClusterRoleBinding subject.
+# Apply this on the cluster running the OpenChoreo data plane.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: openchoreo-cluster-agent-keda
+  labels:
+    app.kubernetes.io/name: autoscaling-keda
+    app.kubernetes.io/part-of: openchoreo
+    app.kubernetes.io/component: cluster-agent
+rules:
+  - apiGroups: ["keda.sh"]
+    resources:
+      - scaledobjects
+      - scaledjobs
+      - triggerauthentications
+      - clustertriggerauthentications
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["http.keda.sh"]
+    resources:
+      - interceptorroutes
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: openchoreo-cluster-agent-keda
+  labels:
+    app.kubernetes.io/name: autoscaling-keda
+    app.kubernetes.io/part-of: openchoreo
+    app.kubernetes.io/component: cluster-agent
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: openchoreo-cluster-agent-keda
+subjects:
+  - kind: ServiceAccount
+    name: cluster-agent-dataplane
+    namespace: openchoreo-data-plane

--- a/autoscaling-keda/componenttypes/service.yaml
+++ b/autoscaling-keda/componenttypes/service.yaml
@@ -1,0 +1,279 @@
+# Copyright 2026 The OpenChoreo Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The stock OpenChoreo `service` ClusterComponentType with `keda-based-scaling` added to
+# allowedTraits. That single addition lets a developer ATTACH the keda-based-scaling trait to a
+# plain service component (spec.traits) and configure it.
+#
+# Regenerate from YOUR platform's live default type (so it never drifts from your OpenChoreo
+# version) with:
+#   kubectl get clustercomponenttype service -o json \
+#     | jq 'del(.metadata.managedFields,.metadata.resourceVersion,.metadata.uid,.metadata.creationTimestamp,.metadata.generation,.status,.metadata.annotations["kubectl.kubernetes.io/last-applied-configuration"])
+#           | if ([.spec.allowedTraits[]?.name] | index("keda-based-scaling")) then . else .spec.allowedTraits += [{"kind":"ClusterTrait","name":"keda-based-scaling"}] end' \
+#     | yq -p json -o yaml
+#
+# Apply by DELETE + RECREATE, never `kubectl apply`: first delete any components using this
+# type, then `kubectl delete clustercomponenttype service` and `kubectl create -f` this file.
+apiVersion: openchoreo.dev/v1alpha1
+kind: ClusterComponentType
+metadata:
+  annotations:
+    openchoreo.dev/description: A long-running request-serving component with one or more endpoints
+  name: service
+spec:
+  allowedTraits:
+    - kind: ClusterTrait
+      name: observability-alert-rule
+    - kind: ClusterTrait
+      name: keda-based-scaling
+  allowedWorkflows:
+    - kind: ClusterWorkflow
+      name: paketo-buildpacks-builder
+    - kind: ClusterWorkflow
+      name: gcp-buildpacks-builder
+    - kind: ClusterWorkflow
+      name: dockerfile-builder
+    - kind: ClusterWorkflow
+      name: ballerina-buildpack-builder
+  environmentConfigs:
+    openAPIV3Schema:
+      $defs:
+        ResourceQuantity:
+          default: {}
+          properties:
+            cpu:
+              default: 100m
+              type: string
+            memory:
+              default: 256Mi
+              type: string
+          type: object
+        ResourceRequirements:
+          default: {}
+          properties:
+            limits:
+              $ref: '#/$defs/ResourceQuantity'
+            requests:
+              $ref: '#/$defs/ResourceQuantity'
+          type: object
+      properties:
+        imagePullPolicy:
+          default: IfNotPresent
+          enum:
+            - Always
+            - IfNotPresent
+            - Never
+          type: string
+        replicas:
+          default: 1
+          minimum: 0
+          type: integer
+        resources:
+          $ref: '#/$defs/ResourceRequirements'
+      type: object
+  resources:
+    - id: deployment
+      targetPlane: dataplane
+      template:
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          labels: ${metadata.labels}
+          name: ${metadata.name}
+          namespace: ${metadata.namespace}
+        spec:
+          replicas: ${environmentConfigs.replicas}
+          selector:
+            matchLabels: ${metadata.podSelectors}
+          template:
+            metadata:
+              labels: ${metadata.podSelectors}
+            spec:
+              containers:
+                - args: |
+                    ${has(workload.container.args) ? workload.container.args : oc_omit()}
+                  command: |
+                    ${has(workload.container.command) ? workload.container.command : oc_omit()}
+                  env: ${dependencies.toContainerEnvs()}
+                  envFrom: ${configurations.toContainerEnvFrom()}
+                  image: ${workload.container.image}
+                  imagePullPolicy: ${environmentConfigs.imagePullPolicy}
+                  name: main
+                  resources:
+                    limits:
+                      cpu: ${environmentConfigs.resources.limits.cpu}
+                      memory: ${environmentConfigs.resources.limits.memory}
+                    requests:
+                      cpu: ${environmentConfigs.resources.requests.cpu}
+                      memory: ${environmentConfigs.resources.requests.memory}
+                  volumeMounts: ${configurations.toContainerVolumeMounts() + dependencies.toContainerVolumeMounts()}
+              volumes: ${configurations.toVolumes() + dependencies.toVolumes()}
+    - id: service
+      includeWhen: ${size(workload.endpoints) > 0}
+      targetPlane: dataplane
+      template:
+        apiVersion: v1
+        kind: Service
+        metadata:
+          labels: ${metadata.labels}
+          name: ${metadata.componentName}
+          namespace: ${metadata.namespace}
+        spec:
+          ports: ${workload.toServicePorts()}
+          selector: ${metadata.podSelectors}
+          type: ClusterIP
+    - forEach: ${workload.endpoints.transformMap(name, ep, "external" in ep.visibility && ep.type in ["HTTP", "GraphQL", "Websocket"], ep)}
+      id: httproute-external
+      targetPlane: dataplane
+      template:
+        apiVersion: gateway.networking.k8s.io/v1
+        kind: HTTPRoute
+        metadata:
+          labels: '${oc_merge(metadata.labels, {"openchoreo.dev/endpoint-name": endpoint.key, "openchoreo.dev/endpoint-visibility": "external"})}'
+          name: ${oc_generate_name(metadata.componentName, endpoint.key)}
+          namespace: ${metadata.namespace}
+        spec:
+          hostnames: |
+            ${[gateway.ingress.external.?http, gateway.ingress.external.?https]
+              .filter(g, g.hasValue()).map(g, g.value().host).distinct()
+              .map(h, metadata.environmentName + "-" + metadata.componentNamespace + "." + h)}
+          parentRefs:
+            - name: ${gateway.ingress.external.name}
+              namespace: ${gateway.ingress.external.namespace}
+          rules:
+            - backendRefs:
+                - name: ${metadata.componentName}
+                  port: ${endpoint.value.port}
+              filters:
+                - type: URLRewrite
+                  urlRewrite:
+                    path:
+                      replacePrefixMatch: ${endpoint.value.?basePath.orValue("/")}
+                      type: ReplacePrefixMatch
+              matches:
+                - path:
+                    type: PathPrefix
+                    value: /${metadata.componentName}-${endpoint.key}
+      var: endpoint
+    - forEach: ${workload.endpoints.transformMap(name, ep, "internal" in ep.visibility && ep.type in ["HTTP", "GraphQL", "Websocket"], ep)}
+      id: httproute-internal
+      targetPlane: dataplane
+      template:
+        apiVersion: gateway.networking.k8s.io/v1
+        kind: HTTPRoute
+        metadata:
+          labels: '${oc_merge(metadata.labels, {"openchoreo.dev/endpoint-name": endpoint.key, "openchoreo.dev/endpoint-visibility": "internal"})}'
+          name: ${oc_generate_name(metadata.componentName, endpoint.key, "internal")}
+          namespace: ${metadata.namespace}
+        spec:
+          hostnames: |
+            ${[gateway.ingress.internal.?http, gateway.ingress.internal.?https]
+              .filter(g, g.hasValue()).map(g, g.value().host).distinct()
+              .map(h, metadata.environmentName + "-" + metadata.componentNamespace + "." + h)}
+          parentRefs:
+            - name: ${gateway.ingress.internal.name}
+              namespace: ${gateway.ingress.internal.namespace}
+          rules:
+            - backendRefs:
+                - name: ${metadata.componentName}
+                  port: ${endpoint.value.port}
+              filters:
+                - type: URLRewrite
+                  urlRewrite:
+                    path:
+                      replacePrefixMatch: ${endpoint.value.?basePath.orValue("/")}
+                      type: ReplacePrefixMatch
+              matches:
+                - path:
+                    type: PathPrefix
+                    value: /${metadata.componentName}-${endpoint.key}
+      var: endpoint
+    - forEach: ${configurations.toConfigEnvsByContainer()}
+      id: env-config
+      targetPlane: dataplane
+      template:
+        apiVersion: v1
+        data: |
+          ${envConfig.envs.transformMapEntry(index, env, {env.name: env.value})}
+        kind: ConfigMap
+        metadata:
+          name: ${envConfig.resourceName}
+          namespace: ${metadata.namespace}
+      var: envConfig
+    - forEach: ${configurations.toConfigFileList()}
+      id: file-config
+      targetPlane: dataplane
+      template:
+        apiVersion: v1
+        data:
+          ${config.name}: |
+            ${config.value}
+        kind: ConfigMap
+        metadata:
+          name: ${config.resourceName}
+          namespace: ${metadata.namespace}
+      var: config
+    - forEach: ${configurations.toSecretEnvsByContainer()}
+      id: secret-env-external
+      targetPlane: dataplane
+      template:
+        apiVersion: external-secrets.io/v1
+        kind: ExternalSecret
+        metadata:
+          name: ${secretEnv.resourceName}
+          namespace: ${metadata.namespace}
+        spec:
+          data: |
+            ${secretEnv.envs.map(secret, {
+              "secretKey": secret.name,
+              "remoteRef": {
+                "key": secret.remoteRef.key,
+                ?"property": secret.remoteRef.?property
+              }
+            })}
+          refreshInterval: 15s
+          secretStoreRef:
+            kind: ClusterSecretStore
+            name: ${dataplane.secretStore}
+          target:
+            creationPolicy: Owner
+            name: ${secretEnv.resourceName}
+      var: secretEnv
+    - forEach: ${configurations.toSecretFileList()}
+      id: secret-file-external
+      targetPlane: dataplane
+      template:
+        apiVersion: external-secrets.io/v1
+        kind: ExternalSecret
+        metadata:
+          name: ${file.resourceName}
+          namespace: ${metadata.namespace}
+        spec:
+          data:
+            - remoteRef:
+                key: ${file.remoteRef.key}
+                property: |
+                  ${has(file.remoteRef.property) ? file.remoteRef.property : oc_omit()}
+              secretKey: ${file.name}
+          refreshInterval: 15s
+          secretStoreRef:
+            kind: ClusterSecretStore
+            name: ${dataplane.secretStore}
+          target:
+            creationPolicy: Owner
+            name: ${file.resourceName}
+      var: file
+  validations:
+    - message: Service components must have at least one endpoint. Use 'deployment/worker' for components without endpoints.
+      rule: ${size(workload.endpoints) > 0}
+    - message: Endpoints with 'external' visibility require gateway.ingress.external to be configured on the Environment or DataPlane.
+      rule: |-
+        ${workload.endpoints.exists(name, ep, "external" in ep.visibility)
+          ? has(gateway.ingress) && has(gateway.ingress.external)
+          : true}
+    - message: Endpoints with 'internal' visibility require gateway.ingress.internal to be configured on the Environment or DataPlane.
+      rule: |-
+        ${workload.endpoints.exists(name, ep, "internal" in ep.visibility)
+          ? has(gateway.ingress) && has(gateway.ingress.internal)
+          : true}
+  workloadType: deployment

--- a/autoscaling-keda/componenttypes/worker.yaml
+++ b/autoscaling-keda/componenttypes/worker.yaml
@@ -1,0 +1,189 @@
+# Copyright 2026 The OpenChoreo Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The stock OpenChoreo `worker` ClusterComponentType with `keda-based-scaling` added to
+# allowedTraits. That single addition lets a developer ATTACH the keda-based-scaling trait to a
+# plain worker component (spec.traits) and configure it.
+#
+# Regenerate from YOUR platform's live default type (so it never drifts from your OpenChoreo
+# version) with:
+#   kubectl get clustercomponenttype worker -o json \
+#     | jq 'del(.metadata.managedFields,.metadata.resourceVersion,.metadata.uid,.metadata.creationTimestamp,.metadata.generation,.status,.metadata.annotations["kubectl.kubernetes.io/last-applied-configuration"])
+#           | if ([.spec.allowedTraits[]?.name] | index("keda-based-scaling")) then . else .spec.allowedTraits += [{"kind":"ClusterTrait","name":"keda-based-scaling"}] end' \
+#     | yq -p json -o yaml
+#
+# Apply by DELETE + RECREATE, never `kubectl apply`: first delete any components using this
+# type, then `kubectl delete clustercomponenttype worker` and `kubectl create -f` this file.
+apiVersion: openchoreo.dev/v1alpha1
+kind: ClusterComponentType
+metadata:
+  annotations:
+    openchoreo.dev/description: A long-running background or event-driven component with no endpoints
+  name: worker
+spec:
+  allowedTraits:
+    - kind: ClusterTrait
+      name: observability-alert-rule
+    - kind: ClusterTrait
+      name: keda-based-scaling
+  allowedWorkflows:
+    - kind: ClusterWorkflow
+      name: paketo-buildpacks-builder
+    - kind: ClusterWorkflow
+      name: gcp-buildpacks-builder
+    - kind: ClusterWorkflow
+      name: dockerfile-builder
+    - kind: ClusterWorkflow
+      name: ballerina-buildpack-builder
+  environmentConfigs:
+    openAPIV3Schema:
+      $defs:
+        ResourceQuantity:
+          default: {}
+          properties:
+            cpu:
+              default: 100m
+              type: string
+            memory:
+              default: 256Mi
+              type: string
+          type: object
+        ResourceRequirements:
+          default: {}
+          properties:
+            limits:
+              $ref: '#/$defs/ResourceQuantity'
+            requests:
+              $ref: '#/$defs/ResourceQuantity'
+          type: object
+      properties:
+        imagePullPolicy:
+          default: IfNotPresent
+          enum:
+            - Always
+            - IfNotPresent
+            - Never
+          type: string
+        replicas:
+          default: 1
+          minimum: 0
+          type: integer
+        resources:
+          $ref: '#/$defs/ResourceRequirements'
+      type: object
+  resources:
+    - id: deployment
+      targetPlane: dataplane
+      template:
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          labels: ${metadata.labels}
+          name: ${metadata.name}
+          namespace: ${metadata.namespace}
+        spec:
+          replicas: ${environmentConfigs.replicas}
+          selector:
+            matchLabels: ${metadata.podSelectors}
+          template:
+            metadata:
+              labels: ${metadata.podSelectors}
+            spec:
+              containers:
+                - args: |
+                    ${has(workload.container.args) ? workload.container.args : oc_omit()}
+                  command: |
+                    ${has(workload.container.command) ? workload.container.command : oc_omit()}
+                  env: ${dependencies.toContainerEnvs()}
+                  envFrom: ${configurations.toContainerEnvFrom()}
+                  image: ${workload.container.image}
+                  imagePullPolicy: ${environmentConfigs.imagePullPolicy}
+                  name: main
+                  resources:
+                    limits:
+                      cpu: ${environmentConfigs.resources.limits.cpu}
+                      memory: ${environmentConfigs.resources.limits.memory}
+                    requests:
+                      cpu: ${environmentConfigs.resources.requests.cpu}
+                      memory: ${environmentConfigs.resources.requests.memory}
+                  volumeMounts: ${configurations.toContainerVolumeMounts() + dependencies.toContainerVolumeMounts()}
+              volumes: ${configurations.toVolumes() + dependencies.toVolumes()}
+    - forEach: ${configurations.toConfigEnvsByContainer()}
+      id: env-config
+      targetPlane: dataplane
+      template:
+        apiVersion: v1
+        data: |
+          ${envConfig.envs.transformMapEntry(index, env, {env.name: env.value})}
+        kind: ConfigMap
+        metadata:
+          name: ${envConfig.resourceName}
+          namespace: ${metadata.namespace}
+      var: envConfig
+    - forEach: ${configurations.toConfigFileList()}
+      id: file-config
+      targetPlane: dataplane
+      template:
+        apiVersion: v1
+        data:
+          ${config.name}: |
+            ${config.value}
+        kind: ConfigMap
+        metadata:
+          name: ${config.resourceName}
+          namespace: ${metadata.namespace}
+      var: config
+    - forEach: ${configurations.toSecretEnvsByContainer()}
+      id: secret-env-external
+      targetPlane: dataplane
+      template:
+        apiVersion: external-secrets.io/v1
+        kind: ExternalSecret
+        metadata:
+          name: ${secretEnv.resourceName}
+          namespace: ${metadata.namespace}
+        spec:
+          data: |
+            ${secretEnv.envs.map(secret, {
+              "secretKey": secret.name,
+              "remoteRef": {
+                "key": secret.remoteRef.key,
+                ?"property": secret.remoteRef.?property
+              }
+            })}
+          refreshInterval: 15s
+          secretStoreRef:
+            kind: ClusterSecretStore
+            name: ${dataplane.secretStore}
+          target:
+            creationPolicy: Owner
+            name: ${secretEnv.resourceName}
+      var: secretEnv
+    - forEach: ${configurations.toSecretFileList()}
+      id: secret-file-external
+      targetPlane: dataplane
+      template:
+        apiVersion: external-secrets.io/v1
+        kind: ExternalSecret
+        metadata:
+          name: ${file.resourceName}
+          namespace: ${metadata.namespace}
+        spec:
+          data:
+            - remoteRef:
+                key: ${file.remoteRef.key}
+                property: |
+                  ${has(file.remoteRef.property) ? file.remoteRef.property : oc_omit()}
+              secretKey: ${file.name}
+          refreshInterval: 15s
+          secretStoreRef:
+            kind: ClusterSecretStore
+            name: ${dataplane.secretStore}
+          target:
+            creationPolicy: Owner
+            name: ${file.resourceName}
+      var: file
+  validations:
+    - message: Worker components must not have endpoints. Use 'deployment/service' for components with endpoints.
+      rule: ${size(workload.endpoints) == 0}
+  workloadType: deployment

--- a/autoscaling-keda/keda-based-scaling-trait.yaml
+++ b/autoscaling-keda/keda-based-scaling-trait.yaml
@@ -1,0 +1,330 @@
+# Copyright 2026 The OpenChoreo Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Autoscaling with KEDA ClusterTrait. Renders KEDA objects so a component scales
+# with demand — down to zero when idle, back up when demand returns. Inert unless
+# the data plane advertises a backend via the
+# `openchoreo.dev/keda-based-scaling-backend: keda` annotation (surfaced to
+# templates as `dataplane.annotations`).
+#
+# Two modes, chosen by `trigger.type`:
+#   ""        -> HTTP mode: InterceptorRoute + companion ScaledObject (KEDA HTTP
+#                Add-on 0.14 split model). The component's Service is aliased to
+#                the interceptor so gateway and in-cluster callers both wake it.
+#   non-empty -> trigger mode: a ScaledObject with that KEDA trigger (cron, kafka, ...).
+#
+# Both modes drop the Deployment's static replicas so KEDA owns the count.
+# See CONFIGURATION.md for the full parameter reference and design rationale.
+apiVersion: openchoreo.dev/v1alpha1
+kind: ClusterTrait
+metadata:
+  name: keda-based-scaling
+  labels:
+    app.kubernetes.io/name: autoscaling-keda
+    app.kubernetes.io/part-of: openchoreo
+spec:
+  parameters:
+    openAPIV3Schema:
+      type: object
+      properties:
+        enabled:
+          type: boolean
+          default: false
+        minReplicas:
+          type: integer
+          default: 0
+          minimum: 0
+        maxReplicas:
+          type: integer
+          default: 10
+          minimum: 1
+        # Seconds all metrics must stay at zero before scaling down to minReplicas.
+        cooldownPeriod:
+          type: integer
+          default: 300
+          minimum: 0
+        # Any KEDA scaler trigger. Leave type "" for HTTP traffic-driven services.
+        trigger:
+          type: object
+          default:
+            type: ""
+          properties:
+            type:
+              type: string
+              default: ""
+            metadata:
+              type: object
+              additionalProperties:
+                type: string
+              default: {}
+        # Location of the keda-add-ons-http interceptor. Defaults match a
+        # `keda-add-ons-http` install in the `keda` namespace.
+        interceptorNamespace:
+          type: string
+          default: keda
+        interceptorService:
+          type: string
+          default: keda-add-ons-http-interceptor-proxy
+        interceptorPort:
+          type: integer
+          default: 8080
+        interceptorMultiportService:
+          type: string
+          default: keda-add-ons-http-interceptor-multiport
+        # Ports the multiport interceptor Service exposes. An HTTP-mode endpoint must
+        # listen on one of these: its Service becomes an ExternalName alias (a DNS
+        # CNAME, which can't remap ports), so the caller-facing port must be one the
+        # interceptor already answers on. Keep in sync with keda-interceptor-multiport.yaml.
+        wakeablePorts:
+          type: array
+          items:
+            type: integer
+          default: [80, 3000, 5000, 8000, 8080, 8081, 8090, 9000, 9090]
+        # The add-on's external scaler that the companion ScaledObject pulls the
+        # request metric from.
+        interceptorScalerService:
+          type: string
+          default: keda-add-ons-http-external-scaler
+        interceptorScalerPort:
+          type: integer
+          default: 9090
+        # HTTP mode scales on request RATE over a sliding window, not instantaneous
+        # concurrency, so sparse traffic keeps the service awake. targetValue is
+        # requests/second per replica.
+        requestRateTargetValue:
+          type: integer
+          default: 1
+          minimum: 1
+        requestRateWindow:
+          type: string
+          default: "1m"
+        requestRateGranularity:
+          type: string
+          default: "1s"
+        # How long the interceptor holds the first request while a pod cold-starts.
+        readinessTimeout:
+          type: string
+          default: "120s"
+
+  environmentConfigs:
+    openAPIV3Schema:
+      type: object
+      properties:
+        minReplicas:
+          type: integer
+          minimum: 0
+        maxReplicas:
+          type: integer
+          minimum: 1
+        cooldownPeriod:
+          type: integer
+          minimum: 0
+
+  validations:
+    # HTTP-mode shape check. The component's Service is aliased to the interceptor
+    # via an ExternalName, which forces two intrinsic constraints (reject loudly
+    # rather than mis-scale):
+    #   - exactly one endpoint: the interceptor routes by Host only (port stripped),
+    #     and all endpoints of a component share one Service name, hence one Host;
+    #   - the endpoint port must be in wakeablePorts: a DNS CNAME can't remap ports.
+    - rule: >-
+        ${(parameters.enabled && (has(dataplane.annotations) && "openchoreo.dev/keda-based-scaling-backend" in dataplane.annotations && dataplane.annotations["openchoreo.dev/keda-based-scaling-backend"] == "keda") && parameters.trigger.type == "" && size(workload.endpoints) > 0)
+          ? (size(workload.endpoints) == 1
+             && workload.endpoints.all(name, ep,
+                  "external" in ep.visibility
+                  && ep.type in ["HTTP", "GraphQL", "Websocket"]
+                  && ep.port in parameters.wakeablePorts))
+          : true}
+      message: "A KEDA-scaled HTTP service must expose exactly one external HTTP/GraphQL/Websocket endpoint, on a wakeable port (default 80, 3000, 5000, 8000, 8080, 8081, 8090, 9000, 9090): the KEDA interceptor routes by Host only, and the ExternalName alias (a DNS CNAME) can't remap ports. Split extra endpoints into their own component, add the port to keda-interceptor-multiport.yaml and wakeablePorts, or keep minReplicas >= 1."
+
+    # Worker-mode guard: a component with no endpoints has no HTTP traffic to wake
+    # on, so it needs an explicit trigger.
+    - rule: >-
+        ${!(parameters.enabled && (has(dataplane.annotations) && "openchoreo.dev/keda-based-scaling-backend" in dataplane.annotations && dataplane.annotations["openchoreo.dev/keda-based-scaling-backend"] == "keda") && parameters.trigger.type == "" && size(workload.endpoints) == 0)}
+      message: "keda-based-scaling on a component with no endpoints (a worker) requires a trigger (e.g. cron, kafka, rabbitmq). Set trigger.type, or attach this trait only to components that expose an HTTP endpoint."
+
+  creates:
+    # (1) Trigger mode: a ScaledObject with the given KEDA trigger.
+    - includeWhen: '${parameters.enabled && (has(dataplane.annotations) && "openchoreo.dev/keda-based-scaling-backend" in dataplane.annotations && dataplane.annotations["openchoreo.dev/keda-based-scaling-backend"] == "keda") && parameters.trigger.type != ""}'
+      template:
+        apiVersion: keda.sh/v1alpha1
+        kind: ScaledObject
+        metadata:
+          name: ${metadata.name}
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+        spec:
+          scaleTargetRef:
+            name: ${metadata.name}
+          minReplicaCount: |
+            ${has(environmentConfigs.minReplicas) ? environmentConfigs.minReplicas : parameters.minReplicas}
+          maxReplicaCount: |
+            ${has(environmentConfigs.maxReplicas) ? environmentConfigs.maxReplicas : parameters.maxReplicas}
+          cooldownPeriod: |
+            ${has(environmentConfigs.cooldownPeriod) ? environmentConfigs.cooldownPeriod : parameters.cooldownPeriod}
+          triggers:
+            - type: ${parameters.trigger.type}
+              metadata: ${parameters.trigger.metadata}
+
+    # (2) HTTP mode: InterceptorRoute (routing rule + scaling metric). The 0.14
+    #     controller does NOT create the ScaledObject for it, so (2b) renders the
+    #     companion. The interceptor holds the first request until a pod is ready,
+    #     so wake-from-zero is lossless.
+    - includeWhen: '${parameters.enabled && (has(dataplane.annotations) && "openchoreo.dev/keda-based-scaling-backend" in dataplane.annotations && dataplane.annotations["openchoreo.dev/keda-based-scaling-backend"] == "keda") && parameters.trigger.type == "" && size(workload.endpoints.transformList(name, ep, ("external" in ep.visibility && ep.type in ["HTTP", "GraphQL", "Websocket"]) ? [name] : []).flatten()) == 1}'
+      forEach: '${workload.endpoints.transformMap(name, ep, "external" in ep.visibility && ep.type in ["HTTP", "GraphQL", "Websocket"], ep)}'
+      var: endpoint
+      template:
+        apiVersion: http.keda.sh/v1beta1
+        kind: InterceptorRoute
+        metadata:
+          name: ${oc_generate_name(metadata.componentName, endpoint.key)}
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+        spec:
+          # The component's own Service name is taken over by the ExternalName alias
+          # (see patches), so forward to the dedicated pod-backing Service instead.
+          target:
+            service: ${oc_dns_label(metadata.componentName, "keda-upstream")}
+            port: ${endpoint.value.port}
+          # Register ONLY the component's unique in-cluster FQDN as the Host rule —
+          # every KEDA-scaled service in an environment shares the gateway hostname
+          # and would otherwise collide. The external HTTPRoute rewrites Host to this
+          # FQDN (see patches) so gateway and in-cluster callers match the same rule.
+          rules:
+            - hosts:
+                - ${metadata.componentName + "." + metadata.namespace + ".svc.cluster.local"}
+          scalingMetric:
+            requestRate:
+              targetValue: ${parameters.requestRateTargetValue}
+              window: ${parameters.requestRateWindow}
+              granularity: ${parameters.requestRateGranularity}
+          timeouts:
+            readiness: ${parameters.readinessTimeout}
+
+    # (2b) Companion ScaledObject: scale target + bounds (minReplicaCount 0 is the
+    #      scale-to-zero gate). Rendered after the InterceptorRoute so the external
+    #      scaler has a metric spec to report instead of falling back to CPU.
+    - includeWhen: '${parameters.enabled && (has(dataplane.annotations) && "openchoreo.dev/keda-based-scaling-backend" in dataplane.annotations && dataplane.annotations["openchoreo.dev/keda-based-scaling-backend"] == "keda") && parameters.trigger.type == "" && size(workload.endpoints.transformList(name, ep, ("external" in ep.visibility && ep.type in ["HTTP", "GraphQL", "Websocket"]) ? [name] : []).flatten()) == 1}'
+      forEach: '${workload.endpoints.transformMap(name, ep, "external" in ep.visibility && ep.type in ["HTTP", "GraphQL", "Websocket"], ep)}'
+      var: endpoint
+      template:
+        apiVersion: keda.sh/v1alpha1
+        kind: ScaledObject
+        metadata:
+          name: ${oc_generate_name(metadata.componentName, endpoint.key)}
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+        spec:
+          scaleTargetRef:
+            apiVersion: apps/v1
+            kind: Deployment
+            name: ${metadata.name}
+          minReplicaCount: |
+            ${has(environmentConfigs.minReplicas) ? environmentConfigs.minReplicas : parameters.minReplicas}
+          maxReplicaCount: |
+            ${has(environmentConfigs.maxReplicas) ? environmentConfigs.maxReplicas : parameters.maxReplicas}
+          cooldownPeriod: |
+            ${has(environmentConfigs.cooldownPeriod) ? environmentConfigs.cooldownPeriod : parameters.cooldownPeriod}
+          triggers:
+            - type: external-push
+              metadata:
+                scalerAddress: ${parameters.interceptorScalerService + "." + parameters.interceptorNamespace + ":" + string(parameters.interceptorScalerPort)}
+                interceptorRoute: ${oc_generate_name(metadata.componentName, endpoint.key)}
+
+    # (3) HTTP mode: a kgateway Backend in the component's namespace targeting the
+    #     interceptor by DNS name — a local Backend needs no cross-namespace
+    #     ReferenceGrant.
+    - includeWhen: '${parameters.enabled && (has(dataplane.annotations) && "openchoreo.dev/keda-based-scaling-backend" in dataplane.annotations && dataplane.annotations["openchoreo.dev/keda-based-scaling-backend"] == "keda") && parameters.trigger.type == "" && size(workload.endpoints.transformList(name, ep, ("external" in ep.visibility && ep.type in ["HTTP", "GraphQL", "Websocket"]) ? [name] : []).flatten()) == 1}'
+      template:
+        apiVersion: gateway.kgateway.dev/v1alpha1
+        kind: Backend
+        metadata:
+          name: ${oc_generate_name(metadata.componentName, "keda-interceptor")}
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+        spec:
+          type: Static
+          static:
+            hosts:
+              - host: ${parameters.interceptorService + "." + parameters.interceptorNamespace + ".svc.cluster.local"}
+                port: ${parameters.interceptorPort}
+
+    # (4) Pod-backing Service the interceptor forwards to (the component's own
+    #     Service no longer selects pods once aliased). Its name sorts after
+    #     ${metadata.componentName} so OpenChoreo's in-cluster URL resolver keeps
+    #     injecting the ExternalName.
+    - includeWhen: '${parameters.enabled && (has(dataplane.annotations) && "openchoreo.dev/keda-based-scaling-backend" in dataplane.annotations && dataplane.annotations["openchoreo.dev/keda-based-scaling-backend"] == "keda") && parameters.trigger.type == "" && size(workload.endpoints.transformList(name, ep, ("external" in ep.visibility && ep.type in ["HTTP", "GraphQL", "Websocket"]) ? [name] : []).flatten()) == 1}'
+      template:
+        apiVersion: v1
+        kind: Service
+        metadata:
+          name: ${oc_dns_label(metadata.componentName, "keda-upstream")}
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+        spec:
+          type: ClusterIP
+          selector: ${metadata.podSelectors}
+          ports: ${workload.toServicePorts()}
+
+  patches:
+    # Drop the static replica count so server-side apply stops resetting it and
+    # fighting the autoscaler — KEDA owns replicas now.
+    - target:
+        group: apps
+        version: v1
+        kind: Deployment
+        where: '${parameters.enabled && (has(dataplane.annotations) && "openchoreo.dev/keda-based-scaling-backend" in dataplane.annotations && dataplane.annotations["openchoreo.dev/keda-based-scaling-backend"] == "keda")}'
+      operations:
+        - op: remove
+          path: /spec/replicas
+
+    # HTTP mode: repoint the external HTTPRoute at the interceptor via the local
+    # kgateway Backend.
+    - target:
+        group: gateway.networking.k8s.io
+        version: v1
+        kind: HTTPRoute
+        where: '${parameters.enabled && (has(dataplane.annotations) && "openchoreo.dev/keda-based-scaling-backend" in dataplane.annotations && dataplane.annotations["openchoreo.dev/keda-based-scaling-backend"] == "keda") && parameters.trigger.type == "" && has(resource.metadata.labels) && resource.metadata.labels["openchoreo.dev/endpoint-visibility"] == "external"}'
+      operations:
+        - op: replace
+          path: /spec/rules/0/backendRefs/0
+          value:
+            group: gateway.kgateway.dev
+            kind: Backend
+            name: ${oc_generate_name(metadata.componentName, "keda-interceptor")}
+            weight: 1
+        # A cold start can outlast the gateway's default route timeout (~15s),
+        # which would drop the first request even though the interceptor holds it.
+        - op: add
+          path: /spec/rules/0/timeouts
+          value:
+            request: "120s"
+        # Rewrite Host to the component's in-cluster FQDN — the only host on the
+        # InterceptorRoute rule — so gateway traffic matches the same rule as
+        # in-cluster traffic. (filters[0] is the URLRewrite the component type
+        # already sets for the basePath.)
+        - op: add
+          path: /spec/rules/0/filters/0/urlRewrite/hostname
+          value: ${metadata.componentName + "." + metadata.namespace + ".svc.cluster.local"}
+
+    # HTTP mode: turn the component's own Service into an ExternalName alias of the
+    # interceptor (via the multiport Service). Connections inject this Service's
+    # in-cluster URL, so an in-cluster call to a sleeping component resolves to the
+    # interceptor, is held, and wakes it — the same path gateway traffic takes.
+    # The `where` excludes the pod-backing Service (different name).
+    - target:
+        group: ""
+        version: v1
+        kind: Service
+        where: '${parameters.enabled && (has(dataplane.annotations) && "openchoreo.dev/keda-based-scaling-backend" in dataplane.annotations && dataplane.annotations["openchoreo.dev/keda-based-scaling-backend"] == "keda") && parameters.trigger.type == "" && resource.metadata.name == metadata.componentName}'
+      operations:
+        - op: replace
+          path: /spec/type
+          value: ExternalName
+        - op: add
+          path: /spec/externalName
+          value: ${parameters.interceptorMultiportService + "." + parameters.interceptorNamespace + ".svc.cluster.local"}
+        # ExternalName Services don't select pods; drop the selector so no stray
+        # EndpointSlices form.
+        - op: remove
+          path: /spec/selector

--- a/autoscaling-keda/keda-interceptor-multiport.yaml
+++ b/autoscaling-keda/keda-interceptor-multiport.yaml
@@ -1,0 +1,66 @@
+# Copyright 2026 The OpenChoreo Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Multi-port front for the keda-add-ons-http interceptor, in the `keda` namespace.
+#
+# A KEDA-scaled HTTP service has its own in-cluster Service aliased to the interceptor through an
+# ExternalName. An ExternalName is a DNS CNAME and cannot remap ports; this Service republishes
+# the interceptor pods on common HTTP ports, all forwarded to the interceptor's 8080.
+#
+# To support a port not listed here, add it below AND to the keda-based-scaling trait's
+# `wakeablePorts` default (keda-based-scaling-trait.yaml); keep the two in sync.
+#
+# The selector must match the interceptor pods. Copy from the add-on's own Service if labels differ:
+#   kubectl get svc keda-add-ons-http-interceptor-proxy -n keda -o jsonpath='{.spec.selector}'
+# Apply this on the data plane.
+apiVersion: v1
+kind: Service
+metadata:
+  name: keda-add-ons-http-interceptor-multiport
+  namespace: keda
+  labels:
+    app.kubernetes.io/name: autoscaling-keda
+    app.kubernetes.io/part-of: openchoreo
+    app.kubernetes.io/component: keda-http-interceptor-multiport
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: http-add-on
+    app.kubernetes.io/component: interceptor
+  ports:
+    - name: p-80
+      port: 80
+      targetPort: 8080
+      protocol: TCP
+    - name: p-3000
+      port: 3000
+      targetPort: 8080
+      protocol: TCP
+    - name: p-5000
+      port: 5000
+      targetPort: 8080
+      protocol: TCP
+    - name: p-8000
+      port: 8000
+      targetPort: 8080
+      protocol: TCP
+    - name: p-8080
+      port: 8080
+      targetPort: 8080
+      protocol: TCP
+    - name: p-8081
+      port: 8081
+      targetPort: 8080
+      protocol: TCP
+    - name: p-8090
+      port: 8090
+      targetPort: 8080
+      protocol: TCP
+    - name: p-9000
+      port: 9000
+      targetPort: 8080
+      protocol: TCP
+    - name: p-9090
+      port: 9090
+      targetPort: 8080
+      protocol: TCP

--- a/autoscaling-keda/samples/cron-worker.yaml
+++ b/autoscaling-keda/samples/cron-worker.yaml
@@ -1,0 +1,79 @@
+# Copyright 2026 The OpenChoreo Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Cron-driven KEDA-based scaling for a worker (no endpoints), using the STOCK `worker` component
+# type with the `keda-based-scaling` trait ATTACHED (spec.traits).
+#
+# Prerequisites:
+#   1. The data plane advertises the KEDA backend:
+#        kubectl annotate clusterdataplane default \
+#          openchoreo.dev/keda-based-scaling-backend=keda --overwrite
+#   2. The `worker` type allows the trait (componenttypes/worker.yaml applied — see README).
+#
+# Workers require an explicit trigger (the trait rejects an enabled, triggerless, endpoint-less
+# component at render time). The cron trigger below (03:00-04:00 UTC) runs 1 hour per day; the
+# worker sits at zero (minReplicas) the other 23 hours.
+---
+apiVersion: openchoreo.dev/v1alpha1
+kind: Component
+metadata:
+  name: batch-worker
+  namespace: default
+spec:
+  owner:
+    projectName: default
+  componentType:
+    kind: ClusterComponentType
+    name: deployment/worker           # stock default type, unmodified except allowedTraits
+  autoDeploy: true
+  traits:
+    - kind: ClusterTrait
+      name: keda-based-scaling
+      instanceName: keda-based-scaling
+      parameters:
+        enabled: true
+        minReplicas: 0
+        maxReplicas: 3
+        cooldownPeriod: 30
+        trigger:
+          type: cron
+          metadata:
+            timezone: "Etc/UTC"
+            start: "0 3 * * *"        # run 03:00-04:00 UTC; scaled to ZERO the other 23h
+            end: "0 4 * * *"
+            desiredReplicas: "1"
+---
+apiVersion: openchoreo.dev/v1alpha1
+kind: Workload
+metadata:
+  name: batch-worker-workload
+  namespace: default
+spec:
+  owner:
+    projectName: default
+    componentName: batch-worker
+  container:
+    image: "busybox:1.36"
+    command:
+      - /bin/sh
+      - -c
+      - "while true; do echo working; sleep 30; done"
+---
+apiVersion: openchoreo.dev/v1alpha1
+kind: ReleaseBinding
+metadata:
+  name: batch-worker-development
+  namespace: default
+spec:
+  owner:
+    projectName: default
+    componentName: batch-worker
+  environment: development
+  componentTypeEnvironmentConfigs:
+    resources:
+      requests:
+        cpu: "10m"
+        memory: "16Mi"
+      limits:
+        cpu: "50m"
+        memory: "64Mi"

--- a/autoscaling-keda/samples/http-service.yaml
+++ b/autoscaling-keda/samples/http-service.yaml
@@ -1,0 +1,81 @@
+# Copyright 2026 The OpenChoreo Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+# HTTP traffic-driven Autoscaling with KEDA, using the STOCK `service` component type with the
+# `keda-based-scaling` trait ATTACHED (spec.traits).
+#
+# Prerequisites:
+#   1. The data plane advertises the KEDA backend:
+#        kubectl annotate clusterdataplane default \
+#          openchoreo.dev/keda-based-scaling-backend=keda --overwrite
+#   2. The `service` type allows the trait (componenttypes/service.yaml applied — see README).
+---
+apiVersion: openchoreo.dev/v1alpha1
+kind: Component
+metadata:
+  name: greeter
+  namespace: default
+spec:
+  owner:
+    projectName: default
+  componentType:
+    kind: ClusterComponentType
+    name: deployment/service          # stock default type, unmodified except allowedTraits
+  autoDeploy: true
+  traits:
+    - kind: ClusterTrait
+      name: keda-based-scaling
+      instanceName: keda-based-scaling
+      parameters:
+        enabled: true
+        minReplicas: 0                # 0 = scale to zero
+        maxReplicas: 5
+        # Short cooldown so the demo scales down quickly. Use a larger value (e.g. the
+        # 300s default) in real workloads to avoid cold starts on bursty traffic.
+        cooldownPeriod: 30
+---
+apiVersion: openchoreo.dev/v1alpha1
+kind: Workload
+metadata:
+  name: greeter-workload
+  namespace: default
+spec:
+  owner:
+    projectName: default
+    componentName: greeter
+  endpoints:
+    http:
+      type: HTTP
+      port: 9090                      # a wakeable port (see the trait's wakeablePorts)
+      visibility: [external]
+  container:
+    # http-echo binds 0.0.0.0 explicitly (reachable over the pod network on any cluster).
+    # It echoes a fixed message to any path, enough to prove the request reached a woken pod.
+    image: "hashicorp/http-echo:1.0.0"
+    args:
+      - "-listen=0.0.0.0:9090"
+      - "-text=Hello from OpenChoreo Autoscaling with KEDA!"
+---
+apiVersion: openchoreo.dev/v1alpha1
+kind: ReleaseBinding
+metadata:
+  name: greeter-development
+  namespace: default
+spec:
+  owner:
+    projectName: default
+    componentName: greeter
+  environment: development
+  componentTypeEnvironmentConfigs:
+    resources:
+      requests:
+        cpu: "25m"
+        memory: "32Mi"
+      limits:
+        cpu: "100m"
+        memory: "128Mi"
+  # Per-environment keda-based-scaling overrides go here, keyed by the trait instanceName.
+  # For example, never scale to zero in production:
+  #   traitEnvironmentConfigs:
+  #     keda-based-scaling:
+  #       minReplicas: 1


### PR DESCRIPTION
## Purpose

Part of the scale-to-zero (Elastic) module epic [openchoreo/openchoreo#3104](https://github.com/openchoreo/openchoreo/issues/3104). Implements the community-modules side of [openchoreo/openchoreo#3760](https://github.com/openchoreo/openchoreo/issues/3760), building on the core render-context change in [openchoreo/openchoreo#3754](https://github.com/openchoreo/openchoreo/pull/3754) and the design in [openchoreo/openchoreo#3752](https://github.com/openchoreo/openchoreo/issues/3752).

A data plane advertises its scaling backend via an annotation (`openchoreo.dev/scale-to-zero-backend: keda`), surfaced to templates as `dataplane.annotations`. The module's `scale-to-zero` ClusterTrait reads that annotation and renders the right KEDA objects so components scale to zero and wake on demand. On a plane with no annotation, the trait is inert.

## Approach

The module is a set of YAML resources applied with `kubectl`:

- **`scale-to-zero` ClusterTrait** — two rendering modes: HTTP services get an `HTTPScaledObject` + the external HTTPRoute is repointed at the keda-add-ons-http interceptor (lossless wake); event/cron workers get a `ScaledObject` with the developer's trigger. In both modes the Deployment's static replica count is removed so KEDA owns it.
- **Reference ComponentTypes** (`service-scale-to-zero-reference`, `worker-scale-to-zero-reference`) — embed the trait and expose a developer-facing `scaling` block with per-environment overrides. The developer never names the trait directly.
- **Cluster-agent RBAC** — grants the data-plane agent permission to manage `keda.sh` and `http.keda.sh` resources.
- **Samples** — HTTP service (traffic-driven) and cron worker demonstrating both modes.

KEDA core and the HTTP Add-on are installed from upstream Helm charts; this module only provides the OpenChoreo glue.

## Related Issues

- Part of [openchoreo/openchoreo#3104](https://github.com/openchoreo/openchoreo/issues/3104)
- Resolves [openchoreo/openchoreo#3760](https://github.com/openchoreo/openchoreo/issues/3760)
- Design: [openchoreo/openchoreo#3752](https://github.com/openchoreo/openchoreo/issues/3752)
- Core change: [openchoreo/openchoreo#3754](https://github.com/openchoreo/openchoreo/pull/3754)
- Proposal: [openchoreo/openchoreo#3744](https://github.com/openchoreo/openchoreo/discussions/3744)

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [x] Samples updated (if applicable)

## Remarks

This module has no Go code, Dockerfile, or Helm chart — it is pure YAML (trait, component types, RBAC, samples) and a README. The PR CI checks (version bump, docker build, unit tests) will skip it since there is no `module.yaml`.

The "Tests" checkbox is unchecked because there is no unit-test surface for declarative YAML resources. Validation is done by applying the resources to a cluster with the core change from #3754.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added KEDA-based autoscaling module enabling scale-to-zero for HTTP services and trigger-based workers (cron, etc.)
  * New `keda-based-scaling` trait with configurable replica bounds, cooldown periods, and request-rate scaling

* **Documentation**
  * Added setup guide, configuration reference, and practical usage examples
<!-- end of auto-generated comment: release notes by coderabbit.ai -->