### PR TITLE
fix: derive log level from declared field instead of substring match

### DIFF
--- a/observability-logs-opensearch/README.md
+++ b/observability-logs-opensearch/README.md
@@ -63,7 +63,7 @@ helm upgrade --install observability-logs-opensearch \
   oci://ghcr.io/openchoreo/helm-charts/observability-logs-opensearch \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.5.1 \
+  --version 0.5.2 \
   --set adapter.openSearchSecretName="opensearch-admin-credentials" \
   --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials"
 ```
@@ -75,7 +75,7 @@ helm upgrade --install observability-logs-opensearch \
 >   oci://ghcr.io/openchoreo/helm-charts/observability-logs-opensearch \
 >   --create-namespace \
 >   --namespace openchoreo-observability-plane \
->   --version 0.5.1 \
+>   --version 0.5.2 \
 >   --set adapter.openSearchSecretName="opensearch-admin-credentials" \
 >   --set openSearch.enabled=false \
 >   --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials"
@@ -94,7 +94,7 @@ helm upgrade observability-logs-opensearch \
   oci://ghcr.io/openchoreo/helm-charts/observability-logs-opensearch \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.5.1 \
+  --version 0.5.2 \
   --reuse-values \
   --set fluent-bit.enabled=true
 ```
@@ -116,7 +116,7 @@ helm upgrade --install observability-logs-opensearch \
   oci://ghcr.io/openchoreo/helm-charts/observability-logs-opensearch \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.5.1 \
+  --version 0.5.2 \
   --set adapter.openSearchSecretName="opensearch-admin-credentials" \
   --set openSearch.enabled=false \
   --set openSearchCluster.enabled=true \
@@ -144,7 +144,7 @@ helm upgrade --install observability-logs-opensearch \
   oci://ghcr.io/openchoreo/helm-charts/observability-logs-opensearch \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.5.1 \
+  --version 0.5.2 \
   --set adapter.enabled=false \
   --set openSearch.enabled=false \
   --set openSearchCluster.enabled=false \

--- a/observability-logs-opensearch/helm/Chart.yaml
+++ b/observability-logs-opensearch/helm/Chart.yaml
@@ -5,8 +5,8 @@ apiVersion: v2
 name: observability-logs-opensearch
 description: A Helm chart for OpenChoreo Observability Logs module with Fluent Bit and OpenSearch
 type: application
-version: 0.5.1
-appVersion: "0.5.1"
+version: 0.5.2
+appVersion: "0.5.2"
 keywords:
   - opensearch
   - observability

--- a/observability-logs-opensearch/internal/opensearch/types.go
+++ b/observability-logs-opensearch/internal/opensearch/types.go
@@ -6,6 +6,7 @@ package opensearch
 import (
 	"encoding/json"
 	"io"
+	"regexp"
 	"strings"
 	"time"
 )
@@ -290,20 +291,94 @@ func getStringValue(m map[string]interface{}, key string) string {
 	return ""
 }
 
-// extractLogLevel extracts log level from log content using common patterns.
+// declaredLevelRe captures the value of a level/severity field in logfmt or JSON,
+// e.g. level=info or "severity":"ERROR".
+var declaredLevelRe = regexp.MustCompile(
+	`(?i)(?:^|[\s,{])"?(?:lvl|level|severity_?text|severity|levelname|@l)"?\s*[=:]\s*"?([a-z]+)`)
+
+// klogHeaderRe matches the single-letter header some loggers emit, e.g. "E0501 12:34:56 ...";
+// the time component guards against matching arbitrary "F1234 ..." text.
+var klogHeaderRe = regexp.MustCompile(`^([IWEF])\d{4} \d{2}:\d{2}:\d{2}`)
+
+// levelMatchers extract a level from a known shape, tried in order: a declared
+// level/severity field first, then the single-letter header.
+var levelMatchers = []struct {
+	re   *regexp.Regexp
+	norm func(token string) string
+}{
+	{declaredLevelRe, normalizeLogLevel},
+	{klogHeaderRe, normalizeKlogPrefix},
+}
+
+// fallbackLevels scan for a bare severity word, used only when no format matched. A word
+// followed by '=' is a field key (e.g. error="<nil>" or error = "<nil>"), not a severity,
+// so it is skipped.
+var fallbackLevels = []struct {
+	name string
+	re   *regexp.Regexp
+}{
+	{"ERROR", regexp.MustCompile(`\bERROR\b(?:\s*[^=\s]|\s*$)`)},
+	{"FATAL", regexp.MustCompile(`\bFATAL\b(?:\s*[^=\s]|\s*$)`)},
+	{"SEVERE", regexp.MustCompile(`\bSEVERE\b(?:\s*[^=\s]|\s*$)`)},
+	{"WARN", regexp.MustCompile(`\bWARNING\b(?:\s*[^=\s]|\s*$)`)},
+	{"WARN", regexp.MustCompile(`\bWARN\b(?:\s*[^=\s]|\s*$)`)},
+	{"INFO", regexp.MustCompile(`\bINFO\b(?:\s*[^=\s]|\s*$)`)},
+	{"DEBUG", regexp.MustCompile(`\bDEBUG\b(?:\s*[^=\s]|\s*$)`)},
+}
+
+// extractLogLevel returns the level of a raw log line, trusting a declared level when
+// present and otherwise scanning for a severity keyword. Defaults to INFO.
 func extractLogLevel(log string) string {
-	log = strings.ToUpper(log)
-
-	logLevels := []string{"ERROR", "FATAL", "SEVERE", "WARN", "WARNING", "INFO", "DEBUG", "UNDEFINED"}
-
-	for _, level := range logLevels {
-		if strings.Contains(log, level) {
-			if level == "WARNING" {
-				return "WARN"
+	for _, m := range levelMatchers {
+		if sub := m.re.FindStringSubmatch(log); sub != nil {
+			if level := m.norm(sub[1]); level != "" {
+				return level
 			}
-			return level
+		}
+	}
+
+	upper := strings.ToUpper(log)
+	for _, lvl := range fallbackLevels {
+		if lvl.re.MatchString(upper) {
+			return lvl.name
 		}
 	}
 
 	return "INFO"
+}
+
+// normalizeKlogPrefix maps a klog/glog severity letter to a level.
+func normalizeKlogPrefix(letter string) string {
+	switch letter {
+	case "I":
+		return "INFO"
+	case "W":
+		return "WARN"
+	case "E":
+		return "ERROR"
+	case "F":
+		return "FATAL"
+	}
+	return ""
+}
+
+// normalizeLogLevel maps a declared level token to a canonical level; unknown values
+// default to INFO.
+func normalizeLogLevel(v string) string {
+	switch strings.ToUpper(v) {
+	case "ERROR", "ERR":
+		return "ERROR"
+	case "FATAL", "CRITICAL", "CRIT", "PANIC", "DPANIC", "EMERG", "EMERGENCY", "ALERT":
+		return "FATAL"
+	case "SEVERE":
+		return "SEVERE"
+	case "WARN", "WARNING":
+		return "WARN"
+	case "INFO", "INFORMATION", "NOTICE", "CONFIG":
+		return "INFO"
+	case "DEBUG", "TRACE", "VERBOSE", "FINE", "FINER", "FINEST", "SILLY":
+		return "DEBUG"
+	default:
+		return "INFO"
+	}
 }

--- a/observability-logs-opensearch/internal/opensearch/types_test.go
+++ b/observability-logs-opensearch/internal/opensearch/types_test.go
@@ -112,15 +112,79 @@ func TestExtractLogLevel(t *testing.T) {
 		input    string
 		expected string
 	}{
+		// Keyword fallback on unstructured lines.
 		{"2025-01-01 ERROR something failed", "ERROR"},
 		{"WARN disk space low", "WARN"},
 		{"WARNING: deprecated function", "WARN"},
+		{"[ERROR] connection refused", "ERROR"},
 		{"INFO application started", "INFO"},
 		{"DEBUG variable x = 5", "DEBUG"},
 		{"FATAL out of memory", "FATAL"},
 		{"SEVERE critical failure", "SEVERE"},
-		{"just a regular log message", "INFO"},
 		{"error in lowercase", "ERROR"},
+		{"just a regular log message", "INFO"},
+		{"", "INFO"},
+		{"   ", "INFO"},
+
+		// Declared logfmt level, trusted over level words in the body.
+		{`time="2026-05-05T07:56:21.304Z" level=info msg="sub-process exited" argo=true error="<nil>"`, "INFO"},
+		{"level=info request failed: connection ERROR", "INFO"},
+		{`level=debug msg="retrying after error"`, "DEBUG"},
+		{`level=error msg="boom"`, "ERROR"},
+		{`level="warn" msg=disk`, "WARN"},
+		{"level = debug starting up", "DEBUG"},
+		{"Level=Error mixed case", "ERROR"},
+		{"lvl=warn cache miss", "WARN"},
+
+		// Declared JSON level, field anywhere in the object.
+		{`{"level":"warn","msg":"disk low"}`, "WARN"},
+		{`{"ts":"2026-01-01","msg":"db down","level":"error"}`, "ERROR"},
+		{`{"level":"info","ts":1620000000.1,"caller":"m.go:1","msg":"ok"}`, "INFO"},
+		{`{"severity":"ERROR","message":"boom"}`, "ERROR"},
+		{`{"severityText":"ERROR","body":"x"}`, "ERROR"},
+		{`{"severity_text":"WARN","body":"x"}`, "WARN"},
+		{`{"levelname":"WARNING","name":"root"}`, "WARN"},
+		{`{"@l":"Information","@m":"started"}`, "INFO"},
+
+		// Common level value vocabularies.
+		{"level=trace entering fn", "DEBUG"},
+		{"level=verbose details", "DEBUG"},
+		{"level=silly noise", "DEBUG"},
+		{"level=information started", "INFO"},
+		{"level=notice heads up", "INFO"},
+		{"level=warning deprecated", "WARN"},
+		{"level=err short alias", "ERROR"},
+		{"level=critical db down", "FATAL"},
+		{"level=crit db down", "FATAL"},
+		{"level=emerg system down", "FATAL"},
+		{"level=alert page oncall", "FATAL"},
+		{"level=panic goroutine stack", "FATAL"},
+		{"level=fatal shutting down", "FATAL"},
+		{"level=bogus unknown value", "INFO"},
+
+		// Single-letter header.
+		{"E0505 07:56:21.304123  1 reflector.go:1 watch failed", "ERROR"},
+		{"W0505 07:56:21.304123  1 throttle.go:1 slow", "WARN"},
+		{"I0505 07:56:21.304123  1 server.go:1 listening", "INFO"},
+		{"F0505 07:56:21.304123  1 panic.go:1 boom", "FATAL"},
+		{"I2024 not a klog header, no time component", "INFO"},
+
+		// A level word used as a field key is not a severity.
+		{"connection error=timeout reset", "INFO"},
+		{"connection error = timeout reset", "INFO"}, // whitespace before '='
+		{"feature warn=disabled in config", "INFO"},
+		{"processed errors=2 warnings=0", "INFO"},
+
+		// Edge cases.
+		{"TERROR raised in prose", "INFO"},                  // level word embedded in a larger word
+		{"adjust the log level for verbosity", "INFO"},      // "level" with no value is not a declared field
+		{"unexpected ERROR after INFO checkpoint", "ERROR"}, // fallback picks highest severity, not first seen
+		{"DEBUG trace then WARN raised", "WARN"},            // WARN outranks DEBUG
+		{"i0501 12:34:56.000 lowercase prefix", "INFO"},     // header match is case-sensitive
+		{"E051 12:34:56 malformed header", "INFO"},          // header needs a 4-digit date
+		{"level=warning, retrying", "WARN"},                 // declared value with trailing punctuation
+		{"level=warn nested level=error", "WARN"},           // first declared field wins
+		{"goroutine 1 [running]:", "INFO"},                  // stack dump, no level
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Problem

Build/workflow logs surface with the wrong level. An Argo line that is `level=info` is reported as `ERROR`:

```json
{
  "timestamp": "2026-05-05T07:56:21Z",
  "log": "time=\"2026-05-05T07:56:21.304Z\" level=info msg=\"sub-process exited\" argo=true error=\"<nil>\"",
  "level": "ERROR"
}
```

The level is re-derived from the raw log text by scanning for level keywords with `strings.Contains`, returning the first match in priority order (ERROR first). Any line whose payload contains a level word — here `error="<nil>"` — is misclassified, regardless of the level the emitter actually declared.

Fixes openchoreo/openchoreo#3370

## Change

Replace the substring scan with a small table of known-shape matchers, tried in order, then a hardened keyword fallback:

- A structural matcher reads the value of a declared `level`/`severity` field (logfmt or JSON), so the declared level is trusted regardless of level words elsewhere on the line.
- A single-letter header matcher (requires the time component) classifies those logs without false-positiving on arbitrary text.
- The keyword fallback matches on token boundaries and ignores a level word used as a field key (`error=`); it runs only on unstructured lines.

## Tests

Table-driven unit tests covering the declared-field formats and value vocabularies, the header shape, the field-key hardening, and edge cases (embedded words, severity precedence, case sensitivity, malformed headers).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Version bumped to 0.5.2

* **Bug Fixes**
  * Enhanced log level detection to support multiple log formats including structured fields, JSON, logfmt, and klog-style headers
  * Improved parsing accuracy with fallback detection for unstructured logs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->