### PR TITLE
chore: publish dev artifacts for any change in a module

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,14 +7,7 @@ on:
   push:
     branches: [main]
     paths:
-      - "**/init/**"
-      - "**/helm/**"
-      - "**/module.yaml"
-      - "**/*.go"
-      - "**/go.mod"
-      - "**/go.sum"
-      - "**/Dockerfile"
-      - "**/Makefile"
+      - "*/**"
   workflow_dispatch:
 
 permissions:
@@ -167,21 +160,14 @@ jobs:
             fi
 
             # Per-module changed-file slice
-            MODULE_CHANGED=$(echo "$CHANGED_FILES" | grep "^${module}/" || true)
+            MODULE_FILES=$(echo "$CHANGED_FILES" | grep "^${module}/" || true)
 
-            HELM_CHANGED=false #A change to any file under helm/
-            NON_HELM_CHANGED=false #A change to any file outside helm/ that could affect the module (module.yaml, Go files, go.mod/sum, Dockerfile, Makefile)
+            MODULE_CHANGED=false #Any file under the module changed
             VERSION_BUMPED=false #The Chart.yaml version field was changed
             APP_VERSION_BUMPED=false #The Chart.yaml appVersion field was changed
 
-            if echo "$MODULE_CHANGED" | grep -q "^${module}/helm/"; then
-              HELM_CHANGED=true
-            fi
-            # Substantive non-helm files only: strip helm/ paths first so files
-            # like helm/charts/foo.go don't falsely trip NON_HELM_CHANGED.
-            NON_HELM_FILES=$(echo "$MODULE_CHANGED" | grep -v "^${module}/helm/" || true)
-            if echo "$NON_HELM_FILES" | grep -qE "^${module}/(init/|module\.yaml$|.*\.go$|(.*/)?go\.mod$|(.*/)?go\.sum$|(.*/)?Dockerfile$|(.*/)?Makefile$)"; then
-              NON_HELM_CHANGED=true
+            if [ -n "$MODULE_FILES" ]; then
+              MODULE_CHANGED=true
             fi
 
             CHART_VERSION=$(yq '.version' "${chart_dir}/Chart.yaml")
@@ -198,22 +184,21 @@ jobs:
 
             # workflow_dispatch: force dev publish only, never formal
             if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-              HELM_CHANGED=true
-              NON_HELM_CHANGED=true
+              MODULE_CHANGED=true
               VERSION_BUMPED=false
               APP_VERSION_BUMPED=false
             fi
 
-            if [ "$HELM_CHANGED" = "false" ] && [ "$NON_HELM_CHANGED" = "false" ] \
+            if [ "$MODULE_CHANGED" = "false" ] \
               && [ "$VERSION_BUMPED" = "false" ] && [ "$APP_VERSION_BUMPED" = "false" ]; then
-              echo "Skipping ${module}: no relevant changes"
+              echo "Skipping ${module}: no changes"
               continue
             fi
 
-            echo "::group::${module} (helm=${HELM_CHANGED} nonhelm=${NON_HELM_CHANGED} ver=${VERSION_BUMPED} app=${APP_VERSION_BUMPED})"
+            echo "::group::${module} (changed=${MODULE_CHANGED} ver=${VERSION_BUMPED} app=${APP_VERSION_BUMPED})"
 
             # ── Build container images ──
-            if [ "$NON_HELM_CHANGED" = "true" ] || [ "$APP_VERSION_BUMPED" = "true" ]; then
+            if [ "$MODULE_CHANGED" = "true" ] || [ "$APP_VERSION_BUMPED" = "true" ]; then
               if [ -f "${module}/module.yaml" ]; then
                 image_count=$(yq '.images | length' "${module}/module.yaml")
                 if [ "$image_count" != "0" ] && [ "$image_count" != "null" ]; then
@@ -225,7 +210,7 @@ jobs:
                     FULL_IMAGE="ghcr.io/${REPO_OWNER}/${image_name}"
 
                     TAG_ARGS=()
-                    if [ "$NON_HELM_CHANGED" = "true" ]; then
+                    if [ "$MODULE_CHANGED" = "true" ]; then
                       TAG_ARGS+=(-t "${FULL_IMAGE}:latest-dev")
                       TAG_ARGS+=(-t "${FULL_IMAGE}:${GIT_SHA_SHORT}")
                     fi
@@ -246,7 +231,7 @@ jobs:
             fi
 
             # ── Package and publish the Helm chart ──
-            if [ "$HELM_CHANGED" = "true" ] || [ "$VERSION_BUMPED" = "true" ]; then
+            if [ "$MODULE_CHANGED" = "true" ] || [ "$VERSION_BUMPED" = "true" ]; then
               chart_name=$(yq '.name' "${chart_dir}/Chart.yaml")
 
               # Add dependency repos and build (once per module)
@@ -275,7 +260,7 @@ jobs:
                 helm push ".packages/${chart_name}-${target_version}.tgz" "oci://ghcr.io/${REPO_OWNER}/helm-charts"
               }
 
-              if [ "$HELM_CHANGED" = "true" ]; then
+              if [ "$MODULE_CHANGED" = "true" ]; then
                 package_and_push "0.0.0-latest-dev" "latest-dev"
                 package_and_push "0.0.0-${GIT_SHA_SHORT}" "${GIT_SHA_SHORT}"
               fi

--- a/README.md
+++ b/README.md
@@ -18,16 +18,16 @@ Each module publishes its container image(s) to `ghcr.io/openchoreo/<image-name>
 
 ### Tags published on every merge to `main`
 
-For each module touched by a merge, the CI workflow publishes development artifacts so consumers can always pull the tip of `main`:
+If any file under `<module>/` changes in a merge, the CI workflow republishes both the container image(s) and the Helm chart with development tags so consumers can always pull the tip of `main`:
 
-- **Container image** — published when any file *outside* `<module>/helm/` changes ( sources, `Dockerfile`, `Makefile`, `module.yaml`, `init/`, etc.):
+- **Container image(s)** declared in the module's `module.yaml`:
   - `ghcr.io/openchoreo/<image>:latest-dev` — moving tag, always points at the latest build from `main`.
   - `ghcr.io/openchoreo/<image>:<short-sha>` — immutable tag (8-character commit SHA) for pinning.
-- **Helm chart** — published when any file under `<module>/helm/` changes:
-  - `<chart>:0.0.0-latest-dev` — moving version.
-  - `<chart>:0.0.0-<short-sha>` — immutable version.
+- **Helm chart**:
+  - `<chart>:0.0.0-latest-dev` — moving version, with `appVersion=latest-dev`.
+  - `<chart>:0.0.0-<short-sha>` — immutable version, with `appVersion=<short-sha>` matching the image tag.
 
-Use the `latest-dev` tags for tracking `main`, and the SHA-suffixed tags when you need a reproducible reference to a specific commit.
+Use the `latest-dev` tags for tracking `main`, and the SHA-suffixed tags when you need a reproducible reference to a specific commit. The chart's `appVersion` always matches an image tag published in the same run.
 
 ### Cutting a formal release
 
@@ -36,11 +36,7 @@ A formal release is triggered by editing `helm/Chart.yaml` in the module:
 - Bump **`version`** to publish the Helm chart at that version (e.g. `<chart>:0.2.1`)
 - Bump **`appVersion`** to publish the container image at that tag (e.g. `<image>:0.2.1`). 
 
-Formal tags are published **independently** of the development tags, on the same per-artifact gating described above. In practice:
-
-- A bump to `appVersion` alone publishes only `<image>:<appVersion>` — the image's `:latest-dev` and `:<short-sha>` tags do *not* fire because no file outside `helm/` changed. The chart's dev tags (`0.0.0-latest-dev`, `0.0.0-<short-sha>`) *do* fire, since `Chart.yaml` lives under `helm/`.
-- A bump to `version` alone publishes the formal chart `<chart>:<version>` and the chart's dev tags. No image tags are published.
-- A release commit that also touches code outside `helm/` (Go sources, `Dockerfile`, etc.) additionally publishes the image's `:latest-dev` and `:<short-sha>` tags.
+Formal tags are published **in addition to** the development tags. Any release commit touches a file under `<module>/` (at minimum `Chart.yaml`), so the dev tags described above always fire alongside the formal tag(s).
 
 ### Manual re-publish (`workflow_dispatch`)
 


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat: add observability-logs-opensearch module
  fix: handle opensearch startup delay in init script
  docs: update observability-logs-opensearch module installation guide
  chore(deps): bump fluent-bit version in observability-logs-openobserve module

See: https://github.com/openchoreo/openchoreo/blob/main/docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
The previous workflow gated image and chart publishing on separate path subtrees (helm/ vs everything else), so a helm/-only change would publish a SHA-pinned chart whose appVersion referenced an image tag that was never built. This made the dev chart uninstallable. This approach fixes such issues by publishing images with the SHA-pinned tag

## Approach
- Collapsed the per-subtree gates (HELM_CHANGED / NON_HELM_CHANGED) into a single MODULE_CHANGED flag in .github/workflows/ci.yaml: any file under `<module>/` republishes both the image(s) and the chart with matching `:latest-dev / :<short-sha>` tags, guaranteeing the chart's appVersion always points at an image that exists.
- Broadened the workflow's push-trigger path filter to `*/**` so any module-scoped file (including .md) starts the run.
- Updated the README "Releases" section

## Related Issues
https://github.com/openchoreo/openchoreo/issues/3818

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how development and formal release tags are published for container images and Helm charts during CI runs.

* **Chore**
  * Enhanced CI workflow module change detection and streamlined automated tagging logic for container images and Helm charts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->