### PR TITLE
docs(observability-metrics-azure-monitor): install via OCI chart

### DIFF
--- a/observability-metrics-azure-monitor/README.md
+++ b/observability-metrics-azure-monitor/README.md
@@ -145,8 +145,10 @@ Secret. Optionally it renders an HTTPRoute so the Action Group can reach the
 webhook through the observability-plane gateway.
 
 ```bash
-helm install metrics-adapter-azure-monitor ./helm \
-  --namespace openchoreo-observability-plane \
+helm upgrade --install metrics-adapter-azure-monitor \
+  oci://ghcr.io/openchoreo/helm-charts/observability-metrics-azure-monitor \
+  --namespace openchoreo-observability-plane --create-namespace \
+  --version 0.1.0 \
   --set region=eastus2 \
   --set workspace.id=<workspace customerId GUID> \
   --set workspace.resourceId=<workspace ARM resource ID> \


### PR DESCRIPTION
## Purpose

The Azure Monitor metrics module's install instructions used `helm install ./helm`
from a local chart path, which diverges from every other observability community
module. All sibling observability modules (logs/metrics/tracing for Azure, AWS,
Prometheus, OpenObserve, OpenSearch, etc.) document installation from the published
OCI chart with `helm upgrade --install`. This PR aligns the metrics-azure-monitor
README with that convention.

## Approach

- Replace `helm install metrics-adapter-azure-monitor ./helm` with
  `helm upgrade --install metrics-adapter-azure-monitor oci://ghcr.io/openchoreo/helm-charts/observability-metrics-azure-monitor`
- Add `--create-namespace` and `--version 0.1.0` (matching the chart's `Chart.yaml`)
- Leave all `--set` values unchanged

## Related Issues

N/A

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Helm installation instructions to use remote OCI registry for chart pulls with explicit versioning, replacing local chart reference approach. Installation command updated to leverage `helm upgrade --install` pattern for better chart management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->