### PR TITLE
docs: add Dependencies sections to module READMEs and an upstream override note

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Browse the available modules in the [OpenChoreo Ecosystem](https://openchoreo.de
 
 For a deeper understanding of how modules work and how to add a new OpenChoreo module, see the [modules overview](https://openchoreo.dev/docs/platform-engineer-guide/modules/overview/) documentation.
 
+Some modules bundle upstream Helm charts, listed under a **Dependencies** section in their README. Override any of their values with `--set <chart-name>.<value>=...` or by nesting them under `<chart-name>:` in your values file.
+
 ## Releases
 
 Each module publishes its container image(s) to `ghcr.io/openchoreo/<image-name>` and its Helm chart to `oci://ghcr.io/openchoreo/helm-charts`. Releases are **author-driven**: PRs may merge without any version bump, and authors choose when to cut a formal release by editing the module's `helm/Chart.yaml`.

--- a/observability-logs-aws-cloudwatch/README.md
+++ b/observability-logs-aws-cloudwatch/README.md
@@ -1190,6 +1190,14 @@ kubectl -n "$NS" logs -l job-name=cloudwatch-setup-logs --tail=100
 | `adapter.networkPolicy.gatewayNamespaceLabels` | `{}` | Namespace labels of the Gateway data-plane pods allowed to proxy the webhook. Set when `webhookRoute` is enabled. |
 | `adapter.networkPolicy.allowProbeIPBlock` | `""` | Optional node CIDR for kubelet probes when required by the CNI. |
 
+## Dependencies
+
+Bundled upstream Helm charts:
+
+| Chart | Repository |
+| ----- | ---------- |
+| amazon-cloudwatch-observability | https://aws-observability.github.io/helm-charts |
+
 ## Compatibility
 
 > **Note:** The Helm chart versions specified in the installation commands above are for the latest module version compatible with the development version of OpenChoreo. Refer to the compatibility table below to determine the appropriate module version for your OpenChoreo installation.

--- a/observability-logs-moesif/README.md
+++ b/observability-logs-moesif/README.md
@@ -130,3 +130,14 @@ To also remove the secret:
 kubectl delete secret moesif-app-secret \
   --namespace openchoreo-observability-plane
 ```
+
+
+## Dependencies
+
+Bundled upstream Helm charts:
+
+| Chart | Repository |
+| ----- | ---------- |
+| opentelemetry-collector | https://open-telemetry.github.io/opentelemetry-helm-charts |
+| fluent-bit | https://fluent.github.io/helm-charts |
+

--- a/observability-logs-openobserve/README.md
+++ b/observability-logs-openobserve/README.md
@@ -124,6 +124,16 @@ helm upgrade --install observability-logs-openobserve \
 > and `fluent-bit.openObserveHost` and `fluent-bit.openObservePort` values are set to the OpenObserve endpoint exposed from the observability plane cluster,
 > while `common.openObserveOrg` and `common.openObserveStream` match the organization and stream configured in the observability plane cluster.
 
+## Dependencies
+
+Bundled upstream Helm charts:
+
+| Chart | Repository |
+| ----- | ---------- |
+| fluent-bit | https://fluent.github.io/helm-charts |
+| openobserve-standalone | https://charts.openobserve.ai |
+| openobserve | https://charts.openobserve.ai |
+
 ## Compatibility
 
 > **Note:** The Helm chart versions specified in the installation commands above are for the latest module version compatible with the development version of OpenChoreo. Refer to the compatibility table below to determine the appropriate module version for your OpenChoreo installation.

--- a/observability-logs-opensearch/README.md
+++ b/observability-logs-opensearch/README.md
@@ -175,6 +175,15 @@ kubectl exec -n openchoreo-observability-plane opensearch-master-0 \
 
 Only logs written after the deletion will appear (Fluent Bit's tail cursor persists at `/var/lib/fluent-bit/db/tail-container-logs.db`). Generate fresh traffic, or remove that DB and restart the DaemonSet to backfill.
 
+## Dependencies
+
+Bundled upstream Helm charts:
+
+| Chart | Repository |
+| ----- | ---------- |
+| opensearch | https://opensearch-project.github.io/helm-charts/ |
+| fluent-bit | https://fluent.github.io/helm-charts |
+
 ## Compatibility
 
 > **Note:** The Helm chart versions specified in the installation commands above are for the latest module version compatible with the development version of OpenChoreo. Refer to the compatibility table below to determine the appropriate module version for your OpenChoreo installation.

--- a/observability-metrics-aws-cloudwatch/README.md
+++ b/observability-metrics-aws-cloudwatch/README.md
@@ -1202,6 +1202,15 @@ kubectl -n "$NS" logs -l job-name=metrics-aws-cloudwatch-retention --tail=100
 
 If you override `metrics.logGroup`, update the CloudWatch Logs IAM policy resource ARN to match that log group.
 
+## Dependencies
+
+Bundled upstream Helm charts:
+
+| Chart | Repository |
+| ----- | ---------- |
+| opentelemetry-collector | https://open-telemetry.github.io/opentelemetry-helm-charts |
+| kube-state-metrics | https://prometheus-community.github.io/helm-charts |
+
 ## Compatibility
 
 > **Note:** The Helm chart versions specified in the installation commands above are for the latest module version compatible with the development version of OpenChoreo. Refer to the compatibility table below to determine the appropriate module version for your OpenChoreo installation.

--- a/observability-metrics-prometheus/README.md
+++ b/observability-metrics-prometheus/README.md
@@ -118,6 +118,14 @@ If remote write from exporter to receiver is failing:
 3. Check that queue capacity and batch settings are appropriate for your metrics volume
 4. Monitor central Prometheus for import errors: `rate(prometheus_tsdb_symbol_table_size_bytes[5m])`
 
+## Dependencies
+
+Bundled upstream Helm charts:
+
+| Chart | Repository |
+| ----- | ---------- |
+| kube-prometheus-stack | https://prometheus-community.github.io/helm-charts |
+
 ## Compatibility
 
 > **Note:** The Helm chart versions specified in the installation commands above reflect the latest module version and is compatible with the development version of OpenChoreo. Refer to the compatibility table below to determine the appropriate module version for your OpenChoreo installation.

--- a/observability-tracing-aws-xray/README.md
+++ b/observability-tracing-aws-xray/README.md
@@ -786,6 +786,14 @@ expose a retention value. AWS X-Ray trace retention is service-managed and fixed
 at 30 days; it is not backed by a customer-managed CloudWatch Logs log group
 with a configurable retention policy.
 
+## Dependencies
+
+Bundled upstream Helm charts:
+
+| Chart | Repository |
+| ----- | ---------- |
+| opentelemetry-collector | https://open-telemetry.github.io/opentelemetry-helm-charts |
+
 ## Compatibility
 
 > **Note:** The Helm chart versions specified in the installation commands above are for the latest module version compatible with the development version of OpenChoreo. Refer to the compatibility table below to determine the appropriate module version for your OpenChoreo installation.

--- a/observability-tracing-openobserve/README.md
+++ b/observability-tracing-openobserve/README.md
@@ -95,6 +95,16 @@ Refer to the [openobserve Helm chart documentation](https://github.com/openobser
 > ```
 
 
+## Dependencies
+
+Bundled upstream Helm charts:
+
+| Chart | Repository |
+| ----- | ---------- |
+| opentelemetry-collector | https://open-telemetry.github.io/opentelemetry-helm-charts |
+| openobserve-standalone | https://charts.openobserve.ai |
+| openobserve | https://charts.openobserve.ai |
+
 ## Compatibility
 
 > **Note:** The Helm chart versions specified in the installation commands above are for the latest module version compatible with the development version of OpenChoreo. Refer to the compatibility table below to determine the appropriate module version for your OpenChoreo installation.

--- a/observability-tracing-opensearch/README.md
+++ b/observability-tracing-opensearch/README.md
@@ -155,6 +155,15 @@ If you are upgrading from a version before 0.4.0, reindex the older tracing data
 curl -fsSL https://raw.githubusercontent.com/openchoreo/community-modules/refs/heads/main/observability-tracing-opensearch/scripts/upgrade-to-0-4-1.sh | bash
 ```
 
+## Dependencies
+
+Bundled upstream Helm charts:
+
+| Chart | Repository |
+| ----- | ---------- |
+| opensearch | https://opensearch-project.github.io/helm-charts/ |
+| opentelemetry-collector | https://open-telemetry.github.io/opentelemetry-helm-charts |
+
 ## Compatibility
 
 > **Note:** The Helm chart versions specified in the installation commands above are for the latest module version compatible with the development version of OpenChoreo. Refer to the compatibility table below to determine the appropriate module version for your OpenChoreo installation.


### PR DESCRIPTION
## Purpose

Make each module's bundled upstream Helm charts discoverable, and show how to override their values.

Addresses openchoreo/openchoreo#3831

## Approach

- Added a `Dependencies` section to the README of every module that declares upstream Helm chart dependencies (the `observability-*` modules), with a `Chart | Version | Repository` table generated from each module's `helm/Chart.yaml`.
- Added a short note in the root README pointing to those sections and showing how to override subchart values — `--set <chart-name>.<value>=...` or by nesting under `<chart-name>:` in a values file.

Modules with no Helm chart or no upstream dependencies are left unchanged.

## Checklist

- [x] Tests added or updated — N/A (docs only)
- [x] Samples updated — N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified main README guidance on overriding Helm chart values in community modules using command-line flags and values file configurations
  * Added Dependencies sections across observability modules, documenting bundled upstream Helm charts and their source repositories

<!-- end of auto-generated comment: release notes by coderabbit.ai -->