### PR TITLE
fix: default Prometheus service to ClusterIP in observability-metrics-prometheus

### DIFF
--- a/observability-metrics-prometheus/README.md
+++ b/observability-metrics-prometheus/README.md
@@ -27,7 +27,7 @@ helm upgrade --install observability-metrics-prometheus \
   oci://ghcr.io/openchoreo/helm-charts/observability-metrics-prometheus \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.6.1
+  --version 0.6.2
 ```
 
 ### Multi-cluster topology
@@ -39,7 +39,7 @@ helm upgrade --install observability-metrics-prometheus \
   oci://ghcr.io/openchoreo/helm-charts/observability-metrics-prometheus \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.6.1 \
+  --version 0.6.2 \
   --set global.installationMode="multiClusterReceiver" \
   --set-json 'prometheusCustomizations.http.hostnames=["prometheus.observability.example.com"]'
 ```
@@ -53,7 +53,7 @@ helm upgrade --install observability-metrics-prometheus \
   oci://ghcr.io/openchoreo/helm-charts/observability-metrics-prometheus \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.6.1 \
+  --version 0.6.2 \
   --set global.installationMode="multiClusterExporter" \
   --set prometheusCustomizations.http.observabilityPlaneUrl=http://prometheus.observability.example.com:9091/api/v1/write \
   --set kube-prometheus-stack.prometheus.enabled=false \

--- a/observability-metrics-prometheus/helm/Chart.yaml
+++ b/observability-metrics-prometheus/helm/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 name: observability-metrics-prometheus
 description: A Helm chart for OpenChoreo Observability Metrics module based on Prometheus
 type: application
-version: 0.6.1
+version: 0.6.2
 appVersion: "0.6.1"
 keywords:
   - prometheus

--- a/observability-metrics-prometheus/helm/values.yaml
+++ b/observability-metrics-prometheus/helm/values.yaml
@@ -39,7 +39,7 @@ kube-prometheus-stack:
     service:
       port: 9091
       reloaderWebPort: 8081
-      type: LoadBalancer
+      type: ClusterIP
 
   alertmanager:
     enabled: true


### PR DESCRIPTION
## Purpose

Prometheus is exposed publicly by default via a `LoadBalancer` service. Default it to `ClusterIP` so public exposure is explicit opt-in.

## Approach

Set `kube-prometheus-stack.prometheus.service.type` to `ClusterIP` in `values.yaml` (was `LoadBalancer`); bump chart to `0.6.2` and the README install version. Verified on k3d: the Prometheus service comes up as ClusterIP and the observer still queries it internally.

## Related Issues

Refs openchoreo/openchoreo#3830


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Prometheus Helm chart to version 0.6.2
  * Changed service exposure from LoadBalancer to ClusterIP

<!-- end of auto-generated comment: release notes by coderabbit.ai -->