### PR TITLE
feat: make the observability-tracing-openobserve collector ConfigMap optional

### DIFF
--- a/observability-tracing-openobserve/README.md
+++ b/observability-tracing-openobserve/README.md
@@ -66,7 +66,7 @@ helm upgrade --install observability-tracing-openobserve \
   oci://ghcr.io/openchoreo/helm-charts/observability-tracing-openobserve \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.2.2
+  --version 0.2.4
 ```
 
 To switch to HA mode, disable the standalone chart and enable the distributed chart:
@@ -75,7 +75,7 @@ To switch to HA mode, disable the standalone chart and enable the distributed ch
 helm upgrade --install observability-tracing-openobserve \
   oci://ghcr.io/openchoreo/helm-charts/observability-tracing-openobserve \
   --namespace openchoreo-observability-plane \
-  --version 0.2.2 \
+  --version 0.2.4 \
   --reuse-values \
   --set openobserve-standalone.enabled=false \
   --set openobserve.enabled=true
@@ -90,7 +90,7 @@ Refer to the [openobserve Helm chart documentation](https://github.com/openobser
 >  oci://ghcr.io/openchoreo/helm-charts/observability-tracing-openobserve \
 >  --create-namespace \
 >  --namespace openchoreo-observability-plane \
->  --version 0.2.2 \
+>  --version 0.2.4 \
 >  --set openobserve-standalone.enabled=false
 > ```
 

--- a/observability-tracing-openobserve/helm/Chart.yaml
+++ b/observability-tracing-openobserve/helm/Chart.yaml
@@ -5,8 +5,8 @@ apiVersion: v2
 name: observability-tracing-openobserve
 description: A Helm chart for OpenChoreo Tracing Module for OpenObserve
 type: application
-version: 0.2.3
-appVersion: "0.2.3"
+version: 0.2.4
+appVersion: "0.2.4"
 keywords:
   - openobserve
   - openchoreo

--- a/observability-tracing-openobserve/helm/templates/opentelemetry-collector/configMap.yaml
+++ b/observability-tracing-openobserve/helm/templates/opentelemetry-collector/configMap.yaml
@@ -1,3 +1,4 @@
+{{- if not (index .Values "opentelemetry-collector" "configMap" "create") }}
 # Copyright 2026 The OpenChoreo Authors
 # SPDX-License-Identifier: Apache-2.0
 
@@ -82,3 +83,4 @@ data:
           processors: [{{ join ", " $processors }}]
           {{- end }}
           exporters: [otlphttp]
+{{- end }}


### PR DESCRIPTION
## Purpose

The collector pipeline is locked in a wrapper-owned ConfigMap, so users can't customize it through the upstream chart's `config:` values.

## Approach

Gate the wrapper ConfigMap on `opentelemetry-collector.configMap.create` — it renders only when we own the config (the default). Setting `create=true` (with `existingName` cleared) lets users supply their own pipeline via the upstream chart, with no orphan ConfigMap left behind. Default behaviour is unchanged. Workload knobs (`mode`, `statefulset.volumeClaimTemplates`) already pass through as standard subchart values. Chart bumped to `0.2.4`; README install version synced.

## Related Issues

Refs openchoreo/openchoreo#3829


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions to reference Helm chart version **0.2.4**.
* **New Features**
  * Made the OpenTelemetry Collector `ConfigMap` rendering optional/configurable, so it can be omitted based on deployment settings.
* **Chores**
  * Bumped the Helm chart and application version metadata to **0.2.4**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->