### PR TITLE
fix: use TLSRoute v1 for opensearch passthrough route

### DIFF
--- a/observability-logs-opensearch/README.md
+++ b/observability-logs-opensearch/README.md
@@ -63,7 +63,7 @@ helm upgrade --install observability-logs-opensearch \
   oci://ghcr.io/openchoreo/helm-charts/observability-logs-opensearch \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.5.2 \
+  --version 0.5.3 \
   --set adapter.openSearchSecretName="opensearch-admin-credentials" \
   --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials"
 ```
@@ -75,7 +75,7 @@ helm upgrade --install observability-logs-opensearch \
 >   oci://ghcr.io/openchoreo/helm-charts/observability-logs-opensearch \
 >   --create-namespace \
 >   --namespace openchoreo-observability-plane \
->   --version 0.5.2 \
+>   --version 0.5.3 \
 >   --set adapter.openSearchSecretName="opensearch-admin-credentials" \
 >   --set openSearch.enabled=false \
 >   --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials"
@@ -94,7 +94,7 @@ helm upgrade observability-logs-opensearch \
   oci://ghcr.io/openchoreo/helm-charts/observability-logs-opensearch \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.5.2 \
+  --version 0.5.3 \
   --reuse-values \
   --set fluent-bit.enabled=true
 ```
@@ -116,7 +116,7 @@ helm upgrade --install observability-logs-opensearch \
   oci://ghcr.io/openchoreo/helm-charts/observability-logs-opensearch \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.5.2 \
+  --version 0.5.3 \
   --set adapter.openSearchSecretName="opensearch-admin-credentials" \
   --set openSearch.enabled=false \
   --set openSearchCluster.enabled=true \
@@ -144,7 +144,7 @@ helm upgrade --install observability-logs-opensearch \
   oci://ghcr.io/openchoreo/helm-charts/observability-logs-opensearch \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.5.2 \
+  --version 0.5.3 \
   --set adapter.enabled=false \
   --set openSearch.enabled=false \
   --set openSearchCluster.enabled=false \

--- a/observability-logs-opensearch/helm/Chart.yaml
+++ b/observability-logs-opensearch/helm/Chart.yaml
@@ -5,8 +5,8 @@ apiVersion: v2
 name: observability-logs-opensearch
 description: A Helm chart for OpenChoreo Observability Logs module with Fluent Bit and OpenSearch
 type: application
-version: 0.5.2
-appVersion: "0.5.2"
+version: 0.5.3
+appVersion: "0.5.3"
 keywords:
   - opensearch
   - observability

--- a/observability-logs-opensearch/helm/templates/opensearch-cluster/tls-route.yaml
+++ b/observability-logs-opensearch/helm/templates/opensearch-cluster/tls-route.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.openSearchCluster.enabled }}
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: TLSRoute
 metadata:
   name: opensearch

--- a/observability-logs-opensearch/helm/templates/opensearch-cluster/tls-route.yaml
+++ b/observability-logs-opensearch/helm/templates/opensearch-cluster/tls-route.yaml
@@ -5,6 +5,10 @@ metadata:
   name: opensearch
   namespace: {{ .Release.Namespace }}
 spec:
+  hostnames:
+    {{- range .Values.openSearchCluster.tlsRoute.hostnames }}
+    - {{ . | quote }}
+    {{- end }}
   parentRefs:
     - name: gateway-default
       namespace: {{ .Release.Namespace }}

--- a/observability-logs-opensearch/helm/values.yaml
+++ b/observability-logs-opensearch/helm/values.yaml
@@ -111,6 +111,16 @@ openSearch:
 openSearchCluster:
   enabled: false
 
+  # SNI hostnames for the TLS passthrough TLSRoute that exposes OpenSearch
+  # through the gateway. These must match the gateway tlsPassthrough listener
+  # hostname and the SNI that remote fluent-bit clients present
+  # (fluent-bit.openSearchVHost). They also need to be present in the OpenSearch
+  # server certificate's dnsNames. Required by Gateway API v1 (spec.hostnames is
+  # mandatory for TLSRoute).
+  tlsRoute:
+    hostnames:
+      - "opensearch.observability.openchoreo.localhost"
+
   bootstrap:
     resources:
       limits:

--- a/observability-tracing-opensearch/README.md
+++ b/observability-tracing-opensearch/README.md
@@ -73,7 +73,7 @@ helm upgrade --install observability-tracing-opensearch \
   oci://ghcr.io/openchoreo/helm-charts/observability-tracing-opensearch \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.4.1 \
+  --version 0.4.2 \
   --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials"
 ```
 
@@ -84,7 +84,7 @@ helm upgrade --install observability-tracing-opensearch \
 >   oci://ghcr.io/openchoreo/helm-charts/observability-tracing-opensearch \
 >   --create-namespace \
 >   --namespace openchoreo-observability-plane \
->   --version 0.4.1 \
+>   --version 0.4.2 \
 >   --set openSearch.enabled=false \
 >   --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials"
 > ```
@@ -105,7 +105,7 @@ helm upgrade --install observability-tracing-opensearch \
   oci://ghcr.io/openchoreo/helm-charts/observability-tracing-opensearch \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.4.1 \
+  --version 0.4.2 \
   --set global.installationMode="multiClusterReceiver" \
   --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials"
 ```
@@ -117,7 +117,7 @@ helm upgrade --install observability-tracing-opensearch \
 >   oci://ghcr.io/openchoreo/helm-charts/observability-tracing-opensearch \
 >   --create-namespace \
 >   --namespace openchoreo-observability-plane \
->   --version 0.4.1 \
+>   --version 0.4.2 \
 >   --set openSearch.enabled=false \
 >   --set global.installationMode="multiClusterReceiver" \
 >   --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials"
@@ -136,7 +136,7 @@ helm upgrade --install observability-tracing-opensearch \
   oci://ghcr.io/openchoreo/helm-charts/observability-tracing-opensearch \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.4.1 \
+  --version 0.4.2 \
   --set global.installationMode="multiClusterExporter" \
   --set openSearch.enabled=false \
   --set openSearchCluster.enabled=false \

--- a/observability-tracing-opensearch/helm/Chart.yaml
+++ b/observability-tracing-opensearch/helm/Chart.yaml
@@ -5,8 +5,8 @@ apiVersion: v2
 name: observability-tracing-opensearch
 description: A Helm chart for OpenChoreo Observability Tracing module with OpenTelemetry Collector and OpenSearch
 type: application
-version: 0.4.1
-appVersion: "0.4.1"
+version: 0.4.2
+appVersion: "0.4.2"
 keywords:
   - opensearch
   - observability

--- a/observability-tracing-opensearch/helm/templates/opensearch-cluster/tls-route.yaml
+++ b/observability-tracing-opensearch/helm/templates/opensearch-cluster/tls-route.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.openSearchCluster.enabled }}
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: TLSRoute
 metadata:
   name: opensearch

--- a/observability-tracing-opensearch/helm/templates/opensearch-cluster/tls-route.yaml
+++ b/observability-tracing-opensearch/helm/templates/opensearch-cluster/tls-route.yaml
@@ -5,6 +5,10 @@ metadata:
   name: opensearch
   namespace: {{ .Release.Namespace }}
 spec:
+  hostnames:
+    {{- range .Values.openSearchCluster.tlsRoute.hostnames }}
+    - {{ . | quote }}
+    {{- end }}
   parentRefs:
     - name: gateway-default
       namespace: {{ .Release.Namespace }}

--- a/observability-tracing-opensearch/helm/values.yaml
+++ b/observability-tracing-opensearch/helm/values.yaml
@@ -84,6 +84,15 @@ opentelemetry-collector:
 openSearchCluster:
   enabled: false
 
+  # SNI hostnames for the TLS passthrough TLSRoute that exposes OpenSearch
+  # through the gateway. These must match the gateway tlsPassthrough listener
+  # hostname and the SNI that remote clients present. They also need to be
+  # present in the OpenSearch server certificate's dnsNames. Required by Gateway
+  # API v1 (spec.hostnames is mandatory for TLSRoute).
+  tlsRoute:
+    hostnames:
+      - "opensearch.observability.openchoreo.localhost"
+
   bootstrap:
     resources:
       limits:


### PR DESCRIPTION
## Purpose

The `observability-logs-opensearch` and `observability-tracing-opensearch` charts render the OpenSearch TLS-passthrough `TLSRoute` as `gateway.networking.k8s.io/v1alpha2`. As of Gateway API v1.5 (the version OpenChoreo now installs via the standard channel — see openchoreo/openchoreo#3883), the `TLSRoute` CRD serves `v1` as the storage version and marks `v1alpha2` as `served: false`. Installing these charts against a standard-channel cluster fails:

```
  no matches for kind "TLSRoute" in version "gateway.networking.k8s.io/v1alpha2"
  ensure CRDs are installed first
```

## Approach

- Bump the TLSRoute `apiVersion` from `v1alpha2` to `v1` in both charts'
    `opensearch-cluster/tls-route.yaml`.
- Patch-bump chart versions so the fix can be published:
    - `observability-logs-opensearch`: 0.5.2 → 0.5.3
    - `observability-tracing-opensearch`: 0.4.1 → 0.4.2
    (`appVersion` bumped to match.)

## Related Issues
Follow-up to openchoreo/openchoreo#3883

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated observability-logs-opensearch helm chart to version 0.5.3
  * Updated observability-tracing-opensearch helm chart to version 0.4.2
  * Migrated TLSRoute configurations to stable Kubernetes Gateway API (v1)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->