### PR TITLE
chore: point adapter openapi specs at openchoreo repo

### DIFF
--- a/observability-logs-aws-cloudwatch/Makefile
+++ b/observability-logs-aws-cloudwatch/Makefile
@@ -2,7 +2,7 @@ CFG_DIR := internal/api
 OAPI_CODEGEN_VERSION ?= v2.5.1
 # Pinned to an immutable commit SHA so `make openapi-codegen` is reproducible.
 # Bump the SHA when the upstream spec changes.
-SPEC := https://raw.githubusercontent.com/openchoreo/openchoreo.github.io/1f1eb6ca3dadb4198ef561eb6fd910cf60f38fa4/static/api-specs/observability-logs-adapter-api.yaml
+SPEC := https://raw.githubusercontent.com/openchoreo/openchoreo/main/openapi/observability-logs-adapter-api.yaml
 
 .PHONY: oapi-codegen-install openapi-codegen unit-test
 

--- a/observability-logs-azure-loganalytics/Makefile
+++ b/observability-logs-azure-loganalytics/Makefile
@@ -3,7 +3,7 @@
 
 CFG_DIR := internal/api
 OAPI_CODEGEN_VERSION ?= v2.5.1
-SPEC := https://raw.githubusercontent.com/openchoreo/openchoreo.github.io/refs/heads/main/static/api-specs/observability-logs-adapter-api.yaml
+SPEC := https://raw.githubusercontent.com/openchoreo/openchoreo/main/openapi/observability-logs-adapter-api.yaml
 
 .PHONY: oapi-codegen-install openapi-codegen unit-test build run
 

--- a/observability-logs-openobserve/Makefile
+++ b/observability-logs-openobserve/Makefile
@@ -1,6 +1,6 @@
 CFG_DIR := internal/api
 OAPI_CODEGEN_VERSION ?= v2.5.1
-SPEC := https://raw.githubusercontent.com/openchoreo/openchoreo.github.io/refs/heads/main/static/api-specs/observability-logs-adapter-api.yaml
+SPEC := https://raw.githubusercontent.com/openchoreo/openchoreo/main/openapi/observability-logs-adapter-api.yaml
 
 .PHONY: oapi-codegen-install openapi-codegen unit-test
 

--- a/observability-logs-opensearch/Makefile
+++ b/observability-logs-opensearch/Makefile
@@ -1,6 +1,6 @@
 CFG_DIR := internal/api
 OAPI_CODEGEN_VERSION ?= v2.5.1
-SPEC := https://raw.githubusercontent.com/openchoreo/openchoreo.github.io/refs/heads/main/static/api-specs/observability-logs-adapter-api.yaml
+SPEC := https://raw.githubusercontent.com/openchoreo/openchoreo/main/openapi/observability-logs-adapter-api.yaml
 
 .PHONY: oapi-codegen-install openapi-codegen unit-test
 

--- a/observability-metrics-aws-cloudwatch/Makefile
+++ b/observability-metrics-aws-cloudwatch/Makefile
@@ -1,6 +1,6 @@
 CFG_DIR := internal/api
 OAPI_CODEGEN_VERSION ?= v2.5.1
-SPEC := https://raw.githubusercontent.com/openchoreo/openchoreo.github.io/refs/heads/main/static/api-specs/observability-metrics-adapter.yaml
+SPEC := https://raw.githubusercontent.com/openchoreo/openchoreo/main/openapi/observability-metrics-adapter.yaml
 GOBIN_DIR := $(or $(shell go env GOBIN),$(shell go env GOPATH)/bin)
 
 .PHONY: oapi-codegen-install openapi-codegen unit-test

--- a/observability-metrics-azure-monitor/Makefile
+++ b/observability-metrics-azure-monitor/Makefile
@@ -5,7 +5,7 @@ CFG_DIR := internal/api
 OAPI_CODEGEN_VERSION ?= v2.5.1
 # Pinned to the same metrics adapter spec the sibling AWS CloudWatch metrics
 # module generates from. Bump deliberately when the upstream spec changes.
-SPEC := https://raw.githubusercontent.com/openchoreo/openchoreo.github.io/refs/heads/main/static/api-specs/observability-metrics-adapter.yaml
+SPEC := https://raw.githubusercontent.com/openchoreo/openchoreo/main/openapi/observability-metrics-adapter.yaml
 GOBIN_DIR := $(or $(shell go env GOBIN),$(shell go env GOPATH)/bin)
 
 .PHONY: oapi-codegen-install openapi-codegen unit-test build run

--- a/observability-metrics-prometheus/Makefile
+++ b/observability-metrics-prometheus/Makefile
@@ -1,6 +1,6 @@
 CFG_DIR := internal/api
 OAPI_CODEGEN_VERSION ?= v2.5.1
-SPEC := https://raw.githubusercontent.com/openchoreo/openchoreo.github.io/refs/heads/main/static/api-specs/observability-metrics-adapter.yaml
+SPEC := https://raw.githubusercontent.com/openchoreo/openchoreo/main/openapi/observability-metrics-adapter.yaml
 
 .PHONY: oapi-codegen-install openapi-codegen unit-test
 

--- a/observability-tracing-aws-xray/Makefile
+++ b/observability-tracing-aws-xray/Makefile
@@ -1,6 +1,6 @@
 CFG_DIR := internal/api
 OAPI_CODEGEN_VERSION ?= v2.5.1
-SPEC := https://raw.githubusercontent.com/openchoreo/openchoreo.github.io/ac623d6153db633fe78ce25fb649635e96b24361/static/api-specs/observability-tracing-adapter-api.yaml
+SPEC := https://raw.githubusercontent.com/openchoreo/openchoreo/main/openapi/observability-tracing-adapter-api.yaml
 
 .PHONY: oapi-codegen-install openapi-codegen unit-test
 

--- a/observability-tracing-openobserve/Makefile
+++ b/observability-tracing-openobserve/Makefile
@@ -1,6 +1,6 @@
 CFG_DIR := internal/api
 OAPI_CODEGEN_VERSION ?= v2.5.1
-SPEC := https://raw.githubusercontent.com/openchoreo/openchoreo.github.io/refs/heads/main/static/api-specs/observability-tracing-adapter-api.yaml
+SPEC := https://raw.githubusercontent.com/openchoreo/openchoreo/main/openapi/observability-tracing-adapter-api.yaml
 
 .PHONY: oapi-codegen-install openapi-codegen unit-test
 

--- a/observability-tracing-opensearch/Makefile
+++ b/observability-tracing-opensearch/Makefile
@@ -1,6 +1,6 @@
 CFG_DIR := internal/api
 OAPI_CODEGEN_VERSION ?= v2.5.1
-SPEC := https://raw.githubusercontent.com/openchoreo/openchoreo.github.io/refs/heads/main/static/api-specs/observability-tracing-adapter-api.yaml
+SPEC := https://raw.githubusercontent.com/openchoreo/openchoreo/main/openapi/observability-tracing-adapter-api.yaml
 
 .PHONY: oapi-codegen-install openapi-codegen unit-test
 


### PR DESCRIPTION
Repoints all observability adapter modules from the deleted docs-repo spec URLs to the canonical `openchoreo/openapi/` location.

The specs were moved into the openchoreo repo and removed from the docs repo per openchoreo/openchoreo#3842, which 404s the URLs these modules' `make openapi-codegen` fetched. The 7 `main`-tracking modules currently fail to regenerate; the 2 SHA-pinned ones still resolve but against a stale copy.

Verified codegen + build against the new URL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated API specification sources for all observability adapter modules (logs, metrics, and tracing) across multiple providers (AWS CloudWatch, Azure, OpenObserve, OpenSearch, and Prometheus). This ensures adapters use the latest API definitions for code generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->