### PR TITLE
chore: update CI workflow to create git tags for releases and add manual workflow for old artifact deletion

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -98,6 +98,9 @@ jobs:
   build-and-release:
     needs: unit-test
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -265,6 +268,18 @@ jobs:
               fi
               if [ "$VERSION_BUMPED" = "true" ]; then
                 package_and_push "${RELEASE_VERSION}" "${RELEASE_VERSION}"
+              fi
+            fi
+
+            # ── Create and push git tag for the release ──
+            if [ "$VERSION_BUMPED" = "true" ]; then
+              TAG="${module}-${RELEASE_VERSION}"
+              if git rev-parse "refs/tags/${TAG}" >/dev/null 2>&1; then
+                echo "Tag ${TAG} already exists; skipping"
+              else
+                echo "Creating and pushing tag ${TAG}"
+                git tag "${TAG}" HEAD
+                git push origin "refs/tags/${TAG}"
               fi
             fi
 

--- a/.github/workflows/cleanup-artifacts.yml
+++ b/.github/workflows/cleanup-artifacts.yml
@@ -1,0 +1,232 @@
+# Copyright 2026 The OpenChoreo Authors
+# SPDX-License-Identifier: Apache-2.0
+
+name: Cleanup Old Artifacts
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (show what would be deleted without deleting)'
+        type: boolean
+        default: true
+      retention_days:
+        description: 'Delete artifacts older than this many days'
+        type: number
+        default: 180
+
+permissions:
+  contents: read
+
+jobs:
+  discover:
+    name: Discover Images and Charts
+    runs-on: ubuntu-latest
+    outputs:
+      images: ${{ steps.collect.outputs.images }}
+      charts: ${{ steps.collect.outputs.charts }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install yq
+        uses: mikefarah/yq@v4
+
+      - name: Collect images and charts from module manifests
+        id: collect
+        run: |
+          set -euo pipefail
+
+          images=()
+          charts=()
+
+          for module_dir in */; do
+            module="${module_dir%/}"
+
+            if [ -f "${module}/module.yaml" ]; then
+              image_count=$(yq '.images | length' "${module}/module.yaml")
+              if [ "$image_count" != "0" ] && [ "$image_count" != "null" ]; then
+                for i in $(seq 0 $((image_count - 1))); do
+                  name=$(yq ".images[${i}].name" "${module}/module.yaml")
+                  images+=("$name")
+                done
+              fi
+            fi
+
+            if [ -f "${module}/helm/Chart.yaml" ]; then
+              chart=$(yq '.name' "${module}/helm/Chart.yaml")
+              charts+=("$chart")
+            fi
+          done
+
+          if [ "${#images[@]}" -eq 0 ]; then
+            images_json='[]'
+          else
+            images_json=$(printf '%s\n' "${images[@]}" | jq -R . | jq -s -c .)
+          fi
+
+          if [ "${#charts[@]}" -eq 0 ]; then
+            charts_json='[]'
+          else
+            charts_json=$(printf '%s\n' "${charts[@]}" | jq -R . | jq -s -c .)
+          fi
+
+          echo "Discovered images: $images_json"
+          echo "Discovered charts: $charts_json"
+
+          echo "images=$images_json" >> "$GITHUB_OUTPUT"
+          echo "charts=$charts_json" >> "$GITHUB_OUTPUT"
+
+  cleanup-docker-images:
+    name: Cleanup Docker Images
+    needs: discover
+    if: ${{ needs.discover.outputs.images != '[]' }}
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        package: ${{ fromJson(needs.discover.outputs.images) }}
+    steps:
+      - name: Calculate cutoff date
+        id: cutoff
+        run: |
+          CUTOFF=$(date -d "${{ inputs.retention_days }} days ago" -Iseconds -u)
+          echo "date=$CUTOFF" >> $GITHUB_OUTPUT
+          echo "Cutoff date: $CUTOFF (retention: ${{ inputs.retention_days }} days, dry_run: ${{ inputs.dry_run }})"
+
+      - name: Find old SHA-only versions
+        id: find
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Finding old SHA-only versions for ${{ matrix.package }}..."
+
+          # Get versions that:
+          # 1. Have tags (not untagged manifests)
+          # 2. All tags match 8-char SHA pattern (excludes latest-dev, releases)
+          # 3. Created before cutoff date
+          VERSIONS=$(gh api '/orgs/${{ github.repository_owner }}/packages/container/${{ matrix.package }}/versions' \
+            --paginate \
+            --jq '
+              .[] |
+              select(.metadata.container.tags | length > 0) |
+              select(.metadata.container.tags | all(test("^[0-9a-f]{8}$"))) |
+              select(.created_at < "${{ steps.cutoff.outputs.date }}") |
+              {id, tags: .metadata.container.tags, created_at}
+            ' 2>/dev/null || echo "")
+
+          if [ -z "$VERSIONS" ]; then
+            echo "No old SHA-only versions found for ${{ matrix.package }}"
+            echo "count=0" >> $GITHUB_OUTPUT
+          else
+            COUNT=$(echo "$VERSIONS" | jq -s 'length')
+            echo "Found $COUNT old SHA-only version(s) for ${{ matrix.package }}:"
+            echo "$VERSIONS" | jq -r '"  - \(.tags[0]) (created: \(.created_at), id: \(.id))"'
+            echo "versions<<EOF" >> $GITHUB_OUTPUT
+            echo "$VERSIONS" >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+            echo "count=$COUNT" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Delete old versions
+        if: ${{ inputs.dry_run == false && steps.find.outputs.count != '0' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Deleting old SHA-only versions for ${{ matrix.package }}..."
+
+          echo '${{ steps.find.outputs.versions }}' | jq -r '.id' | while read -r VERSION_ID; do
+            echo "Deleting version $VERSION_ID..."
+            # TODO: Uncomment when ready to enable deletion
+            # gh api -X DELETE "/orgs/${{ github.repository_owner }}/packages/container/${{ matrix.package }}/versions/$VERSION_ID"
+          done
+
+          echo "Cleanup complete for ${{ matrix.package }}"
+
+      - name: Dry run summary
+        if: ${{ inputs.dry_run == true }}
+        run: |
+          echo "::notice::DRY RUN - No versions were deleted for ${{ matrix.package }}"
+          if [ "${{ steps.find.outputs.count }}" != "0" ]; then
+            echo "Would have deleted ${{ steps.find.outputs.count }} version(s)"
+          fi
+
+  cleanup-helm-charts:
+    name: Cleanup Helm Charts
+    needs: discover
+    if: ${{ needs.discover.outputs.charts != '[]' }}
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        chart: ${{ fromJson(needs.discover.outputs.charts) }}
+    steps:
+      - name: Calculate cutoff date
+        id: cutoff
+        run: |
+          CUTOFF=$(date -d "${{ inputs.retention_days }} days ago" -Iseconds -u)
+          echo "date=$CUTOFF" >> $GITHUB_OUTPUT
+          echo "Cutoff date: $CUTOFF (retention: ${{ inputs.retention_days }} days, dry_run: ${{ inputs.dry_run }})"
+
+      - name: Find old SHA-only versions
+        id: find
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Finding old SHA-only versions for helm-charts/${{ matrix.chart }}..."
+
+          # Note: nested paths require URL encoding (helm-charts%2F)
+          # Get versions that:
+          # 1. Have tags (not untagged manifests)
+          # 2. All tags match 0.0.0-SHA pattern (excludes releases)
+          # 3. Created before cutoff date
+          VERSIONS=$(gh api "https://api.github.com/orgs/${{ github.repository_owner }}/packages/container/helm-charts%2F${{ matrix.chart }}/versions" \
+            --paginate \
+            --jq '
+              .[] |
+              select(.metadata.container.tags | length > 0) |
+              select(.metadata.container.tags | all(test("^0\\.0\\.0-[0-9a-f]{8}$"))) |
+              select(.created_at < "${{ steps.cutoff.outputs.date }}") |
+              {id, tags: .metadata.container.tags, created_at}
+            ' 2>/dev/null || echo "")
+
+          if [ -z "$VERSIONS" ]; then
+            echo "No old SHA-only versions found for helm-charts/${{ matrix.chart }}"
+            echo "count=0" >> $GITHUB_OUTPUT
+          else
+            COUNT=$(echo "$VERSIONS" | jq -s 'length')
+            echo "Found $COUNT old SHA-only version(s) for helm-charts/${{ matrix.chart }}:"
+            echo "$VERSIONS" | jq -r '"  - \(.tags[0]) (created: \(.created_at), id: \(.id))"'
+            echo "versions<<EOF" >> $GITHUB_OUTPUT
+            echo "$VERSIONS" >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+            echo "count=$COUNT" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Delete old versions
+        if: ${{ inputs.dry_run == false && steps.find.outputs.count != '0' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Deleting old SHA-only versions for helm-charts/${{ matrix.chart }}..."
+
+          # Note: nested paths require URL encoding
+          echo '${{ steps.find.outputs.versions }}' | jq -r '.id' | while read -r VERSION_ID; do
+            echo "Deleting version $VERSION_ID..."
+            # TODO: Uncomment when ready to enable deletion
+            # gh api -X DELETE "https://api.github.com/orgs/${{ github.repository_owner }}/packages/container/helm-charts%2F${{ matrix.chart }}/versions/$VERSION_ID"
+          done
+
+          echo "Cleanup complete for helm-charts/${{ matrix.chart }}"
+
+      - name: Dry run summary
+        if: ${{ inputs.dry_run == true }}
+        run: |
+          echo "::notice::DRY RUN - No versions were deleted for helm-charts/${{ matrix.chart }}"
+          if [ "${{ steps.find.outputs.count }}" != "0" ]; then
+            echo "Would have deleted ${{ steps.find.outputs.count }} version(s)"
+          fi

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ To cut a release, edit `<module>/VERSION` to the new semver value (e.g. `0.2.1`)
 
 - `ghcr.io/openchoreo/<image>:<VERSION>` for every image declared in the module's `module.yaml`.
 - `<chart>:<VERSION>` with `appVersion=<VERSION>`.
+- A git tag `<module>-<VERSION>` on the release commit.
 
 Alongside any release, every merge to `main` that touches a file under `<module>/` also republishes development tags so consumers can pull the tip of `main`:
 


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat: add observability-logs-opensearch module
  fix: handle opensearch startup delay in init script
  docs: update observability-logs-opensearch module installation guide
  chore(deps): bump fluent-bit version in observability-logs-openobserve module

See: https://github.com/openchoreo/openchoreo/blob/main/docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
Add automated tagging and dev-artifact cleanup for the community-modules repository, mirroring conventions already used in openchoreo repository.

## Approach
- .github/workflows/ci.yaml: Pushes a git tag `<module-dir>-<VERSION>` on the release commit whenever a module's VERSION file is bumped 
- README.md: added one bullet under Releases noting the new `<module>-<VERSION>` git tag.
- .github/workflows/cleanup-artifacts.yml (new): Added a manually triggered workflow to cleanup old images and helm charts

## Related Issues
https://github.com/openchoreo/openchoreo/issues/3818

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
Cleanup script still has delete commands commented. They will be uncommented after testing
