### PR TITLE
fix: drop traces without a root span in the queried window

### DIFF
--- a/observability-tracing-opensearch/internal/handlers.go
+++ b/observability-tracing-opensearch/internal/handlers.go
@@ -159,13 +159,9 @@ func (h *TracingHandler) queryTracesWithAggregation(ctx context.Context, params 
 		}, nil
 	}
 
-	traces := make([]traceEntry, 0, len(aggResult.Traces.Buckets))
-	for _, bucket := range aggResult.Traces.Buckets {
-		trace := buildTraceFromBucket(bucket)
-		traces = append(traces, trace)
-	}
+	traces := bucketsToTraces(aggResult.Traces.Buckets)
 
-	totalCount := aggResult.TraceCount.Value
+	totalCount := aggResult.TraceCount.DistinctTraces.Value
 	if totalCount > maxLimit {
 		totalCount = maxLimit
 	}
@@ -199,6 +195,24 @@ func parseTracesAggregation(raw json.RawMessage) (*opensearch.TracesAggregationR
 	return &result, nil
 }
 
+// bucketsToTraces converts buckets to trace entries, dropping any trace whose root
+// span is not within the queried window.
+func bucketsToTraces(buckets []opensearch.TraceBucket) []traceEntry {
+	traces := make([]traceEntry, 0, len(buckets))
+	for _, bucket := range buckets {
+		if !traceHasRootSpan(bucket) {
+			continue
+		}
+		traces = append(traces, buildTraceFromBucket(bucket))
+	}
+	return traces
+}
+
+// traceHasRootSpan reports whether the trace's root span fell within the queried window.
+func traceHasRootSpan(bucket opensearch.TraceBucket) bool {
+	return bucket.RootSpan.DocCount > 0
+}
+
 // buildTraceFromBucket converts an aggregation bucket into a traceEntry.
 func buildTraceFromBucket(bucket opensearch.TraceBucket) traceEntry {
 	trace := traceEntry{
@@ -218,24 +232,9 @@ func buildTraceFromBucket(bucket opensearch.TraceBucket) traceEntry {
 		}
 	}
 
-	// Extract root span info from the root_span filter aggregation (parentSpanId == "")
-	// Falls back to the earliest span if no root span is found
+	// Root span info from the root_span filter aggregation (parentSpanId == "").
 	if len(bucket.RootSpan.Hit.Hits.Hits) > 0 {
 		src := bucket.RootSpan.Hit.Hits.Hits[0].Source
-		if src != nil {
-			if spanID, ok := src["spanId"].(string); ok {
-				trace.RootSpanID = spanID
-			}
-			if name, ok := src["name"].(string); ok {
-				trace.RootSpanName = name
-				trace.TraceName = name
-			}
-			if spanKind, ok := src["kind"].(string); ok {
-				trace.RootSpanKind = spanKind
-			}
-		}
-	} else if len(bucket.EarliestSpan.Hits.Hits) > 0 {
-		src := bucket.EarliestSpan.Hits.Hits[0].Source
 		if src != nil {
 			if spanID, ok := src["spanId"].(string); ok {
 				trace.RootSpanID = spanID

--- a/observability-tracing-opensearch/internal/handlers_test.go
+++ b/observability-tracing-opensearch/internal/handlers_test.go
@@ -612,12 +612,15 @@ func TestBuildTraceFromBucket_NoRootSpan(t *testing.T) {
 
 	trace := buildTraceFromBucket(bucket)
 
-	// Should fall back to earliest span when no root span
-	if trace.RootSpanID != "span-earliest" {
-		t.Errorf("expected rootSpanID to fall back to earliest span, got %q", trace.RootSpanID)
+	// No root in window: must not fabricate a root from the earliest span.
+	if trace.RootSpanID != "" {
+		t.Errorf("expected empty rootSpanID with no root span, got %q", trace.RootSpanID)
 	}
-	if trace.TraceName != "earliest-op" {
-		t.Errorf("expected traceName to fall back to earliest span name, got %q", trace.TraceName)
+	if trace.RootSpanName != "" {
+		t.Errorf("expected empty rootSpanName with no root span, got %q", trace.RootSpanName)
+	}
+	if trace.TraceName != "" {
+		t.Errorf("expected empty traceName with no root span, got %q", trace.TraceName)
 	}
 	if trace.HasErrors {
 		t.Error("expected hasErrors false")
@@ -626,7 +629,7 @@ func TestBuildTraceFromBucket_NoRootSpan(t *testing.T) {
 
 func TestParseTracesAggregation(t *testing.T) {
 	raw := json.RawMessage(`{
-		"trace_count": {"value": 42},
+		"trace_count": {"doc_count": 50, "distinct_traces": {"value": 42}},
 		"traces": {
 			"buckets": [
 				{
@@ -645,8 +648,8 @@ func TestParseTracesAggregation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if result.TraceCount.Value != 42 {
-		t.Errorf("expected trace count 42, got %d", result.TraceCount.Value)
+	if result.TraceCount.DistinctTraces.Value != 42 {
+		t.Errorf("expected trace count 42, got %d", result.TraceCount.DistinctTraces.Value)
 	}
 	if len(result.Traces.Buckets) != 1 {
 		t.Errorf("expected 1 bucket, got %d", len(result.Traces.Buckets))
@@ -661,8 +664,8 @@ func TestParseTracesAggregation_Empty(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if result.TraceCount.Value != 0 {
-		t.Errorf("expected trace count 0, got %d", result.TraceCount.Value)
+	if result.TraceCount.DistinctTraces.Value != 0 {
+		t.Errorf("expected trace count 0, got %d", result.TraceCount.DistinctTraces.Value)
 	}
 }
 
@@ -870,7 +873,7 @@ func TestToTracesRequestParams_ZeroLimit(t *testing.T) {
 
 func TestParseTracesAggregation_MultipleBuckets(t *testing.T) {
 	raw := json.RawMessage(`{
-		"trace_count": {"value": 3},
+		"trace_count": {"doc_count": 3, "distinct_traces": {"value": 3}},
 		"traces": {
 			"buckets": [
 				{
@@ -905,8 +908,8 @@ func TestParseTracesAggregation_MultipleBuckets(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if result.TraceCount.Value != 3 {
-		t.Errorf("expected trace count 3, got %d", result.TraceCount.Value)
+	if result.TraceCount.DistinctTraces.Value != 3 {
+		t.Errorf("expected trace count 3, got %d", result.TraceCount.DistinctTraces.Value)
 	}
 	if len(result.Traces.Buckets) != 3 {
 		t.Fatalf("expected 3 buckets, got %d", len(result.Traces.Buckets))
@@ -927,5 +930,128 @@ func TestPtr(t *testing.T) {
 	s := ptr("hello")
 	if s == nil || *s != "hello" {
 		t.Errorf("expected pointer to 'hello', got %v", s)
+	}
+}
+
+func hits(source map[string]interface{}) struct {
+	Hits []opensearch.Hit `json:"hits"`
+} {
+	return struct {
+		Hits []opensearch.Hit `json:"hits"`
+	}{Hits: []opensearch.Hit{{Source: source}}}
+}
+
+// makeBucket builds a TraceBucket for gating tests. A non-empty rootSpanID puts a
+// root span in the window (RootSpan.DocCount = 1); empty means none.
+func makeBucket(key, rootSpanID, rootName string, docCount int) opensearch.TraceBucket {
+	bucket := opensearch.TraceBucket{
+		Key:      key,
+		DocCount: docCount,
+		EarliestSpan: opensearch.AggTopHitsValue{Hits: hits(map[string]interface{}{
+			"spanId":    "earliest-" + key,
+			"name":      "earliest-op",
+			"kind":      "CLIENT",
+			"startTime": "2025-06-01T12:00:00.000000000Z",
+		})},
+		LatestSpan: opensearch.AggTopHitsValue{Hits: hits(map[string]interface{}{
+			"endTime": "2025-06-01T12:00:05.000000000Z",
+		})},
+	}
+	if rootSpanID != "" {
+		bucket.RootSpan = opensearch.AggFilteredTopHits{
+			DocCount: 1,
+			Hit: opensearch.AggTopHitsValue{Hits: hits(map[string]interface{}{
+				"spanId": rootSpanID,
+				"name":   rootName,
+				"kind":   "SERVER",
+			})},
+		}
+	}
+	return bucket
+}
+
+func TestTraceHasRootSpan(t *testing.T) {
+	withRoot := opensearch.TraceBucket{RootSpan: opensearch.AggFilteredTopHits{DocCount: 1}}
+	if !traceHasRootSpan(withRoot) {
+		t.Error("expected traceHasRootSpan true when RootSpan.DocCount > 0")
+	}
+	noRoot := opensearch.TraceBucket{RootSpan: opensearch.AggFilteredTopHits{DocCount: 0}}
+	if traceHasRootSpan(noRoot) {
+		t.Error("expected traceHasRootSpan false when RootSpan.DocCount == 0")
+	}
+}
+
+func TestBucketsToTraces_DropsTracesWithoutRootInWindow(t *testing.T) {
+	buckets := []opensearch.TraceBucket{
+		makeBucket("trace-with-root", "span-root", "GET /api", 5),
+		makeBucket("trace-without-root", "", "", 3),
+	}
+
+	traces := bucketsToTraces(buckets)
+
+	if len(traces) != 1 {
+		t.Fatalf("expected 1 trace (root-less trace dropped), got %d", len(traces))
+	}
+	if traces[0].TraceID != "trace-with-root" {
+		t.Errorf("expected kept trace 'trace-with-root', got %q", traces[0].TraceID)
+	}
+	if traces[0].RootSpanID != "span-root" {
+		t.Errorf("expected rootSpanID 'span-root', got %q", traces[0].RootSpanID)
+	}
+	if traces[0].RootSpanName != "GET /api" {
+		t.Errorf("expected rootSpanName 'GET /api', got %q", traces[0].RootSpanName)
+	}
+}
+
+func TestBucketsToTraces_AllHaveRoot(t *testing.T) {
+	buckets := []opensearch.TraceBucket{
+		makeBucket("t1", "r1", "op1", 2),
+		makeBucket("t2", "r2", "op2", 4),
+	}
+
+	traces := bucketsToTraces(buckets)
+
+	if len(traces) != 2 {
+		t.Fatalf("expected 2 traces, got %d", len(traces))
+	}
+}
+
+func TestBucketsToTraces_NoneHaveRoot(t *testing.T) {
+	buckets := []opensearch.TraceBucket{
+		makeBucket("t1", "", "", 1),
+		makeBucket("t2", "", "", 7),
+	}
+
+	traces := bucketsToTraces(buckets)
+
+	if len(traces) != 0 {
+		t.Fatalf("expected 0 traces when no root spans in window, got %d", len(traces))
+	}
+}
+
+func TestBucketsToTraces_Empty(t *testing.T) {
+	traces := bucketsToTraces(nil)
+
+	if traces == nil {
+		t.Error("expected non-nil empty slice")
+	}
+	if len(traces) != 0 {
+		t.Fatalf("expected 0 traces for nil buckets, got %d", len(traces))
+	}
+}
+
+// TestBucketsToTraces_ClippedWindowDropsTrace: a clipped window with inner spans but
+// no root span (root_span.doc_count == 0) must drop the trace, not report an inner
+// span as root.
+func TestBucketsToTraces_ClippedWindowDropsTrace(t *testing.T) {
+	clipped := makeBucket("2027137a39b53e65e262efeb482b5fb7", "", "", 1)
+	clipped.EarliestSpan.Hits.Hits[0].Source["spanId"] = "dce652f60f5664d3"
+	clipped.EarliestSpan.Hits.Hits[0].Source["name"] = "execute_task ChatPromptTemplate"
+
+	traces := bucketsToTraces([]opensearch.TraceBucket{clipped})
+
+	if len(traces) != 0 {
+		t.Fatalf("expected clipped trace (no root in window) to be dropped, got %d trace(s) with root %q",
+			len(traces), traces[0].RootSpanName)
 	}
 }

--- a/observability-tracing-opensearch/internal/opensearch/queries.go
+++ b/observability-tracing-opensearch/internal/opensearch/queries.go
@@ -181,9 +181,19 @@ func BuildTracesAggregationQuery(params TracesRequestParams) map[string]interfac
 			},
 		},
 		"aggs": map[string]interface{}{
+			// Count only traces with an in-window root span, matching what's returned.
 			"trace_count": map[string]interface{}{
-				"cardinality": map[string]interface{}{
-					"field": "traceId",
+				"filter": map[string]interface{}{
+					"term": map[string]interface{}{
+						"parentSpanId": "",
+					},
+				},
+				"aggs": map[string]interface{}{
+					"distinct_traces": map[string]interface{}{
+						"cardinality": map[string]interface{}{
+							"field": "traceId",
+						},
+					},
 				},
 			},
 			"traces": map[string]interface{}{

--- a/observability-tracing-opensearch/internal/opensearch/queries_test.go
+++ b/observability-tracing-opensearch/internal/opensearch/queries_test.go
@@ -463,3 +463,51 @@ func TestSanitizeWildcardValue(t *testing.T) {
 		}
 	}
 }
+
+func TestBuildTracesAggregationQuery_TraceCountFiltersRootSpans(t *testing.T) {
+	params := TracesRequestParams{
+		StartTime: "2025-06-01T00:00:00Z",
+		EndTime:   "2025-06-02T00:00:00Z",
+		Limit:     20,
+		SortOrder: "desc",
+	}
+
+	query := BuildTracesAggregationQuery(params)
+	data, _ := json.Marshal(query)
+
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("failed to unmarshal query: %v", err)
+	}
+
+	aggs := parsed["aggs"].(map[string]interface{})
+	traceCount, ok := aggs["trace_count"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected trace_count aggregation")
+	}
+
+	// trace_count must filter on root spans (parentSpanId == "").
+	filter, ok := traceCount["filter"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected trace_count to be a filter aggregation")
+	}
+	term, ok := filter["term"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected term filter in trace_count")
+	}
+	if v, ok := term["parentSpanId"]; !ok || v != "" {
+		t.Errorf("expected trace_count filter on parentSpanId == \"\", got %v", term["parentSpanId"])
+	}
+
+	subAggs, ok := traceCount["aggs"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected nested aggs under trace_count")
+	}
+	distinct, ok := subAggs["distinct_traces"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected distinct_traces sub-aggregation")
+	}
+	if _, ok := distinct["cardinality"]; !ok {
+		t.Error("expected distinct_traces to be a cardinality aggregation")
+	}
+}

--- a/observability-tracing-opensearch/internal/opensearch/types.go
+++ b/observability-tracing-opensearch/internal/opensearch/types.go
@@ -28,7 +28,9 @@ type SearchResponse struct {
 // TracesAggregationResult represents the parsed aggregation response for traces queries.
 type TracesAggregationResult struct {
 	TraceCount struct {
-		Value int `json:"value"`
+		DistinctTraces struct {
+			Value int `json:"value"`
+		} `json:"distinct_traces"`
 	} `json:"trace_count"`
 	Traces struct {
 		Buckets []TraceBucket `json:"buckets"`


### PR DESCRIPTION
## Problem

`POST /api/v1alpha1/traces/query` computed a trace's `rootSpanId` / `rootSpanName` / `spanCount` from only the spans that fell within the query window. When the window did not cover a trace's root span, an arbitrary inner span was returned as the root with `spanCount: 1`, and traces with no root in the window were returned anyway. Results were therefore window-dependent for metadata that is intrinsic to the trace.

Fixes openchoreo/openchoreo#3869.

## Fix

- Gate each trace bucket on the presence of its root span (`parentSpanId == ""`) within the window. Root in window → retain current behaviour; root absent → drop the whole trace.
- Remove the earliest-span fallback that fabricated a root from an arbitrary inner span.
- `trace_count` now counts only root-bearing traces so `total` stays consistent with the returned set.

## Tests

Added coverage for the gate (`traceHasRootSpan`, `bucketsToTraces` drop/keep/mixed/empty), a regression test mirroring #3869, the `trace_count` filter shape, and updated the affected parse/fallback tests. `go build`, `go vet`, `go test ./...` all pass.

## Notes

Per-span clipping of `spanCount`/`endTime` for async traces and page under-fill from the terms aggregation are known follow-ups for a deeper (two-phase) change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed trace query results to exclude traces missing root spans within the queried time window; improved accuracy of distinct trace count reporting

* **New Features**
  * Added optional ConfigMap creation toggle in Helm deployment configuration

* **Chores**
  * Updated Helm chart version to 0.2.4

<!-- end of auto-generated comment: release notes by coderabbit.ai -->