### PR TITLE
chore: update workflow to trigger release for new VERSION files

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -181,7 +181,7 @@ jobs:
               if [ -n "$BEFORE_SHA" ] && [ "$BEFORE_SHA" != "0000000000000000000000000000000000000000" ]; then
                 OLD_VERSION=$(git show "${BEFORE_SHA}:${VERSION_FILE}" 2>/dev/null | tr -d '[:space:]' || echo "")
               fi
-              if [ -n "$RELEASE_VERSION" ] && [ -n "$OLD_VERSION" ] && [ "$RELEASE_VERSION" != "$OLD_VERSION" ]; then
+              if [ -n "$RELEASE_VERSION" ] && [ "$RELEASE_VERSION" != "$OLD_VERSION" ]; then
                 VERSION_BUMPED=true
               fi
             fi


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat: add observability-logs-opensearch module
  fix: handle opensearch startup delay in init script
  docs: update observability-logs-opensearch module installation guide
  chore(deps): bump fluent-bit version in observability-logs-openobserve module

See: https://github.com/openchoreo/openchoreo/blob/main/docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
First-time addition of a module's VERSION file does not trigger a release. This PR fixes it

## Approach
In .github/workflows/ci.yaml, dropped the [ -n "$OLD_VERSION" ] clause from the condition. VERSION_BUMPED=true now fires whenever RELEASE_VERSION is non-empty and differs from OLD_VERSION, covering both newly added VERSION files and subsequent value changes.

## Related Issues
https://github.com/openchoreo/openchoreo/issues/3818

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved version bump detection logic in the release workflow to more accurately identify version changes during the build and release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->