### PR TITLE
feat(autoscaling-keda): add web-application support and tidy docs

### DIFF
--- a/autoscaling-keda/CONFIGURATION.md
+++ b/autoscaling-keda/CONFIGURATION.md
@@ -148,7 +148,7 @@ The HTTP path needs a specific shape from the component type:
 - Exactly one external `HTTPRoute` carrying the `openchoreo.dev/endpoint-visibility: external` label
 - For service-style path routing, a `URLRewrite` filter is expected. For web-application-style host routing, the trait adds a hostname-only `URLRewrite` filter.
 
-Any `ClusterComponentType` that produces this shape can allow the trait by adding `keda-based-scaling` to its `allowedTraits` list (delete and recreate, as described in the README's Install step 3).
+Any `ClusterComponentType` that produces this shape can allow the trait by adding `keda-based-scaling` to its `allowedTraits` list. See the README's Install step 3 for the patch command. The change takes effect right away, with no delete or recreate needed.
 
 The trigger/worker path is simpler. It only needs the Deployment, so any deployment-based component type works.
 

--- a/autoscaling-keda/CONFIGURATION.md
+++ b/autoscaling-keda/CONFIGURATION.md
@@ -1,16 +1,10 @@
-# Configuration & Architecture
+# Configuration and architecture
 
-The README covers installation and quick start. This document is the full parameter reference,
-tuning and extension guide, architecture rationale, and troubleshooting reference for the
-`autoscaling-keda` module and its `keda-based-scaling` trait.
-
----
+The README covers installation and the quick start. This document goes deeper. It's the full parameter reference, the guide to tuning and extending the trait, the reasoning behind the architecture, and the troubleshooting notes for the `autoscaling-keda` module and its `keda-based-scaling` trait.
 
 ## Parameter reference
 
-All parameters live under `spec.traits[].parameters` on the component. The trait is named
-`keda-based-scaling`, and the samples use the same value for `instanceName` — per-environment
-overrides in the `ReleaseBinding` are keyed by whatever `instanceName` you pick.
+All parameters live under `spec.traits[].parameters` on the component. The trait is named `keda-based-scaling`, and the samples reuse that same value for `instanceName`. Per-environment overrides in the `ReleaseBinding` are keyed by whatever `instanceName` you pick.
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
@@ -27,15 +21,14 @@ overrides in the `ReleaseBinding` are keyed by whatever `instanceName` you pick.
 | `wakeablePorts` | integer[] | `[80, 3000, 5000, 8000, 8080, 8081, 8090, 9000, 9090]` | Ports the multiport Service exposes. An HTTP-mode endpoint must use one of these. |
 | `interceptorScalerService` | string | `keda-add-ons-http-external-scaler` | The HTTP Add-on's external scaler Service (the companion `ScaledObject` pulls metrics from it). |
 | `interceptorScalerPort` | integer | `9090` | Port on `interceptorScalerService`. |
-| `requestRateTargetValue` | integer | `1` | Target requests/second per replica. KEDA scales up when rate exceeds this value. |
+| `requestRateTargetValue` | integer | `1` | Target requests/second per replica. KEDA scales up when the rate goes over this value. |
 | `requestRateWindow` | string | `"1m"` | Sliding window over which request rate is measured. |
 | `requestRateGranularity` | string | `"1s"` | Bucket granularity inside the window. |
 | `readinessTimeout` | string | `"120s"` | How long the interceptor holds the first request while a pod cold-starts. |
 
 ### Per-environment overrides
 
-The trait's `environmentConfigs` schema exposes a subset of the parameters that platform engineers
-can override per environment from the `ReleaseBinding`, without touching the component definition:
+The trait's `environmentConfigs` schema exposes a subset of the parameters that platform engineers can override per environment from the `ReleaseBinding`, without touching the component definition:
 
 ```yaml
 # environmentConfigs schema (minReplicas / maxReplicas / cooldownPeriod only)
@@ -54,8 +47,7 @@ environmentConfigs:
         minimum: 0
 ```
 
-In the `ReleaseBinding`, set `traitEnvironmentConfigs` keyed by the trait `instanceName`
-(`keda-based-scaling`):
+In the `ReleaseBinding`, set `traitEnvironmentConfigs` keyed by the trait `instanceName` (`keda-based-scaling`):
 
 ```yaml
 spec:
@@ -66,71 +58,39 @@ spec:
       cooldownPeriod: 600
 ```
 
-When any of these fields is present, it wins over the component's `parameters` value for that
-environment. Fields absent from `environmentConfigs` (e.g. `trigger` or any HTTP metric knob)
-cannot be overridden this way — change them on the component.
-
----
+When one of these fields is set, it wins over the component's `parameters` value for that environment. Anything that isn't in `environmentConfigs`, like `trigger` or the HTTP metric knobs, can't be overridden this way. Change those on the component itself.
 
 ## How HTTP scaling behaves
 
-HTTP mode scales on **request rate over a sliding window**, not instantaneous concurrency. The
-interceptor counts all requests that arrived in the last `requestRateWindow` (default `1m`) at
-`requestRateGranularity` resolution (default `1s`), and divides by the window length to get a
-rate in requests/second.
+HTTP mode scales on request rate over a sliding window, not on instantaneous concurrency. The interceptor counts every request that arrived in the last `requestRateWindow` (default `1m`) at `requestRateGranularity` resolution (default `1s`), then divides by the window length to get a rate in requests per second.
 
-KEDA scales up when that rate per replica exceeds `requestRateTargetValue` (default `1 req/s`),
-and begins the scale-down countdown only when the rate reaches zero across the full window. That
-means a service receiving even sparse traffic — say, one request every few seconds — holds a
-non-zero rate across the window and does not prematurely scale to zero. It scales down only once
-no request has arrived for the entire window, and then only after `cooldownPeriod` more seconds
-of idle.
+KEDA scales up when that per-replica rate goes over `requestRateTargetValue` (default `1 req/s`). It only starts the scale-down countdown once the rate hits zero across the full window. So a service getting even sparse traffic, say one request every few seconds, keeps a non-zero rate across the window and won't scale to zero too early. It scales down only after no request has arrived for the entire window, and then only after `cooldownPeriod` more seconds of idle time.
 
-**Worked example.** One request per 10 seconds = 0.1 req/s. With `requestRateTargetValue: 1`,
-that rate is below the target, so one replica is sufficient. The rate stays non-zero for 1 minute
-after the last request, then KEDA starts the `cooldownPeriod` countdown before dropping to zero.
-With the defaults (`window: 1m`, `cooldownPeriod: 300`), the service stays awake for roughly
-6 minutes after the last request arrives.
+To work through an example, one request per 10 seconds is 0.1 req/s. With `requestRateTargetValue: 1` that rate is below the target, so one replica is enough. The rate stays non-zero for a minute after the last request, then KEDA starts the `cooldownPeriod` countdown before dropping to zero. With the defaults (`window: 1m`, `cooldownPeriod: 300`), the service stays awake for roughly 6 minutes after the last request.
 
-**Cold starts and the 120s timeout.** A cold start on a warmed cluster takes 2-4 seconds. The
-interceptor holds the first request in-flight until a pod passes readiness, bounded by
-`readinessTimeout` (default `120s`). The trait also patches the external `HTTPRoute` to set a
-`request` timeout of `120s` on the route, matching the interceptor's hold time so the gateway
-does not drop the request first. Do not set `readinessTimeout` longer than your gateway's
-absolute route timeout.
+### Cold starts and the 120s timeout
 
-The first cold start after a component is deployed can be slower — KEDA registers the new scaler
-against the `InterceptorRoute` during this window, and if the `ScaledObject` reconciles before
-the `InterceptorRoute` exists, KEDA may briefly fall back to a CPU metric. Retry once; subsequent
-cold starts are fast. See Troubleshooting for the fix if it persists.
+A cold start on a warmed cluster takes 2 to 4 seconds. The interceptor holds the first request in-flight until a pod passes readiness, bounded by `readinessTimeout` (default `120s`). The trait also patches the external `HTTPRoute` to set a `request` timeout of `120s`, matching the interceptor's hold time so the gateway doesn't drop the request first. Don't set `readinessTimeout` longer than your gateway's absolute route timeout.
 
-**`cooldownPeriod` tuning.** Lower values reduce idle cost but increase cold-start frequency.
-For services with a long start time, raise `readinessTimeout` and `cooldownPeriod` together to
-avoid a cycle of scale-down/immediate-scale-up under light traffic.
+The first cold start after a component is deployed can be slower. KEDA registers the new scaler against the `InterceptorRoute` during this window, and if the `ScaledObject` reconciles before the `InterceptorRoute` exists, KEDA may briefly fall back to a CPU metric. Retry once, later cold starts are fast. See Troubleshooting for the fix if it sticks around.
 
----
+### Tuning cooldownPeriod
+
+Lower values cut idle cost but mean more frequent cold starts. For a service with a long start time, raise `readinessTimeout` and `cooldownPeriod` together so light traffic doesn't push it into a scale-down/immediate-scale-up cycle.
 
 ## Extending the module
 
 ### Concurrency-based scaling
 
-HTTP mode currently scales on `requestRate` (requests per second over a window). The KEDA HTTP
-Add-on's `InterceptorRoute` also supports `concurrency` as a `scalingMetric`: target concurrent
-in-flight requests per replica. To switch, edit the `InterceptorRoute` template in
-`keda-based-scaling-trait.yaml` and replace the `requestRate` block under `scalingMetric` with
-a `concurrency` block. See the add-on's `InterceptorRoute` reference:
-https://github.com/kedacore/http-add-on/blob/main/docs/ref/v0.14.0/interceptor_route.md
+HTTP mode scales on `requestRate` (requests per second over a window) by default. The KEDA HTTP Add-on's `InterceptorRoute` also supports `concurrency` as a `scalingMetric`, which targets concurrent in-flight requests per replica. To switch, edit the `InterceptorRoute` template in `keda-based-scaling-trait.yaml` and replace the `requestRate` block under `scalingMetric` with a `concurrency` block. See the add-on's `InterceptorRoute` reference: https://github.com/kedacore/http-add-on/blob/main/docs/ref/v0.14.0/interceptor_route.md
 
-Concurrency is useful when requests are long-lived (e.g. streaming or WebSocket) and rate
-under-counts actual load.
+Concurrency helps when requests are long-lived, like streaming or WebSocket connections, where rate under-counts the actual load.
 
 ### Any KEDA scaler for workers and event-driven services
 
-`trigger.type` and `trigger.metadata` are passed straight through to the `ScaledObject`, so
-every scaler in the KEDA catalog works: cron, kafka, rabbitmq, prometheus, aws-sqs, azure-servicebus,
-and 70+ others. Full list: https://keda.sh/docs/latest/scalers/
+`trigger.type` and `trigger.metadata` pass straight through to the `ScaledObject`, so every scaler in the KEDA catalog works: cron, kafka, rabbitmq, prometheus, aws-sqs, azure-servicebus, and 70+ others. The full list is at https://keda.sh/docs/latest/scalers/
 
-Example — RabbitMQ worker:
+Here's a RabbitMQ worker:
 
 ```yaml
 parameters:
@@ -144,42 +104,28 @@ parameters:
       hostFromEnv: RABBITMQ_URL   # injected by a connection binding
 ```
 
-For brokered scalers, use `hostFromEnv` pointing at an env var your workload connection already
-injects. Broker credentials stay out of the component definition and out of git.
+For brokered scalers, use `hostFromEnv` pointing at an env var your workload connection already injects. That keeps broker credentials out of the component definition and out of git.
 
 ### Authenticated triggers
 
-KEDA scalers reference credentials through `triggers[].authenticationRef`, pointing at a
-`TriggerAuthentication`/`ClusterTriggerAuthentication` object. The trait does not expose
-`authenticationRef` as a parameter today — to use it, extend the trigger-mode `ScaledObject`
-template in `keda-based-scaling-trait.yaml`. The module's RBAC already lets the cluster-agent
-manage `triggerauthentications`/`clustertriggerauthentications`, so no extra permissions are
-needed. See the KEDA authentication reference:
-https://keda.sh/docs/latest/concepts/authentication/
+KEDA scalers reference credentials through `triggers[].authenticationRef`, which points at a `TriggerAuthentication` or `ClusterTriggerAuthentication` object. The trait doesn't expose `authenticationRef` as a parameter yet. To use it, extend the trigger-mode `ScaledObject` template in `keda-based-scaling-trait.yaml`. The module's RBAC already lets the cluster-agent manage `triggerauthentications` and `clustertriggerauthentications`, so you don't need extra permissions. See the KEDA authentication docs: https://keda.sh/docs/latest/concepts/authentication/
 
-Where possible, prefer `hostFromEnv`-style metadata (above) over authenticated triggers — it
-needs no extra objects.
+Where you can, prefer the `hostFromEnv`-style metadata above over authenticated triggers, since it needs no extra objects.
 
 ### Wakeable ports
 
-The default wakeable ports are `[80, 3000, 5000, 8000, 8080, 8081, 8090, 9000, 9090]`. An
-HTTP-mode endpoint must listen on one of these because the component's Service is turned into
-an ExternalName DNS CNAME — a CNAME cannot remap ports, so the caller-facing port must be a port
-the interceptor already answers on.
+The default wakeable ports are `[80, 3000, 5000, 8000, 8080, 8081, 8090, 9000, 9090]`. An HTTP-mode endpoint has to listen on one of these because the component's Service is turned into an ExternalName DNS CNAME, and a CNAME can't remap ports. So the caller-facing port must be a port the interceptor already answers on.
 
 To add a port:
 
 1. Add it to `keda-interceptor-multiport.yaml` (the `ports` list on the Service) and re-apply.
-2. Add it to the `wakeablePorts` default in `keda-based-scaling-trait.yaml` and re-apply the
-   trait.
+2. Add it to the `wakeablePorts` default in `keda-based-scaling-trait.yaml` and re-apply the trait.
 
-Keep the two in sync. The trait's validation rule checks `ep.port in parameters.wakeablePorts`
-and rejects a component at render time if the endpoint port is not in the list.
+Keep the two in sync. The trait's validation rule checks `ep.port in parameters.wakeablePorts` and rejects a component at render time if the endpoint port isn't in the list.
 
 ### Interceptor installed elsewhere
 
-If the KEDA HTTP Add-on is installed in a namespace other than `keda`, or with non-default
-Service names or ports, set the corresponding parameters on the trait attachment:
+If the KEDA HTTP Add-on is installed in a namespace other than `keda`, or with non-default Service names or ports, set the matching parameters on the trait attachment:
 
 ```yaml
 parameters:
@@ -191,56 +137,38 @@ parameters:
   interceptorScalerPort: 9090
 ```
 
-These values are per-component, so different components in the same cluster can point at
-different interceptor installations.
+These values are per-component, so different components in the same cluster can point at different interceptor installations.
 
 ### Other component types
 
-The HTTP path requires a specific shape from the component type:
+The HTTP path needs a specific shape from the component type:
 
 - A Deployment named `${metadata.name}`
 - A Service named `${metadata.componentName}`
 - Exactly one external `HTTPRoute` carrying the `openchoreo.dev/endpoint-visibility: external` label
+- For service-style path routing, a `URLRewrite` filter is expected. For web-application-style host routing, the trait adds a hostname-only `URLRewrite` filter.
 
-Any `ClusterComponentType` that produces this shape can allow the trait by adding
-`keda-based-scaling` to its `allowedTraits` list (delete + recreate, as described in the README's
-Install step 3).
+Any `ClusterComponentType` that produces this shape can allow the trait by adding `keda-based-scaling` to its `allowedTraits` list (delete and recreate, as described in the README's Install step 3).
 
-The trigger/worker path is simpler: it only needs the Deployment. Any deployment-based component
-type works.
+The trigger/worker path is simpler. It only needs the Deployment, so any deployment-based component type works.
 
 ### Other gateways
 
-The HTTP path is kgateway-specific. The trait routes to the interceptor through a
-`gateway.kgateway.dev/Backend` in the component's namespace; this Backend requires no
-cross-namespace `ReferenceGrant` because it is local to the workload namespace.
+The HTTP path is kgateway-specific. The trait routes to the interceptor through a `gateway.kgateway.dev/Backend` in the component's namespace. This Backend needs no cross-namespace `ReferenceGrant` because it's local to the workload namespace.
 
-On another Gateway API implementation, adapt the `creates` entry for the Backend resource and
-the HTTPRoute patch. The equivalent approach is a cross-namespace Service `backendRef` pointing
-at the interceptor, plus a `ReferenceGrant` in the interceptor namespace permitting it.
+On another Gateway API implementation, adapt the `creates` entry for the Backend resource and the HTTPRoute patch. The equivalent is a cross-namespace Service `backendRef` pointing at the interceptor, plus a `ReferenceGrant` in the interceptor namespace that permits it.
 
 ### Advanced ScaledObject tuning
 
-The trait does not expose every `ScaledObject` field as a parameter. Fields like `fallback`
-(behavior when the scaler is unavailable) and
-`advanced.horizontalPodAutoscalerConfig.behavior` (scale-up/scale-down stabilization windows)
-can be added by editing the `ScaledObject` templates directly in the trait. Full spec reference:
-https://keda.sh/docs/latest/reference/scaledobject-spec/
-
----
+The trait doesn't expose every `ScaledObject` field as a parameter. Fields like `fallback` (behavior when the scaler is unavailable) and `advanced.horizontalPodAutoscalerConfig.behavior` (scale-up/scale-down stabilization windows) can be added by editing the `ScaledObject` templates directly in the trait. Full `ScaledObject` spec: https://keda.sh/docs/latest/reference/scaledobject-spec/
 
 ## Architecture
 
 ### Backend annotation contract
 
-The trait reads `dataplane.annotations["openchoreo.dev/keda-based-scaling-backend"]` from the
-render context (available from OpenChoreo 1.2 onward). When the value is `keda`, the trait
-renders KEDA objects. When the annotation is absent or set to any other value, the trait is
-completely inert — the component runs at its configured static replica count. No per-environment
-forking is needed: the same component definition runs normally on a plane without KEDA and scales
-to zero on a plane that advertises `keda`.
+The trait reads `dataplane.annotations["openchoreo.dev/keda-based-scaling-backend"]` from the render context (available from OpenChoreo 1.2 onward). When the value is `keda`, the trait renders KEDA objects. When the annotation is absent or set to anything else, the trait is completely inert and the component runs at its configured static replica count. There's no per-environment forking to manage. The same component definition runs normally on a plane without KEDA and scales to zero on a plane that advertises `keda`.
 
-Annotate the data plane to activate:
+Annotate the data plane to activate it:
 
 ```bash
 kubectl annotate clusterdataplane default \
@@ -251,151 +179,99 @@ kubectl annotate clusterdataplane default \
 
 | Mode | Condition | Renders |
 |---|---|---|
-| **HTTP** | `enabled: true`, backend `keda`, `trigger.type == ""`, one external HTTP/GraphQL/WebSocket endpoint | `InterceptorRoute` + companion `ScaledObject`, kgateway `Backend`, pod-backing Service, patches to ExternalName the component's Service and repoint the `HTTPRoute` |
+| **HTTP** | `enabled: true`, backend `keda`, `trigger.type == ""`, one external HTTP/GraphQL/WebSocket endpoint | `InterceptorRoute` + companion `ScaledObject`, kgateway `Backend`, pod-backing Service, patches to ExternalName the component's Service for in-cluster wake, and repoint the `HTTPRoute` at the Backend for gateway traffic |
 | **Trigger** | `enabled: true`, backend `keda`, `trigger.type != ""` | `ScaledObject` with the given trigger |
 
-Both modes patch the Deployment to remove `spec.replicas`, handing replica ownership to KEDA.
-If `spec.replicas` remained, server-side apply would reset it on every render and fight the
-autoscaler.
-
-### The 0.14 split model
-
-HTTP scaling uses the KEDA HTTP Add-on 0.14 split model. An `InterceptorRoute`
-(`http.keda.sh/v1beta1`) carries the routing rule (which hosts to intercept, which upstream to
-forward to) and the scaling metric (`requestRate` with target, window, and granularity). A
-companion `ScaledObject` carries the scale target (the Deployment) and the replica bounds
-(`minReplicaCount: 0` is what enables scale-to-zero).
-
-In 0.14, the `InterceptorRoute` controller does **not** create the `ScaledObject` automatically.
-The trait renders both. The `InterceptorRoute` is rendered first so the external scaler has a
-metric spec to report by the time the `ScaledObject` reconciles; if the `ScaledObject` arrives
-first, KEDA may briefly fall back to CPU.
+Both modes patch the Deployment to remove `spec.replicas`, handing replica ownership to KEDA. If `spec.replicas` stuck around, server-side apply would reset it on every render and fight the autoscaler.
 
 ### In-cluster wake: the ExternalName alias mechanism
 
-OpenChoreo connection bindings inject the callee's in-cluster Service URL
-(`http://<component>.<ns>.svc.cluster.local:<port>`). Without intervention that URL goes directly
-to the Deployment pods and is refused while the service sleeps.
+OpenChoreo connection bindings inject the callee's in-cluster Service URL (`http://<component>.<ns>.svc.cluster.local:<port>`). Left alone, that URL goes straight to the Deployment pods and gets refused while the service sleeps.
 
 In HTTP mode the trait closes that gap:
 
-1. **Component Service → ExternalName.** The component's own Service (named
-   `${metadata.componentName}`) is patched to `type: ExternalName`, with `externalName` pointing
-   at `keda-add-ons-http-interceptor-multiport.<interceptorNamespace>.svc.cluster.local`. An
-   in-cluster call to the injected URL now resolves to the interceptor.
-2. **Pod-backing Service.** A separate ClusterIP Service (`${componentName}-keda-upstream`) is
-   created with the original pod selector and ports. The `InterceptorRoute` forwards here after a
-   pod is ready.
-3. **Host-based routing.** The `InterceptorRoute` registers exactly one `rules[].hosts` entry:
-   the component's FQDN (`<componentName>.<namespace>.svc.cluster.local`). The HTTPRoute patch
-   adds a `urlRewrite.hostname` filter rewriting the outbound Host header to this FQDN, so
-   gateway traffic and in-cluster traffic match the same interceptor rule.
+1. The component's own Service (named `${metadata.componentName}`) is patched to `type: ExternalName`, with `externalName` pointing at `keda-add-ons-http-interceptor-multiport.<interceptorNamespace>.svc.cluster.local`. An in-cluster call to the injected URL now resolves to the interceptor.
+2. A separate ClusterIP Service (`${componentName}-keda-upstream`) is created with the original pod selector and ports. The `InterceptorRoute` forwards here once a pod is ready.
+3. The `InterceptorRoute` registers exactly one `rules[].hosts` entry: the component's FQDN (`<componentName>.<namespace>.svc.cluster.local`). The HTTPRoute patch adds a `urlRewrite.hostname` filter that rewrites the outbound Host header to this FQDN, so gateway traffic and in-cluster traffic match the same interceptor rule.
 
-The Service is born as ExternalName on first render, so there is no ClusterIP → ExternalName
-mutation to trip over. If you convert a long-lived component and the data-plane apply rejects the
-in-place Service type change, redeploy the component so the Service is recreated from scratch.
+The Service is born as ExternalName on first render, so there's no ClusterIP-to-ExternalName mutation to trip over. If you convert a long-lived component and the data-plane apply rejects the in-place Service type change, redeploy the component so the Service is recreated from scratch.
 
 ### Why exactly one HTTP endpoint
 
-Two intrinsic constraints force the single-endpoint shape:
+Two constraints force the single-endpoint shape.
 
-**One Service, one Host.** OpenChoreo gives a component a single Service (one DNS name, possibly
-many ports). Connection bindings inject that one name. Every endpoint on the component is reached
-as the same host (`<component>.<ns>.svc.cluster.local`), differing only by port. The KEDA
-interceptor routes purely by the `Host` header — it strips the port first. So it cannot
-distinguish two endpoints on the same component: a second endpoint would be silently forwarded to
-the wrong port. Hence exactly one endpoint.
+The first is one Service, one Host. OpenChoreo gives a component a single Service (one DNS name, possibly many ports), and connection bindings inject that one name. Every endpoint on the component is reached as the same host (`<component>.<ns>.svc.cluster.local`), differing only by port. The KEDA interceptor routes purely by the `Host` header and strips the port first, so it can't tell two endpoints on the same component apart. A second endpoint would be forwarded to the wrong port without warning. So there can be only one endpoint.
 
-**A CNAME cannot remap ports.** An ExternalName Service is a DNS CNAME. A caller hitting the
-component on its endpoint port lands on the interceptor on that same port. So the endpoint port
-must be one the interceptor already answers on. The multiport Service (`keda-interceptor-multiport.yaml`)
-fronts the interceptor on a set of common ports precisely to avoid pinning every service to a
-single port. Hence the endpoint port must be in `wakeablePorts`.
+The second is that a CNAME can't remap ports. An ExternalName Service is a DNS CNAME, so a caller hitting the component on its endpoint port lands on the interceptor on that same port. The endpoint port has to be one the interceptor already answers on. The multiport Service (`keda-interceptor-multiport.yaml`) fronts the interceptor on a set of common ports for exactly this reason, so you're not pinned to a single port. That's why the endpoint port has to be in `wakeablePorts`.
 
-A service that does not fit (multiple endpoints, or a port outside `wakeablePorts`) has three
-escape hatches:
+A service that doesn't fit (multiple endpoints, or a port outside `wakeablePorts`) has three ways out:
 
-- Split extra endpoints into a separate component, each with its own trait attachment.
+- Split the extra endpoints into a separate component, each with its own trait attachment.
 - Add the port to `keda-interceptor-multiport.yaml` and `wakeablePorts`.
-- Keep `minReplicas >= 1` on the component (no scale-to-zero, no ExternalName takeover).
-
----
+- Keep `minReplicas >= 1` on the component, which skips scale-to-zero and the ExternalName takeover.
 
 ## Limitations
 
-- **Exactly one external HTTP endpoint per service in HTTP mode.** The interceptor routes by
-  `Host` only (port stripped), and the ExternalName alias is a DNS CNAME that cannot remap ports.
-  See the Architecture section for the full rationale and escape hatches.
-- **The HTTP path is kgateway-specific.** The trait routes to the interceptor through a
-  `gateway.kgateway.dev/Backend`. On a different Gateway API implementation, adapt the Backend
-  resource and the HTTPRoute patch (cross-namespace Service backendRef + `ReferenceGrant` works).
-- **Component types are a 1.2 snapshot.** The `componenttypes/service.yaml` and
-  `componenttypes/worker.yaml` files mirror the stock OpenChoreo 1.2 defaults. If your platform
-  customizes those types, regenerate from your live types instead of applying the committed copies.
-- **Mutually exclusive with HPA-style traits.** Both claim ownership of the Deployment's replica
-  count. Do not attach both an HPA-style trait and `keda-based-scaling` to the same component.
-- **Cilium-signal backend** (`backend: cilium`) is a future path and is not implemented.
-
----
+- Exactly one external HTTP endpoint per service in HTTP mode. The interceptor routes by `Host` only (port stripped), and the ExternalName alias is a DNS CNAME that can't remap ports. See the Architecture section for the full reasoning and the escape hatches.
+- The HTTP path is kgateway-specific. The trait routes to the interceptor through a `gateway.kgateway.dev/Backend`. On a different Gateway API implementation, adapt the Backend resource and the HTTPRoute patch (a cross-namespace Service backendRef plus a `ReferenceGrant` works).
+- The committed component types are a snapshot. `componenttypes/service.yaml`, `componenttypes/webapp.yaml`, and `componenttypes/worker.yaml` mirror the stock OpenChoreo defaults. If your platform customizes those types, regenerate from your live types instead of applying the committed copies.
+- It's mutually exclusive with HPA-style traits. Both claim ownership of the Deployment's replica count, so don't attach an HPA-style trait and `keda-based-scaling` to the same component.
+- The Cilium-signal backend (`backend: cilium`) is a future path and isn't implemented.
 
 ## Troubleshooting
 
-- **Nothing scales / no KEDA objects rendered.** Confirm the data plane annotation:
-  ```bash
-  kubectl get clusterdataplane default -o jsonpath='{.metadata.annotations}'
-  ```
-  Without `openchoreo.dev/keda-based-scaling-backend=keda` the trait is intentionally inert.
-  Also confirm the trait is attached under `spec.traits` and that the component type allows it:
-  ```bash
-  kubectl get clustercomponenttype service -o jsonpath='{.spec.allowedTraits[*].name}'
-  ```
+Nothing scales, or no KEDA objects get rendered. Confirm the data plane annotation:
 
-- **First request returns a 504 or hangs for ~60s.** Usually the KEDA scaling pipeline warming
-  up for a newly-created `InterceptorRoute`/`ScaledObject`, or the interceptor/scaler pods not
-  Ready yet. Wait for the `keda-add-ons-http-*` rollouts and retry — later cold starts complete
-  in a few seconds.
+```bash
+kubectl get clusterdataplane default -o jsonpath='{.metadata.annotations}'
+```
 
-- **HTTP service never wakes / scale-up doesn't work; the HPA shows a `cpu` metric.** The
-  companion `ScaledObject` was reconciled before its `InterceptorRoute` existed, so the external
-  scaler returned an empty metric spec and KEDA fell back to CPU. The trait renders the
-  `InterceptorRoute` first, but if you hit this, re-apply the binding (or delete the
-  `ScaledObject`) so KEDA re-reads the route's metric. Confirm with:
-  ```bash
-  kubectl get scaledobject -n <wl-ns> -o jsonpath='{.items[0].spec.triggers}'
-  ```
+Without `openchoreo.dev/keda-based-scaling-backend=keda` the trait is inert on purpose. Also confirm the trait is attached under `spec.traits` and that the component type allows it:
 
-- **Every request 504s after ~60s, even though the pod wakes and is Ready.** The interceptor
-  pods are missing the `openchoreo.dev/system-component` label, so the component's NetworkPolicy
-  drops the interceptor's forwards. Re-install the HTTP add-on with the `additionalLabels` flag
-  from the README and check:
-  ```bash
-  kubectl get pods -n keda --show-labels
-  ```
+```bash
+kubectl get clustercomponenttype service -o jsonpath='{.spec.allowedTraits[*].name}'
+```
 
-- **Request returns 404 or 503 after scaling to zero.** Check the kgateway `Backend` exists in
-  the workload namespace and the `HTTPRoute` backendRef was repointed at it:
-  ```bash
-  kubectl get backends.gateway.kgateway.dev,httproute -n <wl-ns> -o yaml
-  ```
+The first request returns a 504 or hangs for about 60 seconds. This is usually the KEDA scaling pipeline warming up for a newly-created `InterceptorRoute`/`ScaledObject`, or the interceptor and scaler pods not being Ready yet. Wait for the `keda-add-ons-http-*` rollouts and retry, later cold starts finish in a few seconds.
 
-- **Agent can't create ScaledObjects (RBAC forbidden in cluster-agent logs).** Confirm the RBAC
-  was applied and bound to the right ServiceAccount:
-  ```bash
-  kubectl get clusterrolebinding openchoreo-cluster-agent-keda -o yaml
-  ```
+The HTTP service never wakes, scale-up doesn't work, and the HPA shows a `cpu` metric. The companion `ScaledObject` reconciled before its `InterceptorRoute` existed, so the external scaler returned an empty metric spec and KEDA fell back to CPU. The trait renders the `InterceptorRoute` first, but if you hit this, re-apply the binding (or delete the `ScaledObject`) so KEDA re-reads the route's metric. Confirm with:
 
-- **In-cluster (service-to-service) calls don't wake the service.** Confirm the callee's Service
-  became an ExternalName:
-  ```bash
-  kubectl get svc <component> -n <wl-ns> -o jsonpath='{.spec.type}'   # should print ExternalName
-  ```
-  Confirm the in-cluster FQDN appears in the `InterceptorRoute` `rules[].hosts`. Then check the
-  multiport front actually selects the interceptor pods:
-  ```bash
-  kubectl get endpoints keda-add-ons-http-interceptor-multiport -n keda
-  ```
-  If that is empty, the selector in `keda-interceptor-multiport.yaml` does not match your
-  add-on's interceptor pod labels. Compare with:
-  ```bash
-  kubectl get svc keda-add-ons-http-interceptor-proxy -n keda -o jsonpath='{.spec.selector}'
-  ```
+```bash
+kubectl get scaledobject -n <wl-ns> -o jsonpath='{.items[0].spec.triggers}'
+```
+
+Every request 504s after about 60 seconds, even though the pod wakes and is Ready. The interceptor pods are missing the `openchoreo.dev/system-component` label, so the component's NetworkPolicy drops the interceptor's forwards. Re-install the HTTP add-on with the `additionalLabels` flag from the README and check:
+
+```bash
+kubectl get pods -n keda --show-labels
+```
+
+A request returns 404 or 503 after scaling to zero. Check that the kgateway `Backend` exists in the workload namespace and the `HTTPRoute` backendRef was repointed at it:
+
+```bash
+kubectl get backends.gateway.kgateway.dev,httproute -n <wl-ns> -o yaml
+```
+
+The agent can't create ScaledObjects (RBAC forbidden in the cluster-agent logs). Confirm the RBAC was applied and bound to the right ServiceAccount:
+
+```bash
+kubectl get clusterrolebinding openchoreo-cluster-agent-keda -o yaml
+```
+
+In-cluster (service-to-service) calls don't wake the service. Confirm the callee's Service became an ExternalName:
+
+```bash
+kubectl get svc <component> -n <wl-ns> -o jsonpath='{.spec.type}'   # should print ExternalName
+```
+
+Confirm the in-cluster FQDN shows up in the `InterceptorRoute` `rules[].hosts`. Then check that the multiport front actually selects the interceptor pods:
+
+```bash
+kubectl get endpoints keda-add-ons-http-interceptor-multiport -n keda
+```
+
+If that's empty, the selector in `keda-interceptor-multiport.yaml` doesn't match your add-on's interceptor pod labels. Compare with:
+
+```bash
+kubectl get svc keda-add-ons-http-interceptor-proxy -n keda -o jsonpath='{.spec.selector}'
+```

--- a/autoscaling-keda/README.md
+++ b/autoscaling-keda/README.md
@@ -1,58 +1,38 @@
 # Autoscaling with KEDA
 
-Scale OpenChoreo components on demand with [KEDA](https://keda.sh). HTTP services scale to zero
-when idle and wake on the first request — the KEDA HTTP Add-on interceptor holds it, nothing is
-dropped; in-cluster service-to-service calls wake them too. Workers scale on cron or queue triggers.
-You attach the `keda-based-scaling` trait to a plain service or worker component and set a few
-parameters.
+This module scales OpenChoreo components on demand with [KEDA](https://keda.sh). An HTTP service can drop to zero replicas while it's idle and wake up on the first request. The KEDA HTTP Add-on interceptor holds that request while a pod starts, so nothing gets dropped, and in-cluster service-to-service calls wake the service the same way. Workers scale on cron or queue triggers instead. You get all of this by attaching the `keda-based-scaling` trait to a plain service or worker component and setting a few parameters.
 
-**What's in the module:**
+The module has four pieces:
 
-- `keda-based-scaling-trait.yaml` — the `ClusterTrait` that renders the right KEDA objects per
-  data plane
-- `cluster-agent-keda-rbac.yaml` — RBAC so the data-plane cluster-agent can manage KEDA objects
-- `keda-interceptor-multiport.yaml` — a multi-port Service fronting the interceptor for in-cluster
-  wake
-- `componenttypes/service.yaml` + `componenttypes/worker.yaml` — reference examples showing the
-  `keda-based-scaling` entry added to `allowedTraits`; patch your own types rather than applying these
+- `keda-based-scaling-trait.yaml` holds the `ClusterTrait` that renders the right KEDA objects for each data plane.
+- `cluster-agent-keda-rbac.yaml` gives the data-plane cluster-agent permission to manage KEDA objects.
+- `keda-interceptor-multiport.yaml` is a multi-port Service that fronts the interceptor so in-cluster calls can wake a service.
+- `componenttypes/service.yaml`, `componenttypes/webapp.yaml`, and `componenttypes/worker.yaml` are reference examples showing the `keda-based-scaling` entry added to `allowedTraits`. Patch your own types rather than applying these directly.
 
-KEDA core and the KEDA HTTP Add-on install from their upstream Helm charts (see Install below) —
-this module provides only the OpenChoreo glue.
-
----
+KEDA core and the KEDA HTTP Add-on come from their own upstream Helm charts (see Install below). This module is only the OpenChoreo glue.
 
 ## How it works
 
-A data plane opts in by carrying the annotation
-`openchoreo.dev/keda-based-scaling-backend: keda`. The trait reads that annotation at render time;
-on planes without it the trait is inert, so a component definition is portable across environments.
+A data plane opts in by carrying the annotation `openchoreo.dev/keda-based-scaling-backend: keda`. The trait reads that annotation when it renders. On a plane without it the trait does nothing, so the same component definition stays portable across environments.
 
 | Mode | When | What KEDA creates |
 |------|------|-------------------|
-| **HTTP** | service with one external HTTP endpoint, no `trigger.type` | `InterceptorRoute` + companion `ScaledObject`; gateway and in-cluster traffic both wake the service |
+| **HTTP** | service or web-application with one external HTTP endpoint, no `trigger.type` | `InterceptorRoute` + companion `ScaledObject`; gateway and in-cluster traffic both wake the component |
 | **Trigger** | any component with `trigger.type` set | `ScaledObject` with that trigger (cron, kafka, rabbitmq, …) |
 
-Requires OpenChoreo 1.2+. Full architecture, tuning, and extension details: [CONFIGURATION.md](./CONFIGURATION.md).
-
----
+You need OpenChoreo 1.2 or later. For the architecture, tuning, and extension details, see [CONFIGURATION.md](./CONFIGURATION.md).
 
 ## Prerequisites
 
-- An OpenChoreo 1.2+ control plane and data plane. For a fresh local cluster, follow the
-  [single-cluster k3d guide](https://github.com/openchoreo/openchoreo/blob/main/install/k3d/single-cluster/README.md)
-  through step 5.
-- `kubectl`, `helm`, `jq`, `yq`, and cluster access.
-- The data-plane gateway must be **kgateway** (the OpenChoreo default). For other Gateway API
-  implementations, see [CONFIGURATION.md](./CONFIGURATION.md).
-
----
+- An OpenChoreo 1.2+ control plane and data plane. For a fresh local cluster, follow the [single-cluster k3d guide](https://github.com/openchoreo/openchoreo/blob/main/install/k3d/single-cluster/README.md) through step 5.
+- `kubectl`, `helm`, `jq`, `yq`, and access to the cluster.
+- The data-plane gateway needs to be kgateway, which is the OpenChoreo default. For other Gateway API implementations, see [CONFIGURATION.md](./CONFIGURATION.md).
 
 ## Install
 
 ### 1. Install KEDA core, then the HTTP Add-on
 
-KEDA's CRDs must be established before the HTTP Add-on's resources are applied, so install them as
-two separate releases.
+KEDA's CRDs have to be established before the HTTP Add-on's resources are applied, so install them as two separate releases.
 
 ```bash
 helm repo add kedacore https://kedacore.github.io/charts && helm repo update kedacore
@@ -71,11 +51,7 @@ helm upgrade --install keda-add-ons-http kedacore/keda-add-ons-http --version 0.
 kubectl wait --for=condition=Established crd/interceptorroutes.http.keda.sh --timeout=120s
 ```
 
-> The `additionalLabels` flag is required. OpenChoreo renders a NetworkPolicy per component that
-> only admits traffic from the same namespace or from pods carrying the
-> `openchoreo.dev/system-component` label. Without it, on any cluster whose CNI enforces
-> NetworkPolicy (k3s/k3d included), the interceptor's forwards are silently dropped and every
-> request times out with a 504 — even though the wake-up itself succeeds.
+> The `additionalLabels` flag matters. OpenChoreo renders a NetworkPolicy for each component that only admits traffic from the same namespace or from pods carrying the `openchoreo.dev/system-component` label. Leave the flag out and, on any cluster whose CNI enforces NetworkPolicy (k3s and k3d included), the interceptor's forwarded requests get dropped silently. Every request then times out with a 504, even though the wake-up itself worked.
 
 ### 2. Apply the trait and data-plane resources
 
@@ -89,18 +65,14 @@ kubectl apply \
 
 ### 3. Enable the trait on your component types
 
-Patch `keda-based-scaling` into `allowedTraits` on the component types you use. No components
-need to be deleted or recreated — the change takes effect immediately:
+Add `keda-based-scaling` to `allowedTraits` on the component types you use. You don't need to delete or recreate any components, the change takes effect right away:
 
 ```bash
 kubectl patch clustercomponenttype <your-type> --type=json \
   -p '[{"op":"add","path":"/spec/allowedTraits/-","value":{"kind":"ClusterTrait","name":"keda-based-scaling"}}]'
 ```
 
-`componenttypes/service.yaml` and `componenttypes/worker.yaml` in this module are reference
-examples showing the full type definition with the trait included — use them as a guide, not as
-a replacement for your own types. See [CONFIGURATION.md](./CONFIGURATION.md) for the shape
-requirements a component type must satisfy to be compatible with the HTTP scaling path.
+`componenttypes/service.yaml`, `componenttypes/webapp.yaml`, and `componenttypes/worker.yaml` in this module show the full type definition with the trait already included. Treat them as a guide, not a drop-in replacement for your own types. [CONFIGURATION.md](./CONFIGURATION.md) covers the shape a component type has to have for the HTTP scaling path to work.
 
 ### 4. Annotate the data plane
 
@@ -116,15 +88,13 @@ kubectl rollout status deploy/keda-add-ons-http-interceptor -n keda --timeout=18
 kubectl rollout status deploy/keda-add-ons-http-external-scaler -n keda --timeout=180s
 
 kubectl get clustertrait keda-based-scaling
-kubectl get clustercomponenttype service worker \
+kubectl get clustercomponenttype service web-application worker \
   -o jsonpath='{range .items[*]}{.metadata.name}{": "}{.spec.allowedTraits[*].name}{"\n"}{end}'
 kubectl get clusterrolebinding openchoreo-cluster-agent-keda
 
 # Non-empty Endpoints means the interceptor multiport Service is working:
 kubectl get endpoints keda-add-ons-http-interceptor-multiport -n keda
 ```
-
----
 
 ## Quick start
 
@@ -134,21 +104,20 @@ kubectl get endpoints keda-add-ons-http-interceptor-multiport -n keda
 kubectl apply -f https://raw.githubusercontent.com/openchoreo/community-modules/main/autoscaling-keda/samples/http-service.yaml
 ```
 
-Find the workload namespace OpenChoreo created (re-run if empty — it appears once the
-ReleaseBinding has rendered):
+Find the workload namespace OpenChoreo created. Re-run it if the output is empty, it shows up once the ReleaseBinding has rendered:
 
 ```bash
 WL_NS=$(kubectl get ns -o name | sed 's|namespace/||' | grep '^dp-default-default-development')
 echo "$WL_NS"
 ```
 
-Watch it scale to zero (after ~30s of no traffic):
+Watch it scale to zero after about 30 seconds of no traffic:
 
 ```bash
 kubectl get deploy -n "$WL_NS" -w        # replicas -> 0, then Ctrl-C
 ```
 
-Hit it — the interceptor holds the request and wakes a pod:
+Hit it, and the interceptor holds the request while it wakes a pod:
 
 ```bash
 curl http://development-default.openchoreoapis.localhost:19080/greeter-http/
@@ -159,9 +128,23 @@ curl http://development-default.openchoreoapis.localhost:19080/greeter-http/
 kubectl get deploy -n "$WL_NS"           # replicas back to 1 right after the request
 ```
 
-The very first cold start after deploying can be slow or return a 504 while KEDA registers the new
-scaler — retry once. Subsequent cold starts take ~2-4s; the trait sets a 120s route timeout so the
-gateway holds the request through them.
+The very first cold start after you deploy can be slow, or return a 504 while KEDA registers the new scaler. Just retry once. After that, cold starts take about 2 to 4 seconds, and the trait sets a 120s route timeout so the gateway holds the request while the pod comes up.
+
+### HTTP web application that scales to zero
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/openchoreo/community-modules/main/autoscaling-keda/samples/http-webapp.yaml
+```
+
+Find its generated hostname and call the root path:
+
+```bash
+WL_NS=$(kubectl get ns -o name | sed 's|namespace/||' | grep '^dp-default-default-development')
+WEBAPP_HOST=$(kubectl get httproute -n "$WL_NS" \
+  -l openchoreo.dev/component=keda-webapp,openchoreo.dev/endpoint-visibility=external \
+  -o jsonpath='{.items[0].spec.hostnames[0]}')
+curl "http://$WEBAPP_HOST:19080/"
+```
 
 ### Cron worker that scales to zero
 
@@ -169,8 +152,7 @@ gateway holds the request through them.
 kubectl apply -f https://raw.githubusercontent.com/openchoreo/community-modules/main/autoscaling-keda/samples/cron-worker.yaml
 ```
 
-The worker runs at 1 replica inside its cron window (`03:00–04:00 UTC` in the sample) and sits at
-zero the other 23 hours — so right after applying it you see the scaled-to-zero state:
+The worker runs at 1 replica inside its cron window (`03:00–04:00 UTC` in the sample) and sits at zero the other 23 hours. So right after you apply it, you see the scaled-to-zero state:
 
 ```bash
 WL_NS=$(kubectl get ns -o name | sed 's|namespace/||' | grep '^dp-default-default-development')
@@ -178,11 +160,7 @@ kubectl get scaledobject -n "$WL_NS"
 kubectl get deploy -n "$WL_NS"
 ```
 
-To prove scaling quickly, edit the component's `trigger.metadata.start`/`end` to a window starting
-a couple of minutes from now and watch the Deployment go `0 -> 1 -> 0`. Swap `type`/`metadata` for
-any [KEDA scaler](https://keda.sh/docs/latest/scalers/) (`rabbitmq`, `kafka`, `prometheus`, …).
-
----
+To prove scaling quickly, edit the component's `trigger.metadata.start`/`end` to a window that starts a couple of minutes from now and watch the Deployment go `0 -> 1 -> 0`. Swap `type`/`metadata` for any [KEDA scaler](https://keda.sh/docs/latest/scalers/) you like (`rabbitmq`, `kafka`, `prometheus`, and so on).
 
 ## Usage
 
@@ -221,21 +199,13 @@ spec:
       maxReplicas: 10
 ```
 
-Full parameter reference, tuning (request rate vs. concurrency), extension points, architecture,
-and troubleshooting are in [CONFIGURATION.md](./CONFIGURATION.md).
-
----
+The full parameter reference, tuning notes (request rate vs. concurrency), extension points, architecture, and troubleshooting all live in [CONFIGURATION.md](./CONFIGURATION.md).
 
 ## Limitations
 
-- **One external HTTP endpoint per service** — the interceptor routes by `Host` only (port
-  stripped), and an ExternalName alias can't remap ports; see CONFIGURATION.md.
-- **HTTP path is kgateway-specific** — uses `gateway.kgateway.dev/Backend`; adapt for other
-  Gateway API implementations per CONFIGURATION.md.
-- **Mutually exclusive with HPA traits** — both claim the Deployment's replica count; don't attach
-  both to the same component.
-
----
+- One external HTTP endpoint per service. The interceptor routes by `Host` only (it strips the port first), and an ExternalName alias can't remap ports. See CONFIGURATION.md for the reasoning.
+- The HTTP path is kgateway-specific. It uses `gateway.kgateway.dev/Backend`, so you'll need to adapt it for other Gateway API implementations per CONFIGURATION.md.
+- It doesn't mix with HPA traits. Both want to own the Deployment's replica count, so don't attach both to the same component.
 
 ## Uninstall
 
@@ -248,7 +218,7 @@ kubectl delete \
   -f https://raw.githubusercontent.com/openchoreo/community-modules/main/autoscaling-keda/cluster-agent-keda-rbac.yaml \
   -f https://raw.githubusercontent.com/openchoreo/community-modules/main/autoscaling-keda/keda-based-scaling-trait.yaml
 # To revert the component types, remove keda-based-scaling from allowedTraits:
-#   kubectl patch clustercomponenttype service worker --type=json \
+#   kubectl patch clustercomponenttype service web-application worker --type=json \
 #     -p '[{"op":"remove","path":"/spec/allowedTraits/<index>"}]'
 #   (find the index with: kubectl get clustercomponenttype service -o jsonpath='{.spec.allowedTraits}')
 # optionally:

--- a/autoscaling-keda/cluster-agent-keda-rbac.yaml
+++ b/autoscaling-keda/cluster-agent-keda-rbac.yaml
@@ -1,11 +1,6 @@
 # Copyright 2026 The OpenChoreo Authors
 # SPDX-License-Identifier: Apache-2.0
 #
-# The OpenChoreo data-plane cluster-agent applies the rendered KEDA objects, but
-# its base ClusterRole does not include the KEDA API groups. This grants the agent
-# ServiceAccount permission to manage the KEDA resources the keda-based-scaling trait
-# renders.
-#
 # The subject below is the standard data-plane agent ServiceAccount
 # (`cluster-agent-dataplane` in `openchoreo-data-plane`). If your data plane uses a
 # different ServiceAccount name or namespace, edit the ClusterRoleBinding subject.

--- a/autoscaling-keda/componenttypes/webapp.yaml
+++ b/autoscaling-keda/componenttypes/webapp.yaml
@@ -236,6 +236,6 @@ spec:
             creationPolicy: Owner
             name: ${file.resourceName}
   validations:
-    - message: Web-application components must have at least one HTTP.
+    - message: Web-application components must have at least one HTTP endpoint.
       rule: ${workload.endpoints.exists(name, endpoint, endpoint.type == 'HTTP')}
   workloadType: deployment

--- a/autoscaling-keda/componenttypes/webapp.yaml
+++ b/autoscaling-keda/componenttypes/webapp.yaml
@@ -1,21 +1,21 @@
 # Copyright 2026 The OpenChoreo Authors
 # SPDX-License-Identifier: Apache-2.0
 #
-# Regenerate from YOUR platform's live default type (so it never drifts from your OpenChoreo
-# version) with:
-#   kubectl get clustercomponenttype service -o json \
+# Regenerate from YOUR platform's live default type (so it never drifts from your
+# OpenChoreo version) with:
+#   kubectl get clustercomponenttype web-application -o json \
 #     | jq 'del(.metadata.managedFields,.metadata.resourceVersion,.metadata.uid,.metadata.creationTimestamp,.metadata.generation,.status,.metadata.annotations["kubectl.kubernetes.io/last-applied-configuration"])
 #           | if ([.spec.allowedTraits[]?.name] | index("keda-based-scaling")) then . else .spec.allowedTraits += [{"kind":"ClusterTrait","name":"keda-based-scaling"}] end' \
 #     | yq -p json -o yaml
 #
 # Apply by DELETE + RECREATE, never `kubectl apply`: first delete any components using this
-# type, then `kubectl delete clustercomponenttype service` and `kubectl create -f` this file.
+# type, then `kubectl delete clustercomponenttype web-application` and `kubectl create -f` this file.
 apiVersion: openchoreo.dev/v1alpha1
 kind: ClusterComponentType
 metadata:
   annotations:
-    openchoreo.dev/description: A long-running request-serving component with one or more endpoints
-  name: service
+    openchoreo.dev/description: A long-running component that serves web requests and exposes at least one HTTP endpoint
+  name: web-application
 spec:
   allowedTraits:
     - kind: ClusterTrait
@@ -29,8 +29,6 @@ spec:
       name: gcp-buildpacks-builder
     - kind: ClusterWorkflow
       name: dockerfile-builder
-    - kind: ClusterWorkflow
-      name: ballerina-buildpack-builder
   environmentConfigs:
     openAPIV3Schema:
       $defs:
@@ -132,7 +130,7 @@ spec:
           hostnames: |
             ${[gateway.ingress.external.?http, gateway.ingress.external.?https]
               .filter(g, g.hasValue()).map(g, g.value().host).distinct()
-              .map(h, metadata.environmentName + "-" + metadata.componentNamespace + "." + h)}
+              .map(h, oc_dns_label(endpoint.key, metadata.componentName, metadata.environmentName, metadata.componentNamespace) + "." + h)}
           parentRefs:
             - name: ${gateway.ingress.external.name}
               namespace: ${gateway.ingress.external.namespace}
@@ -140,17 +138,6 @@ spec:
             - backendRefs:
                 - name: ${metadata.componentName}
                   port: ${endpoint.value.port}
-              filters:
-                - type: URLRewrite
-                  urlRewrite:
-                    path:
-                      replacePrefixMatch: ${endpoint.value.?basePath.orValue("/")}
-                      type: ReplacePrefixMatch
-              matches:
-                - path:
-                    type: PathPrefix
-                    value: /${metadata.componentName}-${endpoint.key}
-      var: endpoint
     - forEach: ${workload.endpoints.transformMap(name, ep, "internal" in ep.visibility && ep.type in ["HTTP", "GraphQL", "Websocket"], ep)}
       id: httproute-internal
       targetPlane: dataplane
@@ -165,7 +152,7 @@ spec:
           hostnames: |
             ${[gateway.ingress.internal.?http, gateway.ingress.internal.?https]
               .filter(g, g.hasValue()).map(g, g.value().host).distinct()
-              .map(h, metadata.environmentName + "-" + metadata.componentNamespace + "." + h)}
+              .map(h, oc_dns_label(endpoint.key, metadata.componentName, metadata.environmentName, metadata.componentNamespace) + "." + h)}
           parentRefs:
             - name: ${gateway.ingress.internal.name}
               namespace: ${gateway.ingress.internal.namespace}
@@ -173,20 +160,10 @@ spec:
             - backendRefs:
                 - name: ${metadata.componentName}
                   port: ${endpoint.value.port}
-              filters:
-                - type: URLRewrite
-                  urlRewrite:
-                    path:
-                      replacePrefixMatch: ${endpoint.value.?basePath.orValue("/")}
-                      type: ReplacePrefixMatch
-              matches:
-                - path:
-                    type: PathPrefix
-                    value: /${metadata.componentName}-${endpoint.key}
-      var: endpoint
     - forEach: ${configurations.toConfigEnvsByContainer()}
       id: env-config
       targetPlane: dataplane
+      var: envConfig
       template:
         apiVersion: v1
         data: |
@@ -195,10 +172,10 @@ spec:
         metadata:
           name: ${envConfig.resourceName}
           namespace: ${metadata.namespace}
-      var: envConfig
     - forEach: ${configurations.toConfigFileList()}
       id: file-config
       targetPlane: dataplane
+      var: config
       template:
         apiVersion: v1
         data:
@@ -208,10 +185,10 @@ spec:
         metadata:
           name: ${config.resourceName}
           namespace: ${metadata.namespace}
-      var: config
     - forEach: ${configurations.toSecretEnvsByContainer()}
       id: secret-env-external
       targetPlane: dataplane
+      var: secretEnv
       template:
         apiVersion: external-secrets.io/v1
         kind: ExternalSecret
@@ -234,10 +211,10 @@ spec:
           target:
             creationPolicy: Owner
             name: ${secretEnv.resourceName}
-      var: secretEnv
     - forEach: ${configurations.toSecretFileList()}
       id: secret-file-external
       targetPlane: dataplane
+      var: file
       template:
         apiVersion: external-secrets.io/v1
         kind: ExternalSecret
@@ -258,18 +235,7 @@ spec:
           target:
             creationPolicy: Owner
             name: ${file.resourceName}
-      var: file
   validations:
-    - message: Service components must have at least one endpoint. Use 'deployment/worker' for components without endpoints.
-      rule: ${size(workload.endpoints) > 0}
-    - message: Endpoints with 'external' visibility require gateway.ingress.external to be configured on the Environment or DataPlane.
-      rule: |-
-        ${workload.endpoints.exists(name, ep, "external" in ep.visibility)
-          ? has(gateway.ingress) && has(gateway.ingress.external)
-          : true}
-    - message: Endpoints with 'internal' visibility require gateway.ingress.internal to be configured on the Environment or DataPlane.
-      rule: |-
-        ${workload.endpoints.exists(name, ep, "internal" in ep.visibility)
-          ? has(gateway.ingress) && has(gateway.ingress.internal)
-          : true}
+    - message: Web-application components must have at least one HTTP.
+      rule: ${workload.endpoints.exists(name, endpoint, endpoint.type == 'HTTP')}
   workloadType: deployment

--- a/autoscaling-keda/componenttypes/worker.yaml
+++ b/autoscaling-keda/componenttypes/worker.yaml
@@ -1,10 +1,6 @@
 # Copyright 2026 The OpenChoreo Authors
 # SPDX-License-Identifier: Apache-2.0
 #
-# The stock OpenChoreo `worker` ClusterComponentType with `keda-based-scaling` added to
-# allowedTraits. That single addition lets a developer ATTACH the keda-based-scaling trait to a
-# plain worker component (spec.traits) and configure it.
-#
 # Regenerate from YOUR platform's live default type (so it never drifts from your OpenChoreo
 # version) with:
 #   kubectl get clustercomponenttype worker -o json \

--- a/autoscaling-keda/keda-based-scaling-trait.yaml
+++ b/autoscaling-keda/keda-based-scaling-trait.yaml
@@ -1,20 +1,5 @@
 # Copyright 2026 The OpenChoreo Authors
 # SPDX-License-Identifier: Apache-2.0
-#
-# Autoscaling with KEDA ClusterTrait. Renders KEDA objects so a component scales
-# with demand — down to zero when idle, back up when demand returns. Inert unless
-# the data plane advertises a backend via the
-# `openchoreo.dev/keda-based-scaling-backend: keda` annotation (surfaced to
-# templates as `dataplane.annotations`).
-#
-# Two modes, chosen by `trigger.type`:
-#   ""        -> HTTP mode: InterceptorRoute + companion ScaledObject (KEDA HTTP
-#                Add-on 0.14 split model). The component's Service is aliased to
-#                the interceptor so gateway and in-cluster callers both wake it.
-#   non-empty -> trigger mode: a ScaledObject with that KEDA trigger (cron, kafka, ...).
-#
-# Both modes drop the Deployment's static replicas so KEDA owns the count.
-# See CONFIGURATION.md for the full parameter reference and design rationale.
 apiVersion: openchoreo.dev/v1alpha1
 kind: ClusterTrait
 metadata:
@@ -38,12 +23,10 @@ spec:
           type: integer
           default: 10
           minimum: 1
-        # Seconds all metrics must stay at zero before scaling down to minReplicas.
         cooldownPeriod:
           type: integer
           default: 300
           minimum: 0
-        # Any KEDA scaler trigger. Leave type "" for HTTP traffic-driven services.
         trigger:
           type: object
           default:
@@ -57,8 +40,6 @@ spec:
               additionalProperties:
                 type: string
               default: {}
-        # Location of the keda-add-ons-http interceptor. Defaults match a
-        # `keda-add-ons-http` install in the `keda` namespace.
         interceptorNamespace:
           type: string
           default: keda
@@ -71,26 +52,17 @@ spec:
         interceptorMultiportService:
           type: string
           default: keda-add-ons-http-interceptor-multiport
-        # Ports the multiport interceptor Service exposes. An HTTP-mode endpoint must
-        # listen on one of these: its Service becomes an ExternalName alias (a DNS
-        # CNAME, which can't remap ports), so the caller-facing port must be one the
-        # interceptor already answers on. Keep in sync with keda-interceptor-multiport.yaml.
         wakeablePorts:
           type: array
           items:
             type: integer
           default: [80, 3000, 5000, 8000, 8080, 8081, 8090, 9000, 9090]
-        # The add-on's external scaler that the companion ScaledObject pulls the
-        # request metric from.
         interceptorScalerService:
           type: string
           default: keda-add-ons-http-external-scaler
         interceptorScalerPort:
           type: integer
           default: 9090
-        # HTTP mode scales on request RATE over a sliding window, not instantaneous
-        # concurrency, so sparse traffic keeps the service awake. targetValue is
-        # requests/second per replica.
         requestRateTargetValue:
           type: integer
           default: 1
@@ -101,7 +73,6 @@ spec:
         requestRateGranularity:
           type: string
           default: "1s"
-        # How long the interceptor holds the first request while a pod cold-starts.
         readinessTimeout:
           type: string
           default: "120s"
@@ -121,12 +92,6 @@ spec:
           minimum: 0
 
   validations:
-    # HTTP-mode shape check. The component's Service is aliased to the interceptor
-    # via an ExternalName, which forces two intrinsic constraints (reject loudly
-    # rather than mis-scale):
-    #   - exactly one endpoint: the interceptor routes by Host only (port stripped),
-    #     and all endpoints of a component share one Service name, hence one Host;
-    #   - the endpoint port must be in wakeablePorts: a DNS CNAME can't remap ports.
     - rule: >-
         ${(parameters.enabled && (has(dataplane.annotations) && "openchoreo.dev/keda-based-scaling-backend" in dataplane.annotations && dataplane.annotations["openchoreo.dev/keda-based-scaling-backend"] == "keda") && parameters.trigger.type == "" && size(workload.endpoints) > 0)
           ? (size(workload.endpoints) == 1
@@ -137,14 +102,11 @@ spec:
           : true}
       message: "A KEDA-scaled HTTP service must expose exactly one external HTTP/GraphQL/Websocket endpoint, on a wakeable port (default 80, 3000, 5000, 8000, 8080, 8081, 8090, 9000, 9090): the KEDA interceptor routes by Host only, and the ExternalName alias (a DNS CNAME) can't remap ports. Split extra endpoints into their own component, add the port to keda-interceptor-multiport.yaml and wakeablePorts, or keep minReplicas >= 1."
 
-    # Worker-mode guard: a component with no endpoints has no HTTP traffic to wake
-    # on, so it needs an explicit trigger.
     - rule: >-
         ${!(parameters.enabled && (has(dataplane.annotations) && "openchoreo.dev/keda-based-scaling-backend" in dataplane.annotations && dataplane.annotations["openchoreo.dev/keda-based-scaling-backend"] == "keda") && parameters.trigger.type == "" && size(workload.endpoints) == 0)}
       message: "keda-based-scaling on a component with no endpoints (a worker) requires a trigger (e.g. cron, kafka, rabbitmq). Set trigger.type, or attach this trait only to components that expose an HTTP endpoint."
 
   creates:
-    # (1) Trigger mode: a ScaledObject with the given KEDA trigger.
     - includeWhen: '${parameters.enabled && (has(dataplane.annotations) && "openchoreo.dev/keda-based-scaling-backend" in dataplane.annotations && dataplane.annotations["openchoreo.dev/keda-based-scaling-backend"] == "keda") && parameters.trigger.type != ""}'
       template:
         apiVersion: keda.sh/v1alpha1
@@ -166,10 +128,6 @@ spec:
             - type: ${parameters.trigger.type}
               metadata: ${parameters.trigger.metadata}
 
-    # (2) HTTP mode: InterceptorRoute (routing rule + scaling metric). The 0.14
-    #     controller does NOT create the ScaledObject for it, so (2b) renders the
-    #     companion. The interceptor holds the first request until a pod is ready,
-    #     so wake-from-zero is lossless.
     - includeWhen: '${parameters.enabled && (has(dataplane.annotations) && "openchoreo.dev/keda-based-scaling-backend" in dataplane.annotations && dataplane.annotations["openchoreo.dev/keda-based-scaling-backend"] == "keda") && parameters.trigger.type == "" && size(workload.endpoints.transformList(name, ep, ("external" in ep.visibility && ep.type in ["HTTP", "GraphQL", "Websocket"]) ? [name] : []).flatten()) == 1}'
       forEach: '${workload.endpoints.transformMap(name, ep, "external" in ep.visibility && ep.type in ["HTTP", "GraphQL", "Websocket"], ep)}'
       var: endpoint
@@ -181,15 +139,9 @@ spec:
           namespace: ${metadata.namespace}
           labels: ${metadata.labels}
         spec:
-          # The component's own Service name is taken over by the ExternalName alias
-          # (see patches), so forward to the dedicated pod-backing Service instead.
           target:
             service: ${oc_dns_label(metadata.componentName, "keda-upstream")}
             port: ${endpoint.value.port}
-          # Register ONLY the component's unique in-cluster FQDN as the Host rule —
-          # every KEDA-scaled service in an environment shares the gateway hostname
-          # and would otherwise collide. The external HTTPRoute rewrites Host to this
-          # FQDN (see patches) so gateway and in-cluster callers match the same rule.
           rules:
             - hosts:
                 - ${metadata.componentName + "." + metadata.namespace + ".svc.cluster.local"}
@@ -201,9 +153,6 @@ spec:
           timeouts:
             readiness: ${parameters.readinessTimeout}
 
-    # (2b) Companion ScaledObject: scale target + bounds (minReplicaCount 0 is the
-    #      scale-to-zero gate). Rendered after the InterceptorRoute so the external
-    #      scaler has a metric spec to report instead of falling back to CPU.
     - includeWhen: '${parameters.enabled && (has(dataplane.annotations) && "openchoreo.dev/keda-based-scaling-backend" in dataplane.annotations && dataplane.annotations["openchoreo.dev/keda-based-scaling-backend"] == "keda") && parameters.trigger.type == "" && size(workload.endpoints.transformList(name, ep, ("external" in ep.visibility && ep.type in ["HTTP", "GraphQL", "Websocket"]) ? [name] : []).flatten()) == 1}'
       forEach: '${workload.endpoints.transformMap(name, ep, "external" in ep.visibility && ep.type in ["HTTP", "GraphQL", "Websocket"], ep)}'
       var: endpoint
@@ -231,9 +180,6 @@ spec:
                 scalerAddress: ${parameters.interceptorScalerService + "." + parameters.interceptorNamespace + ":" + string(parameters.interceptorScalerPort)}
                 interceptorRoute: ${oc_generate_name(metadata.componentName, endpoint.key)}
 
-    # (3) HTTP mode: a kgateway Backend in the component's namespace targeting the
-    #     interceptor by DNS name — a local Backend needs no cross-namespace
-    #     ReferenceGrant.
     - includeWhen: '${parameters.enabled && (has(dataplane.annotations) && "openchoreo.dev/keda-based-scaling-backend" in dataplane.annotations && dataplane.annotations["openchoreo.dev/keda-based-scaling-backend"] == "keda") && parameters.trigger.type == "" && size(workload.endpoints.transformList(name, ep, ("external" in ep.visibility && ep.type in ["HTTP", "GraphQL", "Websocket"]) ? [name] : []).flatten()) == 1}'
       template:
         apiVersion: gateway.kgateway.dev/v1alpha1
@@ -249,10 +195,6 @@ spec:
               - host: ${parameters.interceptorService + "." + parameters.interceptorNamespace + ".svc.cluster.local"}
                 port: ${parameters.interceptorPort}
 
-    # (4) Pod-backing Service the interceptor forwards to (the component's own
-    #     Service no longer selects pods once aliased). Its name sorts after
-    #     ${metadata.componentName} so OpenChoreo's in-cluster URL resolver keeps
-    #     injecting the ExternalName.
     - includeWhen: '${parameters.enabled && (has(dataplane.annotations) && "openchoreo.dev/keda-based-scaling-backend" in dataplane.annotations && dataplane.annotations["openchoreo.dev/keda-based-scaling-backend"] == "keda") && parameters.trigger.type == "" && size(workload.endpoints.transformList(name, ep, ("external" in ep.visibility && ep.type in ["HTTP", "GraphQL", "Websocket"]) ? [name] : []).flatten()) == 1}'
       template:
         apiVersion: v1
@@ -267,8 +209,6 @@ spec:
           ports: ${workload.toServicePorts()}
 
   patches:
-    # Drop the static replica count so server-side apply stops resetting it and
-    # fighting the autoscaler — KEDA owns replicas now.
     - target:
         group: apps
         version: v1
@@ -278,8 +218,6 @@ spec:
         - op: remove
           path: /spec/replicas
 
-    # HTTP mode: repoint the external HTTPRoute at the interceptor via the local
-    # kgateway Backend.
     - target:
         group: gateway.networking.k8s.io
         version: v1
@@ -287,31 +225,39 @@ spec:
         where: '${parameters.enabled && (has(dataplane.annotations) && "openchoreo.dev/keda-based-scaling-backend" in dataplane.annotations && dataplane.annotations["openchoreo.dev/keda-based-scaling-backend"] == "keda") && parameters.trigger.type == "" && has(resource.metadata.labels) && resource.metadata.labels["openchoreo.dev/endpoint-visibility"] == "external"}'
       operations:
         - op: replace
-          path: /spec/rules/0/backendRefs/0
+          path: /spec/rules/[*]/backendRefs/[?(@.name=='${metadata.componentName}')]
           value:
             group: gateway.kgateway.dev
             kind: Backend
             name: ${oc_generate_name(metadata.componentName, "keda-interceptor")}
             weight: 1
-        # A cold start can outlast the gateway's default route timeout (~15s),
-        # which would drop the first request even though the interceptor holds it.
         - op: add
-          path: /spec/rules/0/timeouts
+          path: /spec/rules/[*]/timeouts
           value:
-            request: "120s"
-        # Rewrite Host to the component's in-cluster FQDN — the only host on the
-        # InterceptorRoute rule — so gateway traffic matches the same rule as
-        # in-cluster traffic. (filters[0] is the URLRewrite the component type
-        # already sets for the basePath.)
+            request: ${parameters.readinessTimeout}
+    - target:
+        group: gateway.networking.k8s.io
+        version: v1
+        kind: HTTPRoute
+        where: '${parameters.enabled && (has(dataplane.annotations) && "openchoreo.dev/keda-based-scaling-backend" in dataplane.annotations && dataplane.annotations["openchoreo.dev/keda-based-scaling-backend"] == "keda") && parameters.trigger.type == "" && has(resource.metadata.labels) && resource.metadata.labels["openchoreo.dev/endpoint-visibility"] == "external" && has(resource.spec.rules[0].filters) && resource.spec.rules[0].filters.exists(f, f.type == "URLRewrite")}'
+      operations:
         - op: add
-          path: /spec/rules/0/filters/0/urlRewrite/hostname
+          path: /spec/rules/[*]/filters/[?(@.type=='URLRewrite')]/urlRewrite/hostname
           value: ${metadata.componentName + "." + metadata.namespace + ".svc.cluster.local"}
 
-    # HTTP mode: turn the component's own Service into an ExternalName alias of the
-    # interceptor (via the multiport Service). Connections inject this Service's
-    # in-cluster URL, so an in-cluster call to a sleeping component resolves to the
-    # interceptor, is held, and wakes it — the same path gateway traffic takes.
-    # The `where` excludes the pod-backing Service (different name).
+    - target:
+        group: gateway.networking.k8s.io
+        version: v1
+        kind: HTTPRoute
+        where: '${parameters.enabled && (has(dataplane.annotations) && "openchoreo.dev/keda-based-scaling-backend" in dataplane.annotations && dataplane.annotations["openchoreo.dev/keda-based-scaling-backend"] == "keda") && parameters.trigger.type == "" && has(resource.metadata.labels) && resource.metadata.labels["openchoreo.dev/endpoint-visibility"] == "external" && !(has(resource.spec.rules[0].filters) && resource.spec.rules[0].filters.exists(f, f.type == "URLRewrite"))}'
+      operations:
+        - op: add
+          path: /spec/rules/[*]/filters/-
+          value:
+            type: URLRewrite
+            urlRewrite:
+              hostname: ${metadata.componentName + "." + metadata.namespace + ".svc.cluster.local"}
+
     - target:
         group: ""
         version: v1
@@ -324,7 +270,5 @@ spec:
         - op: add
           path: /spec/externalName
           value: ${parameters.interceptorMultiportService + "." + parameters.interceptorNamespace + ".svc.cluster.local"}
-        # ExternalName Services don't select pods; drop the selector so no stray
-        # EndpointSlices form.
         - op: remove
           path: /spec/selector

--- a/autoscaling-keda/keda-interceptor-multiport.yaml
+++ b/autoscaling-keda/keda-interceptor-multiport.yaml
@@ -3,10 +3,6 @@
 #
 # Multi-port front for the keda-add-ons-http interceptor, in the `keda` namespace.
 #
-# A KEDA-scaled HTTP service has its own in-cluster Service aliased to the interceptor through an
-# ExternalName. An ExternalName is a DNS CNAME and cannot remap ports; this Service republishes
-# the interceptor pods on common HTTP ports, all forwarded to the interceptor's 8080.
-#
 # To support a port not listed here, add it below AND to the keda-based-scaling trait's
 # `wakeablePorts` default (keda-based-scaling-trait.yaml); keep the two in sync.
 #

--- a/autoscaling-keda/samples/cron-worker.yaml
+++ b/autoscaling-keda/samples/cron-worker.yaml
@@ -5,7 +5,7 @@
 #   1. The data plane advertises the KEDA backend:
 #        kubectl annotate clusterdataplane default \
 #          openchoreo.dev/keda-based-scaling-backend=keda --overwrite
-#   2. The `worker` type allows the trait (componenttypes/worker.yaml applied — see README).
+#   2. The `worker` type allows the trait (componenttypes/worker.yaml applied, see README).
 ---
 apiVersion: openchoreo.dev/v1alpha1
 kind: Component

--- a/autoscaling-keda/samples/cron-worker.yaml
+++ b/autoscaling-keda/samples/cron-worker.yaml
@@ -1,18 +1,11 @@
 # Copyright 2026 The OpenChoreo Authors
 # SPDX-License-Identifier: Apache-2.0
 #
-# Cron-driven KEDA-based scaling for a worker (no endpoints), using the STOCK `worker` component
-# type with the `keda-based-scaling` trait ATTACHED (spec.traits).
-#
 # Prerequisites:
 #   1. The data plane advertises the KEDA backend:
 #        kubectl annotate clusterdataplane default \
 #          openchoreo.dev/keda-based-scaling-backend=keda --overwrite
 #   2. The `worker` type allows the trait (componenttypes/worker.yaml applied — see README).
-#
-# Workers require an explicit trigger (the trait rejects an enabled, triggerless, endpoint-less
-# component at render time). The cron trigger below (03:00-04:00 UTC) runs 1 hour per day; the
-# worker sits at zero (minReplicas) the other 23 hours.
 ---
 apiVersion: openchoreo.dev/v1alpha1
 kind: Component
@@ -24,7 +17,7 @@ spec:
     projectName: default
   componentType:
     kind: ClusterComponentType
-    name: deployment/worker           # stock default type, unmodified except allowedTraits
+    name: deployment/worker
   autoDeploy: true
   traits:
     - kind: ClusterTrait
@@ -39,7 +32,7 @@ spec:
           type: cron
           metadata:
             timezone: "Etc/UTC"
-            start: "0 3 * * *"        # run 03:00-04:00 UTC; scaled to ZERO the other 23h
+            start: "0 3 * * *"
             end: "0 4 * * *"
             desiredReplicas: "1"
 ---

--- a/autoscaling-keda/samples/http-service.yaml
+++ b/autoscaling-keda/samples/http-service.yaml
@@ -5,7 +5,7 @@
 #   1. The data plane advertises the KEDA backend:
 #        kubectl annotate clusterdataplane default \
 #          openchoreo.dev/keda-based-scaling-backend=keda --overwrite
-#   2. The `service` type allows the trait (componenttypes/service.yaml applied — see README).
+#   2. The `service` type allows the trait (componenttypes/service.yaml applied, see README).
 ---
 apiVersion: openchoreo.dev/v1alpha1
 kind: Component

--- a/autoscaling-keda/samples/http-webapp.yaml
+++ b/autoscaling-keda/samples/http-webapp.yaml
@@ -5,19 +5,19 @@
 #   1. The data plane advertises the KEDA backend:
 #        kubectl annotate clusterdataplane default \
 #          openchoreo.dev/keda-based-scaling-backend=keda --overwrite
-#   2. The `service` type allows the trait (componenttypes/service.yaml applied — see README).
+#   2. The `web-application` type allows the trait (componenttypes/webapp.yaml applied — see README).
 ---
 apiVersion: openchoreo.dev/v1alpha1
 kind: Component
 metadata:
-  name: greeter
+  name: keda-webapp
   namespace: default
 spec:
   owner:
     projectName: default
   componentType:
     kind: ClusterComponentType
-    name: deployment/service
+    name: deployment/web-application
   autoDeploy: true
   traits:
     - kind: ClusterTrait
@@ -32,32 +32,29 @@ spec:
 apiVersion: openchoreo.dev/v1alpha1
 kind: Workload
 metadata:
-  name: greeter-workload
+  name: keda-webapp-workload
   namespace: default
 spec:
   owner:
     projectName: default
-    componentName: greeter
+    componentName: keda-webapp
   endpoints:
     http:
       type: HTTP
-      port: 9090
+      port: 80
       visibility: [external]
   container:
-    image: "hashicorp/http-echo:1.0.0"
-    args:
-      - "-listen=0.0.0.0:9090"
-      - "-text=Hello from OpenChoreo Autoscaling with KEDA!"
+    image: "nginx:1.27-alpine"
 ---
 apiVersion: openchoreo.dev/v1alpha1
 kind: ReleaseBinding
 metadata:
-  name: greeter-development
+  name: keda-webapp-development
   namespace: default
 spec:
   owner:
     projectName: default
-    componentName: greeter
+    componentName: keda-webapp
   environment: development
   componentTypeEnvironmentConfigs:
     resources:

--- a/autoscaling-keda/samples/http-webapp.yaml
+++ b/autoscaling-keda/samples/http-webapp.yaml
@@ -5,7 +5,7 @@
 #   1. The data plane advertises the KEDA backend:
 #        kubectl annotate clusterdataplane default \
 #          openchoreo.dev/keda-based-scaling-backend=keda --overwrite
-#   2. The `web-application` type allows the trait (componenttypes/webapp.yaml applied — see README).
+#   2. The `web-application` type allows the trait (componenttypes/webapp.yaml applied, see README).
 ---
 apiVersion: openchoreo.dev/v1alpha1
 kind: Component


### PR DESCRIPTION
This does two things to the autoscaling-keda module.

## Web-application support

Adds a `web-application` component type (`componenttypes/webapp.yaml`) and a matching `samples/http-webapp.yaml`, so a web app can use the `keda-based-scaling` trait the same way a service already can. The type is the stock OpenChoreo `web-application` definition with `keda-based-scaling` added to `allowedTraits`.

## Doc and comment cleanup

The YAML files carried a lot of explanatory prose that duplicated the README and CONFIGURATION docs. I stripped that back to just the license headers and the operational commands you actually need (the regenerate command, the delete-and-recreate warning, and the sample prerequisites), so the manifests are easier to skim.

I also rewrote README.md and CONFIGURATION.md. Same facts, commands, and tables as before, but the prose reads more like a person wrote it: fewer em-dashes, no bolded list lead-ins, and a more direct voice. Nothing technical changed. I dropped the "0.14 split model" subsection from CONFIGURATION since it was version-specific internals, and the one fact worth keeping (InterceptorRoute renders first, or KEDA falls back to CPU) is already covered in the cold-start and troubleshooting sections.

## Verified

- All eight YAML files still parse (`yaml.safe_load_all`).
- No em-dashes or smart quotes left in either doc.
- No parameter, default, command, or URL was changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new web app component type and sample manifest for building and scaling HTTP applications.
  * Expanded support for HTTP routing and autoscaling setup across the module.

* **Bug Fixes**
  * Improved request timeout handling and route rewrites for more reliable wake-up behavior.
  * Clarified scaling behavior for HTTP traffic and cold starts.

* **Documentation**
  * Reworked setup, configuration, and troubleshooting guides for clearer onboarding and tuning.
  * Updated sample usage instructions and verification steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->