### PR TITLE
test(observability-logs-gcp-cloudlogging): use real UUIDs in filter tests

### DIFF
--- a/observability-logs-gcp-cloudlogging/internal/cloudlogging/queries_test.go
+++ b/observability-logs-gcp-cloudlogging/internal/cloudlogging/queries_test.go
@@ -35,9 +35,9 @@ func TestBuildComponentLogsFilter_RequiredAndOptionalClauses(t *testing.T) {
 
 	f := BuildComponentLogsFilter(ComponentLogsParams{
 		Namespace:      "ns1",
-		ComponentUID:   "c-uid",
-		ProjectUID:     "p-uid",
-		EnvironmentUID: "e-uid",
+		ComponentUID:   "846bb581-d6ba-446d-a160-8cec468d2219",
+		ProjectUID:     "2f1c9a4e-7b3d-4e5a-9c8f-1a2b3c4d5e6f",
+		EnvironmentUID: "b7e6d3c2-5f4a-4d1e-8c9b-0a1b2c3d4e5f",
 		StartTime:      start,
 		EndTime:        end,
 		LogLevels:      []string{"ERROR"},
@@ -47,9 +47,9 @@ func TestBuildComponentLogsFilter_RequiredAndOptionalClauses(t *testing.T) {
 	for _, want := range []string{
 		`resource.type="k8s_container"`,
 		`labels."k8s-pod/openchoreo_dev/namespace"="ns1"`,
-		`labels."k8s-pod/openchoreo_dev/component-uid"="c-uid"`,
-		`labels."k8s-pod/openchoreo_dev/project-uid"="p-uid"`,
-		`labels."k8s-pod/openchoreo_dev/environment-uid"="e-uid"`,
+		`labels."k8s-pod/openchoreo_dev/component-uid"="846bb581-d6ba-446d-a160-8cec468d2219"`,
+		`labels."k8s-pod/openchoreo_dev/project-uid"="2f1c9a4e-7b3d-4e5a-9c8f-1a2b3c4d5e6f"`,
+		`labels."k8s-pod/openchoreo_dev/environment-uid"="b7e6d3c2-5f4a-4d1e-8c9b-0a1b2c3d4e5f"`,
 		`timestamp>="2026-06-25T00:00:00Z"`,
 		`timestamp<="2026-06-26T00:00:00Z"`,
 		`severity="ERROR"`,

--- a/observability-logs-gcp-cloudlogging/internal/cloudmonitoring/filter_webhook_test.go
+++ b/observability-logs-gcp-cloudlogging/internal/cloudmonitoring/filter_webhook_test.go
@@ -13,13 +13,13 @@ import (
 func TestBuildAlertFilter_ScopeAndPhrase(t *testing.T) {
 	f := BuildAlertFilter(RuleInput{
 		Namespace:    "default",
-		ComponentUID: "c-uid",
+		ComponentUID: "846bb581-d6ba-446d-a160-8cec468d2219",
 		Query:        "panic",
 	})
 	for _, want := range []string{
 		`resource.type="k8s_container"`,
 		`labels."k8s-pod/openchoreo_dev/namespace"="default"`,
-		`labels."k8s-pod/openchoreo_dev/component-uid"="c-uid"`,
+		`labels."k8s-pod/openchoreo_dev/component-uid"="846bb581-d6ba-446d-a160-8cec468d2219"`,
 		`(textPayload:"panic" OR jsonPayload.message:"panic")`,
 	} {
 		if !strings.Contains(f, want) {


### PR DESCRIPTION
## Purpose

Follow-up to #258. Two GCP Cloud Logging adapter filter tests still used toy placeholder identifiers (`c-uid`, `p-uid`, `e-uid`) where the real inputs are UUIDs. This makes the package consistent — every filter/mapping test now exercises realistic UUID-shaped values, matching the ones already used in `mapping_test.go` and `translator_test.go`.

## Approach

- `queries_test.go` — `TestBuildComponentLogsFilter_RequiredAndOptionalClauses`: replace `c-uid`/`p-uid`/`e-uid` with real UUIDs in both the input params and the expected filter substrings.
- `filter_webhook_test.go` — `TestBuildAlertFilter_ScopeAndPhrase`: same for the component UID input and its expected substring.
- Uses the same three UUIDs across the package for consistency. Format-specific literals (zero UUID, `1111...`) are intentionally left as-is.

## Related Issues

Related #258

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)