### PR TITLE
fix: stitch multi-line stack traces into one log event in observability-logs-openobserve

### DIFF
--- a/observability-logs-openobserve/helm/templates/fluent-bit/config.yaml
+++ b/observability-logs-openobserve/helm/templates/fluent-bit/config.yaml
@@ -87,5 +87,5 @@ data:
         type          regex
         flush_timeout 2000
         rule          "start_state" "/^.*Exception[:,].*$/" "cont"
-        rule          "cont"        "/^\s+(at|--- End of).*$/" "cont"
+        rule          "cont"        "/^\s+(at\s|--- End of).*$/" "cont"
 {{- end }}

--- a/observability-logs-openobserve/helm/templates/fluent-bit/config.yaml
+++ b/observability-logs-openobserve/helm/templates/fluent-bit/config.yaml
@@ -34,6 +34,15 @@ data:
         Tag kube.*
 
     [FILTER]
+        Name multiline
+        Match kube.*
+        multiline.key_content log
+        mode parser
+        multiline.parser go, java, python, dotnet
+        buffer On
+        flush_ms 2000
+
+    [FILTER]
         Name kubernetes
         Buffer_Size 15MB
         K8S-Logging.Parser On
@@ -62,4 +71,21 @@ data:
         Time_Keep Off
         Time_Key time
         Time_Format %Y-%m-%dT%H:%M:%S.%L
+
+    # The go, java and python multiline parsers referenced by the multiline
+    # filter above are built into Fluent Bit. .NET is not, so it is defined
+    # here as a custom parser. A .NET stack trace starts with a line that
+    # ends in "Exception: <message>" and continues with "   at ..." frames and
+    # "--- End of ... stack trace ---" markers.
+    #
+    # To support another log format not covered by the built-ins, add a
+    # [MULTILINE_PARSER] here (type regex) and append its name to
+    # `multiline.parser` on the multiline filter. See
+    # https://docs.fluentbit.io/manual/data-pipeline/filters/multiline-stacktrace
+    [MULTILINE_PARSER]
+        name          dotnet
+        type          regex
+        flush_timeout 2000
+        rule          "start_state" "/^.*Exception[:,].*$/" "cont"
+        rule          "cont"        "/^\s+(at|--- End of).*$/" "cont"
 {{- end }}


### PR DESCRIPTION
## Purpose

Multi-line exceptions (a .NET `FluentValidation.ValidationException`, or a Java/Go/Python stack trace) emitted by a workload are shipped to OpenObserve as one record per physical line instead of one record per exception, so a single error is scattered across many records and continuation lines get inconsistent log levels. Fixes openchoreo/openchoreo#4150.

## Approach

Follows the proposed fix in the issue, and mirrors #280 (the same fix for the opensearch module) so the sibling modules stay consistent:

- Added a `multiline` filter between the `tail` input and the `kubernetes` filter, keyed on `log` content, using the built-in `go, java, python` parsers plus a custom `dotnet` parser (`buffer On`, `flush_ms 2000`).
- Defined the `dotnet` `[MULTILINE_PARSER]` in `parsers.conf` — Fluent Bit has no built-in .NET parser. A comment documents how to add further custom parsers for formats the built-ins don't cover.

## Verification

- Checked the `dotnet` rules against a representative `FluentValidation.ValidationException` trace: the `…Exception: …` line matches `start_state` only, the `   at …` / `   --- End of inner exception stack trace ---` lines match `cont` only, and a following normal log line matches neither — so the exception is stitched into one record (level taken from the first line) and the next record starts cleanly.
- Rendered template parses as valid YAML; resulting pipeline order is `tail → multiline → kubernetes → http`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved log collection for multiline application logs.
  * Added support for combining Go, Java, Python, and .NET stack traces into single log entries.
  * Enhanced detection of .NET exception stack traces, including indented frames and stack trace completion markers.
  * Added buffering and timed flushing to improve multiline log handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->