### PR TITLE
feat(autoscaling-keda): compose with an edge API-gateway trait, add architecture diagrams

### DIFF
--- a/autoscaling-keda/CONFIGURATION.md
+++ b/autoscaling-keda/CONFIGURATION.md
@@ -179,6 +179,8 @@ This is deliberately simpler than a per-data-plane backend switch. Heterogeneous
 
 Both modes patch the Deployment to remove `spec.replicas`, handing replica ownership to KEDA. If `spec.replicas` stuck around, server-side apply would reset it on every render and fight the autoscaler.
 
+The three HTTP-mode `HTTPRoute` patches (repoint the `backendRef`, add the `request` timeout, add the `urlRewrite.hostname`) only apply while keda still owns the external route, i.e. a `backendRef` named after the component is still present. If another edge trait attached ahead of `keda-scaling` has already repointed the route, keda skips those three patches and keeps only the ExternalName/interceptor wiring. See [Composing with an API gateway trait](#composing-with-an-api-gateway-trait).
+
 ### In-cluster wake: the ExternalName alias mechanism
 
 OpenChoreo connection bindings inject the callee's in-cluster Service URL (`http://<component>.<ns>.svc.cluster.local:<port>`). Left alone, that URL goes straight to the Deployment pods and gets refused while the service sleeps.
@@ -187,7 +189,7 @@ In HTTP mode the trait closes that gap:
 
 1. The component's own Service (named `${metadata.componentName}`) is patched to `type: ExternalName`, with `externalName` pointing at `keda-add-ons-http-interceptor-multiport.<interceptorNamespace>.svc.cluster.local`. An in-cluster call to the injected URL now resolves to the interceptor.
 2. A separate ClusterIP Service (`${componentName}-keda-upstream`) is created with the original pod selector and ports. The `InterceptorRoute` forwards here once a pod is ready.
-3. The `InterceptorRoute` registers exactly one `rules[].hosts` entry: the component's FQDN (`<componentName>.<namespace>.svc.cluster.local`). The HTTPRoute patch adds a `urlRewrite.hostname` filter that rewrites the outbound Host header to this FQDN, so gateway traffic and in-cluster traffic match the same interceptor rule.
+3. The `InterceptorRoute` registers two `rules[].hosts` entries: the component's FQDN (`<componentName>.<namespace>.svc.cluster.local`) and its two-label form (`<componentName>.<namespace>`). The HTTPRoute patch adds a `urlRewrite.hostname` filter that rewrites the outbound Host header to the FQDN, so gateway traffic and in-cluster traffic match the same interceptor rule. The two-label host is what an edge API-gateway trait sends when it fronts the component (see [Composing with an API gateway trait](#composing-with-an-api-gateway-trait)).
 
 The Service is born as ExternalName on first render, so there's no ClusterIP-to-ExternalName mutation to trip over. If you convert a long-lived component and the data-plane apply rejects the in-place Service type change, redeploy the component so the Service is recreated from scratch.
 
@@ -204,6 +206,19 @@ A service that doesn't fit (multiple endpoints, or a port outside `wakeablePorts
 - Split the extra endpoints into a separate component, each with its own trait attachment.
 - Add the port to `keda-interceptor-multiport.yaml` and `wakeablePorts`.
 - Keep `minReplicas >= 1` on the component, which skips scale-to-zero and the ExternalName takeover.
+
+### Composing with an API gateway trait
+
+`keda-scaling` can coexist on one component with an edge API-management trait such as `api-management` (the `gateway-wso2-api-platform` module). Both traits repoint the external `HTTPRoute`'s `backendRef`, selecting it by the component's Service name, so naively attaching both would make the second one to render match zero elements and fail.
+
+Two things make the composition work:
+
+1. **The edge trait renders first and keda defers.** List the API-gateway trait before `keda-scaling` in `spec.traits`. Traits render in list order, so the gateway trait repoints the route's `backendRef` to its own backend first. keda's three HTTPRoute patches are guarded on the route still carrying a `backendRef` named after the component; once the gateway trait has renamed it, that guard is false and keda skips the edge-route patches. keda still applies its Service->ExternalName patch, so in-cluster wiring stays intact. If keda rendered first, the gateway trait would fail to find the component-named `backendRef`, which is why the order is required.
+2. **The interceptor accepts the gateway's upstream host.** The API gateway forwards to the component's upstream by its configured authority `<component>.<namespace>` (a two-label name), not the full `.svc.cluster.local` FQDN. The `InterceptorRoute` lists both hosts for this reason, so the gateway's request matches an interceptor rule and wakes the pod.
+
+The resulting path is edge gateway -> API gateway -> the component's ExternalName Service -> the KEDA interceptor -> the pod. Idle scale-to-zero and the API gateway's policies both keep working.
+
+The order dependency is currently conventional, not enforced. A wrong order fails at render time with the gateway trait's zero-match error rather than silently misrouting.
 
 ## Limitations
 

--- a/autoscaling-keda/CONFIGURATION.md
+++ b/autoscaling-keda/CONFIGURATION.md
@@ -1,12 +1,10 @@
 # Configuration and architecture
 
-The README covers installation and the quick start. This document goes deeper. It's the full parameter reference, the guide to tuning and extending the trait, the reasoning behind the architecture, and the troubleshooting notes for the `autoscaling-keda` module and its `keda-scaling` trait.
+The README covers installation and the quick start. This document has the full parameter reference, the tuning and extension guide, the reasoning behind the architecture, and the troubleshooting notes for the `autoscaling-keda` module and its `keda-scaling` trait.
 
 ## Parameter reference
 
 All parameters live under `spec.traits[].parameters` on the component. The trait is named `keda-scaling`, and the samples reuse that same value for `instanceName`. Per-environment overrides in the `ReleaseBinding` are keyed by whatever `instanceName` you pick.
-
-Attaching the trait to a component activates it; detaching removes everything it rendered. There's no `enabled` flag.
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
@@ -168,7 +166,7 @@ The trait doesn't expose every `ScaledObject` field as a parameter. Fields like 
 
 Attaching the trait to a component is what activates it; there's no data-plane flag. The trait assumes every data plane the component promotes across runs KEDA, so it renders KEDA objects unconditionally when attached.
 
-This is deliberately simpler than a per-data-plane backend switch. Heterogeneous fleets, where only some data planes run KEDA (or run a different scaling backend entirely), need a consistent cross-plane mechanism that OpenChoreo doesn't have yet; until then, keep the data planes in a component's promotion path identical. If a plane in that path doesn't run KEDA, don't attach the trait to components that promote onto it.
+This is deliberately simpler than a per-data-plane backend switch. Heterogeneous fleets, where only some data planes run KEDA (or run a different scaling backend entirely), need a consistent cross-plane mechanism that OpenChoreo doesn't have yet. Until then, keep the data planes in a component's promotion path identical. If a plane in that path doesn't run KEDA, don't attach the trait to components that promote onto it.
 
 ### Rendering modes
 
@@ -177,7 +175,7 @@ This is deliberately simpler than a per-data-plane backend switch. Heterogeneous
 | **HTTP** | `trigger.type == ""`, one external HTTP/GraphQL/WebSocket endpoint | `InterceptorRoute` + companion `ScaledObject`, kgateway `Backend`, pod-backing Service, patches to ExternalName the component's Service for in-cluster wake, and repoint the `HTTPRoute` at the Backend for gateway traffic |
 | **Trigger** | `trigger.type != ""` | `ScaledObject` with the given trigger |
 
-Both modes patch the Deployment to remove `spec.replicas`, handing replica ownership to KEDA. If `spec.replicas` stuck around, server-side apply would reset it on every render and fight the autoscaler.
+Both modes patch the Deployment to remove `spec.replicas`, which hands replica ownership to KEDA. If `spec.replicas` stuck around, server-side apply would reset it on every render and fight the autoscaler.
 
 The three HTTP-mode `HTTPRoute` patches (repoint the `backendRef`, add the `request` timeout, add the `urlRewrite.hostname`) only apply while keda still owns the external route, i.e. a `backendRef` named after the component is still present. If another edge trait attached ahead of `keda-scaling` has already repointed the route, keda skips those three patches and keeps only the ExternalName/interceptor wiring. See [Composing with an API gateway trait](#composing-with-an-api-gateway-trait).
 
@@ -197,9 +195,9 @@ The Service is born as ExternalName on first render, so there's no ClusterIP-to-
 
 Two constraints force the single-endpoint shape.
 
-The first is one Service, one Host. OpenChoreo gives a component a single Service (one DNS name, possibly many ports), and connection bindings inject that one name. Every endpoint on the component is reached as the same host (`<component>.<ns>.svc.cluster.local`), differing only by port. The KEDA interceptor routes purely by the `Host` header and strips the port first, so it can't tell two endpoints on the same component apart. A second endpoint would be forwarded to the wrong port without warning. So there can be only one endpoint.
+First, OpenChoreo gives a component a single Service (one DNS name, possibly many ports), and connection bindings inject that one name. Every endpoint on the component is reached as the same host (`<component>.<ns>.svc.cluster.local`), differing only by port. The KEDA interceptor routes purely by the `Host` header and strips the port first, so it can't tell two endpoints on the same component apart. A second endpoint would be forwarded to the wrong port without warning. So there can be only one endpoint.
 
-The second is that a CNAME can't remap ports. An ExternalName Service is a DNS CNAME, so a caller hitting the component on its endpoint port lands on the interceptor on that same port. The endpoint port has to be one the interceptor already answers on. The multiport Service (`keda-interceptor-multiport.yaml`) fronts the interceptor on a set of common ports for exactly this reason, so you're not pinned to a single port. That's why the endpoint port has to be in `wakeablePorts`.
+Second, a CNAME can't remap ports. An ExternalName Service is a DNS CNAME, so a caller hitting the component on its endpoint port lands on the interceptor on that same port. The endpoint port has to be one the interceptor already answers on. The multiport Service (`keda-interceptor-multiport.yaml`) fronts the interceptor on a set of common ports for exactly this reason, so you're not pinned to a single port. That's why the endpoint port has to be in `wakeablePorts`.
 
 A service that doesn't fit (multiple endpoints, or a port outside `wakeablePorts`) has three ways out:
 
@@ -211,20 +209,15 @@ A service that doesn't fit (multiple endpoints, or a port outside `wakeablePorts
 
 `keda-scaling` can coexist on one component with an edge API-management trait such as `api-management` (the `gateway-wso2-api-platform` module). Both traits repoint the external `HTTPRoute`'s `backendRef`, selecting it by the component's Service name, so naively attaching both would make the second one to render match zero elements and fail.
 
-Two things make the composition work:
+Two things make the composition work.
 
-1. **The edge trait renders first and keda defers.** List the API-gateway trait before `keda-scaling` in `spec.traits`. Traits render in list order, so the gateway trait repoints the route's `backendRef` to its own backend first. keda's three HTTPRoute patches are guarded on the route still carrying a `backendRef` named after the component; once the gateway trait has renamed it, that guard is false and keda skips the edge-route patches. keda still applies its Service->ExternalName patch, so in-cluster wiring stays intact. If keda rendered first, the gateway trait would fail to find the component-named `backendRef`, which is why the order is required.
-2. **The interceptor accepts the gateway's upstream host.** The API gateway forwards to the component's upstream by its configured authority `<component>.<namespace>` (a two-label name), not the full `.svc.cluster.local` FQDN. The `InterceptorRoute` lists both hosts for this reason, so the gateway's request matches an interceptor rule and wakes the pod.
+The first is that the edge trait renders first and keda defers. List the API-gateway trait before `keda-scaling` in `spec.traits`. Traits render in list order, so the gateway trait repoints the route's `backendRef` to its own backend first. keda's three HTTPRoute patches are guarded on the route still carrying a `backendRef` named after the component. Once the gateway trait has renamed it, that guard is false and keda skips the edge-route patches. keda still applies its Service->ExternalName patch, so in-cluster wiring stays intact. If keda rendered first, the gateway trait would fail to find the component-named `backendRef`, which is why the order is required.
+
+The second is that the interceptor accepts the gateway's upstream host. The API gateway forwards to the component's upstream by its configured authority `<component>.<namespace>` (a two-label name), not the full `.svc.cluster.local` FQDN. The `InterceptorRoute` lists both hosts for this reason, so the gateway's request matches an interceptor rule and wakes the pod.
 
 The resulting path is edge gateway -> API gateway -> the component's ExternalName Service -> the KEDA interceptor -> the pod. Idle scale-to-zero and the API gateway's policies both keep working.
 
 The order dependency is currently conventional, not enforced. A wrong order fails at render time with the gateway trait's zero-match error rather than silently misrouting.
-
-## Limitations
-
-- Exactly one external HTTP endpoint per service in HTTP mode. The interceptor routes by `Host` only (port stripped), and the ExternalName alias is a DNS CNAME that can't remap ports. See the Architecture section for the full reasoning and the escape hatches.
-- The HTTP path is kgateway-specific. The trait routes to the interceptor through a `gateway.kgateway.dev/Backend`. On a different Gateway API implementation, adapt the Backend resource and the HTTPRoute patch to whatever reaches the interceptor Service there.
-- It's mutually exclusive with HPA-style traits. Both claim ownership of the Deployment's replica count, so don't attach an HPA-style trait and `keda-scaling` to the same component.
 
 ## Troubleshooting
 

--- a/autoscaling-keda/README.md
+++ b/autoscaling-keda/README.md
@@ -14,12 +14,22 @@ KEDA core and the KEDA HTTP Add-on come from their own upstream Helm charts (see
 
 ## How it works
 
-Attach the `keda-scaling` trait to a component and it renders the right KEDA objects; detach it and they're gone. Attaching is the on/off switch, there's no separate flag to set. The trait assumes every data plane it targets runs KEDA. Mixed fleets, where only some data planes run KEDA, are a separate design still being worked out; for now keep the data planes a component promotes across identical.
+Attach the `keda-scaling` trait to a component and it renders the right KEDA objects; detach it and they're gone. Attaching is the on/off switch, there's no separate flag to set. The trait definition lives on the control plane, and the cluster-agent applies whatever it renders onto the data plane:
+
+![What the keda-scaling trait renders in each mode](keda-overview.svg)
 
 | Mode | When | What KEDA creates |
 |------|------|-------------------|
 | **HTTP** | service or web-application with one external HTTP endpoint, no `trigger.type` | `InterceptorRoute` + companion `ScaledObject`; gateway and in-cluster traffic both wake the component |
 | **Trigger** | any component with `trigger.type` set | `ScaledObject` with that trigger (cron, kafka, rabbitmq, …) |
+
+### Waking a sleeping service
+
+In HTTP mode the component scales to zero when idle, and the first request wakes it, whichever way it arrives. Gateway traffic reaches the interceptor because the trait repoints the external `HTTPRoute` at it. In-cluster calls reach it because the component's Service becomes an ExternalName alias for the interceptor. Either way the interceptor holds the request while a pod starts, then forwards it:
+
+![How a request wakes a scaled-to-zero service](keda-http-flow.svg)
+
+The trait assumes every data plane it targets runs KEDA. Mixed fleets, where only some data planes run KEDA, are a separate design still being worked out; for now keep the data planes a component promotes across identical.
 
 You need OpenChoreo 1.2 or later. For the architecture, tuning, and extension details, see [CONFIGURATION.md](./CONFIGURATION.md).
 
@@ -105,7 +115,7 @@ WL_NS=$(kubectl get ns -o name | sed 's|namespace/||' | grep '^dp-default-defaul
 echo "$WL_NS"
 ```
 
-Watch it scale to zero after about 30 seconds of no traffic:
+Watch it scale to zero. This happens once no request has arrived for the full request-rate window (1 minute by default) plus the sample's `cooldownPeriod: 30`, so roughly 90 seconds after the last request:
 
 ```bash
 kubectl get deploy -n "$WL_NS" -w        # replicas -> 0, then Ctrl-C
@@ -196,30 +206,7 @@ The full parameter reference, tuning notes (request rate vs. concurrency), exten
 
 ## Composing with an API gateway trait
 
-`keda-scaling` can share a component with an edge API-management trait such as `api-management` (from the `gateway-wso2-api-platform` module), so one service gets both scale-to-zero and API management. Both traits repoint the external `HTTPRoute`, so two rules apply:
-
-- **Order matters.** List the API-gateway trait *before* `keda-scaling` in `spec.traits`. The gateway trait takes over the edge route, and `keda-scaling` then sees it no longer owns that route and skips its own edge-route patches, keeping just the in-cluster ExternalName wiring. Reverse the order and the gateway trait fails to render.
-- **The chain.** Traffic flows edge gateway -> API gateway (e.g. WSO2) -> the component's ExternalName Service -> the KEDA interceptor -> the pod, and the interceptor wakes the pod on the first request. Idle scale-to-zero and the API gateway's own policies (rate limiting, auth, headers) both keep working.
-
-```yaml
-traits:
-  - name: api-management        # edge trait first: it owns the external route
-    instanceName: my-api
-    kind: ClusterTrait
-    parameters:
-      rateLimit:
-        enabled: true
-        limits:
-          - requests: 100
-            duration: "1m"
-  - name: keda-scaling          # keda second: defers the edge route, keeps scale-to-zero
-    instanceName: keda-scaling
-    kind: ClusterTrait
-    parameters:
-      minReplicas: 0
-```
-
-See [CONFIGURATION.md](./CONFIGURATION.md) for how the deferral works and why the interceptor accepts the API gateway's upstream host.
+`keda-scaling` can share a component with an edge API-management trait such as `api-management` (from the `gateway-wso2-api-platform` module), so one service gets both scale-to-zero and API management. List the API-gateway trait *before* `keda-scaling` in `spec.traits`: the gateway trait takes over the external route, and keda keeps its in-cluster wake wiring, so scale-to-zero and the gateway's policies both keep working. The reverse order fails to render. How the deferral works is covered in [CONFIGURATION.md](./CONFIGURATION.md#composing-with-an-api-gateway-trait).
 
 ## Limitations
 

--- a/autoscaling-keda/README.md
+++ b/autoscaling-keda/README.md
@@ -2,19 +2,11 @@
 
 This module scales OpenChoreo components on demand with [KEDA](https://keda.sh). An HTTP service can drop to zero replicas while it's idle and wake up on the first request. The KEDA HTTP Add-on interceptor holds that request while a pod starts, so nothing gets dropped, and in-cluster service-to-service calls wake the service the same way. Workers scale on cron or queue triggers instead. You get all of this by attaching the `keda-scaling` trait to a plain service or worker component and setting a few parameters.
 
-The module has three pieces:
-
-- `keda-scaling-trait.yaml` holds the `ClusterTrait` that renders the right KEDA objects for each data plane.
-- `cluster-agent-keda-rbac.yaml` gives the data-plane cluster-agent permission to manage KEDA objects.
-- `keda-interceptor-multiport.yaml` is a multi-port Service that fronts the interceptor so in-cluster calls can wake a service.
-
-To use it, add `keda-scaling` to the `allowedTraits` of your existing component types (a one-line patch, see Install step 3) and attach the trait to a component. The module ships no component types of its own; it works with whatever `service`/`web-application`/`worker` types your platform already runs.
-
-KEDA core and the KEDA HTTP Add-on come from their own upstream Helm charts (see Install below). This module is only the OpenChoreo glue.
+The module is just the OpenChoreo glue: a `ClusterTrait` that renders the right KEDA objects, RBAC so the data-plane cluster-agent can manage them, and a multi-port Service that lets in-cluster calls wake a sleeping service. KEDA core and the KEDA HTTP Add-on come from their own upstream Helm charts (see Install below). The module ships no component types of its own. Add `keda-scaling` to the `allowedTraits` of whatever `service`/`web-application`/`worker` types your platform already runs (a one-line patch, Install step 3) and attach the trait to a component.
 
 ## How it works
 
-Attach the `keda-scaling` trait to a component and it renders the right KEDA objects; detach it and they're gone. Attaching is the on/off switch, there's no separate flag to set. The trait definition lives on the control plane, and the cluster-agent applies whatever it renders onto the data plane:
+Attach the `keda-scaling` trait to a component and it renders the right KEDA objects. Detach it and they're gone. Attaching is the on/off switch, there's no separate flag to set. The trait definition lives on the control plane, and the cluster-agent applies whatever it renders onto the data plane:
 
 ![What the keda-scaling trait renders in each mode](keda-overview.svg)
 
@@ -62,7 +54,7 @@ helm upgrade --install keda-add-ons-http kedacore/keda-add-ons-http --version 0.
 kubectl wait --for=condition=Established crd/interceptorroutes.http.keda.sh --timeout=120s
 ```
 
-> The `additionalLabels` flag matters. OpenChoreo renders a NetworkPolicy for each component that only admits traffic from the same namespace or from pods carrying the `openchoreo.dev/system-component` label. Leave the flag out and, on any cluster whose CNI enforces NetworkPolicy (k3s and k3d included), the interceptor's forwarded requests get dropped silently. Every request then times out with a 504, even though the wake-up itself worked.
+> Don't skip the `additionalLabels` flag. OpenChoreo renders a NetworkPolicy for each component that only admits traffic from the same namespace or from pods carrying the `openchoreo.dev/system-component` label. Without the label, on any cluster whose CNI enforces NetworkPolicy (k3s and k3d included), the interceptor's forwarded requests get dropped silently and every request times out with a 504, even though the wake-up itself worked.
 
 ### 2. Apply the trait and data-plane resources
 
@@ -192,21 +184,13 @@ spec:
             desiredReplicas: "1"
 ```
 
-Platform engineers can floor the bounds per environment from the `ReleaseBinding`:
-
-```yaml
-spec:
-  traitEnvironmentConfigs:
-    keda-scaling:
-      minReplicas: 1        # never scale to zero in production
-      maxReplicas: 10
-```
+Platform engineers can override `minReplicas`, `maxReplicas`, and `cooldownPeriod` per environment from the `ReleaseBinding`, for example to never scale to zero in production. See [per-environment overrides](./CONFIGURATION.md#per-environment-overrides).
 
 The full parameter reference, tuning notes (request rate vs. concurrency), extension points, architecture, and troubleshooting all live in [CONFIGURATION.md](./CONFIGURATION.md).
 
 ## Composing with an API gateway trait
 
-`keda-scaling` can share a component with an edge API-management trait such as `api-management` (from the `gateway-wso2-api-platform` module), so one service gets both scale-to-zero and API management. List the API-gateway trait *before* `keda-scaling` in `spec.traits`: the gateway trait takes over the external route, and keda keeps its in-cluster wake wiring, so scale-to-zero and the gateway's policies both keep working. The reverse order fails to render. How the deferral works is covered in [CONFIGURATION.md](./CONFIGURATION.md#composing-with-an-api-gateway-trait).
+`keda-scaling` can share a component with an edge API-management trait such as `api-management` (from the `gateway-wso2-api-platform` module), so one service gets both scale-to-zero and API management. Put the API-gateway trait before `keda-scaling` in `spec.traits`. The gateway trait then takes over the external route while keda keeps its in-cluster wake wiring, so scale-to-zero and the gateway's policies both keep working. The reverse order fails to render. How the deferral works is covered in [CONFIGURATION.md](./CONFIGURATION.md#composing-with-an-api-gateway-trait).
 
 ## Limitations
 

--- a/autoscaling-keda/README.md
+++ b/autoscaling-keda/README.md
@@ -194,6 +194,33 @@ spec:
 
 The full parameter reference, tuning notes (request rate vs. concurrency), extension points, architecture, and troubleshooting all live in [CONFIGURATION.md](./CONFIGURATION.md).
 
+## Composing with an API gateway trait
+
+`keda-scaling` can share a component with an edge API-management trait such as `api-management` (from the `gateway-wso2-api-platform` module), so one service gets both scale-to-zero and API management. Both traits repoint the external `HTTPRoute`, so two rules apply:
+
+- **Order matters.** List the API-gateway trait *before* `keda-scaling` in `spec.traits`. The gateway trait takes over the edge route, and `keda-scaling` then sees it no longer owns that route and skips its own edge-route patches, keeping just the in-cluster ExternalName wiring. Reverse the order and the gateway trait fails to render.
+- **The chain.** Traffic flows edge gateway -> API gateway (e.g. WSO2) -> the component's ExternalName Service -> the KEDA interceptor -> the pod, and the interceptor wakes the pod on the first request. Idle scale-to-zero and the API gateway's own policies (rate limiting, auth, headers) both keep working.
+
+```yaml
+traits:
+  - name: api-management        # edge trait first: it owns the external route
+    instanceName: my-api
+    kind: ClusterTrait
+    parameters:
+      rateLimit:
+        enabled: true
+        limits:
+          - requests: 100
+            duration: "1m"
+  - name: keda-scaling          # keda second: defers the edge route, keeps scale-to-zero
+    instanceName: keda-scaling
+    kind: ClusterTrait
+    parameters:
+      minReplicas: 0
+```
+
+See [CONFIGURATION.md](./CONFIGURATION.md) for how the deferral works and why the interceptor accepts the API gateway's upstream host.
+
 ## Limitations
 
 - One external HTTP endpoint per service. The interceptor routes by `Host` only (it strips the port first), and an ExternalName alias can't remap ports. See CONFIGURATION.md for the reasoning.

--- a/autoscaling-keda/keda-http-flow.svg
+++ b/autoscaling-keda/keda-http-flow.svg
@@ -1,0 +1,155 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 545" font-family="'Segoe UI', system-ui, -apple-system, sans-serif">
+  <defs>
+    <linearGradient id="extGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#ef6c00"/>
+      <stop offset="100%" stop-color="#e65100"/>
+    </linearGradient>
+    <linearGradient id="callerGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#5c6bc0"/>
+      <stop offset="100%" stop-color="#3949ab"/>
+    </linearGradient>
+    <linearGradient id="kgatewayGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#7e57c2"/>
+      <stop offset="100%" stop-color="#5e35b1"/>
+    </linearGradient>
+    <linearGradient id="kedaGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#26a69a"/>
+      <stop offset="100%" stop-color="#00897b"/>
+    </linearGradient>
+    <linearGradient id="componentGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#42a5f5"/>
+      <stop offset="100%" stop-color="#1e88e5"/>
+    </linearGradient>
+    <filter id="shadow" x="-2%" y="-2%" width="104%" height="108%">
+      <feDropShadow dx="0" dy="2" stdDeviation="3" flood-opacity="0.12"/>
+    </filter>
+    <filter id="shadowSm" x="-2%" y="-2%" width="104%" height="108%">
+      <feDropShadow dx="0" dy="1" stdDeviation="2" flood-opacity="0.1"/>
+    </filter>
+    <marker id="arrowHead" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <path d="M0,0 L10,3.5 L0,7 Z" fill="#546e7a"/>
+    </marker>
+    <marker id="arrowHeadOrange" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <path d="M0,0 L10,3.5 L0,7 Z" fill="#e65100"/>
+    </marker>
+    <marker id="arrowHeadIndigo" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <path d="M0,0 L10,3.5 L0,7 Z" fill="#3949ab"/>
+    </marker>
+    <marker id="arrowHeadTeal" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <path d="M0,0 L10,3.5 L0,7 Z" fill="#00897b"/>
+    </marker>
+  </defs>
+
+  <!-- Background -->
+  <rect width="780" height="545" rx="12" fill="#fafafa"/>
+
+  <!-- Client (outside the cluster, top middle) -->
+  <rect x="330" y="8" width="120" height="40" rx="8" fill="url(#extGrad)" filter="url(#shadow)"/>
+  <g stroke="#fff" stroke-width="1.3" fill="none">
+    <circle cx="368" cy="28" r="8"/>
+    <ellipse cx="368" cy="28" rx="3.5" ry="8"/>
+    <line x1="360" y1="28" x2="376" y2="28"/>
+  </g>
+  <text x="382" y="32" font-size="10" font-weight="600" fill="#fff">Client</text>
+
+  <!-- Client -> kgateway (L-shaped, into the edge of the cluster) -->
+  <path d="M450,28 L661,28 L661,66" stroke="#e65100" stroke-width="1.5" fill="none" marker-end="url(#arrowHeadOrange)"/>
+  <circle cx="682" cy="47" r="9" fill="#263238"/>
+  <text x="682" y="50.5" text-anchor="middle" font-size="9" font-weight="700" fill="#fff">1</text>
+
+  <!-- ==================== DATA PLANE CLUSTER ==================== -->
+  <rect x="30" y="88" width="720" height="432" rx="10" fill="#ffffff" stroke="#b0bec5" stroke-width="1.2"/>
+  <text x="42" y="106" font-size="9" font-weight="600" fill="#546e7a" letter-spacing="1">DATA PLANE CLUSTER</text>
+
+  <!-- kgateway, straddling the cluster boundary -->
+  <rect x="601" y="70" width="120" height="44" rx="8" fill="url(#kgatewayGrad)" filter="url(#shadow)"/>
+  <text x="661" y="97" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">kgateway</text>
+
+  <!-- kgateway -> Backend -->
+  <line x1="661" y1="114" x2="661" y2="144" stroke="#e65100" stroke-width="1.5" marker-end="url(#arrowHeadOrange)"/>
+  <text x="653" y="133" text-anchor="end" font-size="8" fill="#e65100">backendRef</text>
+
+  <!-- Backend CRD -->
+  <rect x="609" y="150" width="104" height="44" rx="5" fill="#fff" filter="url(#shadowSm)" stroke="#7e57c2" stroke-width="1"/>
+  <text x="621" y="168" font-size="9" font-weight="600" fill="#5e35b1">Backend</text>
+  <text x="621" y="183" font-size="8" fill="#546e7a">(kgateway CRD)</text>
+
+  <!-- ==================== namespace: dp-acme-default-development ==================== -->
+  <rect x="50" y="126" width="330" height="374" rx="8" fill="#ede7f6" filter="url(#shadowSm)" stroke="#b39ddb" stroke-width="1"/>
+  <text x="62" y="144" font-size="9" font-weight="600" fill="#4527a0" letter-spacing="0.5">namespace: dp-acme-default-development</text>
+
+  <!-- client pod -->
+  <rect x="70" y="154" width="100" height="34" rx="8" fill="url(#callerGrad)" filter="url(#shadow)"/>
+  <text x="120" y="176" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">client pod</text>
+
+  <!-- client pod -> greeter Service (direct) -->
+  <line x1="120" y1="188" x2="120" y2="230" stroke="#3949ab" stroke-width="1.5" marker-end="url(#arrowHeadIndigo)"/>
+  <circle cx="99" cy="209" r="9" fill="#263238"/>
+  <text x="99" y="212.5" text-anchor="middle" font-size="9" font-weight="700" fill="#fff">1</text>
+  <text x="132" y="212" font-size="8" fill="#3949ab" font-family="ui-monospace, Consolas, monospace">curl -v http://greeter:9090</text>
+
+  <!-- greeter Service (ExternalName) -->
+  <rect x="70" y="236" width="286" height="44" rx="6" fill="#fff" filter="url(#shadowSm)" stroke="#26a69a" stroke-width="1"/>
+  <text x="82" y="254" font-size="9" font-weight="600" fill="#00897b">greeter.dp-acme-default-development.svc.cluster.local</text>
+  <text x="82" y="269" font-size="8" fill="#546e7a">(Service &#x00B7; ExternalName)</text>
+
+  <!-- greeter-keda-upstream -->
+  <rect x="70" y="340" width="130" height="44" rx="6" fill="#fff" filter="url(#shadowSm)" stroke="#26a69a" stroke-width="1"/>
+  <text x="82" y="358" font-size="9" font-weight="600" fill="#00897b">greeter-keda-upstream</text>
+  <text x="82" y="373" font-size="8" fill="#546e7a">(Service &#x00B7; ClusterIP)</text>
+
+  <!-- greeter pod -->
+  <rect x="70" y="434" width="160" height="48" rx="8" fill="url(#componentGrad)" filter="url(#shadow)"/>
+  <text x="150" y="454" text-anchor="middle" font-size="10" font-weight="600" fill="#fff">greeter pod</text>
+  <text x="150" y="469" text-anchor="middle" font-size="8" fill="#e3f2fd">(Deployment &#x00B7; replicas 0 &#x2192; 1)</text>
+
+  <!-- upstream -> pod -->
+  <line x1="135" y1="384" x2="135" y2="428" stroke="#546e7a" stroke-width="1.5" marker-end="url(#arrowHead)"/>
+
+  <!-- ==================== namespace: keda ==================== -->
+  <rect x="400" y="204" width="340" height="196" rx="8" fill="#e0f2f1" filter="url(#shadowSm)" stroke="#80cbc4" stroke-width="1"/>
+  <text x="412" y="222" font-size="9" font-weight="600" fill="#00695c" letter-spacing="1">namespace: keda</text>
+
+  <!-- multiport Service -->
+  <rect x="420" y="236" width="160" height="44" rx="5" fill="#fff" filter="url(#shadowSm)" stroke="#26a69a" stroke-width="1"/>
+  <text x="432" y="254" font-size="9" font-weight="600" fill="#00897b">interceptor-multiport</text>
+  <text x="432" y="269" font-size="8" fill="#546e7a">(Service &#x00B7; 80, 3000, &#x2026; &#x2192; 8080)</text>
+
+  <!-- proxy Service -->
+  <rect x="590" y="236" width="144" height="44" rx="5" fill="#fff" filter="url(#shadowSm)" stroke="#26a69a" stroke-width="1"/>
+  <text x="602" y="254" font-size="9" font-weight="600" fill="#00897b">interceptor-proxy</text>
+  <text x="602" y="269" font-size="8" fill="#546e7a">(Service &#x00B7; ClusterIP :8080)</text>
+
+  <!-- Backend -> proxy Service -->
+  <line x1="661" y1="194" x2="661" y2="230" stroke="#e65100" stroke-width="1.5" marker-end="url(#arrowHeadOrange)"/>
+  <circle cx="684" cy="212" r="9" fill="#263238"/>
+  <text x="684" y="215.5" text-anchor="middle" font-size="9" font-weight="700" fill="#fff">2</text>
+  <text x="653" y="215" text-anchor="end" font-size="8" fill="#e65100">static host</text>
+
+  <!-- DNS CNAME hop across the namespace boundary -->
+  <line x1="356" y1="258" x2="414" y2="258" stroke="#3949ab" stroke-width="1.5" stroke-dasharray="4,3" marker-end="url(#arrowHeadIndigo)"/>
+  <circle cx="385" cy="240" r="9" fill="#263238"/>
+  <text x="385" y="243.5" text-anchor="middle" font-size="9" font-weight="700" fill="#fff">2</text>
+  <text x="385" y="276" text-anchor="middle" font-size="8" fill="#3949ab">DNS</text>
+
+  <!-- Interceptor -->
+  <rect x="420" y="336" width="300" height="52" rx="8" fill="url(#kedaGrad)" filter="url(#shadow)"/>
+  <text x="570" y="357" text-anchor="middle" font-size="11" font-weight="600" fill="#fff">KEDA HTTP Interceptor</text>
+  <text x="570" y="372" text-anchor="middle" font-size="8" fill="#b2dfdb">holds the request until the pod is ready</text>
+
+  <!-- multiport -> interceptor -->
+  <line x1="500" y1="280" x2="500" y2="330" stroke="#3949ab" stroke-width="1.5" marker-end="url(#arrowHeadIndigo)"/>
+  <!-- proxy -> interceptor -->
+  <line x1="661" y1="280" x2="661" y2="330" stroke="#e65100" stroke-width="1.5" marker-end="url(#arrowHeadOrange)"/>
+
+  <!-- Forward path: interceptor -> upstream -->
+  <line x1="420" y1="362" x2="206" y2="362" stroke="#546e7a" stroke-width="1.5" marker-end="url(#arrowHead)"/>
+  <circle cx="310" cy="362" r="9" fill="#263238"/>
+  <text x="310" y="365.5" text-anchor="middle" font-size="9" font-weight="700" fill="#fff">4</text>
+
+  <!-- Scale path: interceptor -> pod -->
+  <path d="M570,388 L570,458 L236,458" stroke="#00897b" stroke-width="1.2" fill="none" stroke-dasharray="4,3" marker-end="url(#arrowHeadTeal)"/>
+  <circle cx="570" cy="425" r="9" fill="#00897b"/>
+  <text x="570" y="428.5" text-anchor="middle" font-size="9" font-weight="700" fill="#fff">3</text>
+  <text x="584" y="428" font-size="8" fill="#00897b">scale 0 &#x2192; 1</text>
+</svg>

--- a/autoscaling-keda/keda-overview.svg
+++ b/autoscaling-keda/keda-overview.svg
@@ -1,0 +1,111 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 560" font-family="'Segoe UI', system-ui, -apple-system, sans-serif">
+  <defs>
+    <linearGradient id="controlPlane" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#e8eaf6"/>
+      <stop offset="100%" stop-color="#c5cae9"/>
+    </linearGradient>
+    <linearGradient id="dataPlane" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#ede7f6"/>
+      <stop offset="100%" stop-color="#d1c4e9"/>
+    </linearGradient>
+    <linearGradient id="controllerGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#5c6bc0"/>
+      <stop offset="100%" stop-color="#3949ab"/>
+    </linearGradient>
+    <filter id="shadow" x="-2%" y="-2%" width="104%" height="108%">
+      <feDropShadow dx="0" dy="2" stdDeviation="3" flood-opacity="0.12"/>
+    </filter>
+    <filter id="shadowSm" x="-2%" y="-2%" width="104%" height="108%">
+      <feDropShadow dx="0" dy="1" stdDeviation="2" flood-opacity="0.1"/>
+    </filter>
+    <marker id="arrowHead" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6 Z" fill="#546e7a"/>
+    </marker>
+  </defs>
+
+  <!-- Background -->
+  <rect width="780" height="560" rx="12" fill="#fafafa"/>
+
+  <!-- Title -->
+  <text x="390" y="36" text-anchor="middle" font-size="18" font-weight="700" fill="#263238">keda-scaling Trait &#x2014; What It Renders</text>
+  <text x="390" y="56" text-anchor="middle" font-size="11" fill="#78909c">Attach the trait on the control plane &#x00B7; the cluster-agent applies the result on the data plane</text>
+
+  <!-- ==================== CONTROL PLANE ==================== -->
+  <rect x="40" y="76" width="700" height="88" rx="8" fill="url(#controlPlane)" filter="url(#shadow)" stroke="#9fa8da" stroke-width="1"/>
+  <text x="52" y="94" font-size="9" font-weight="600" fill="#3949ab" letter-spacing="1">CONTROL PLANE</text>
+
+  <!-- Component card -->
+  <rect x="52" y="104" width="210" height="46" rx="5" fill="#fff" filter="url(#shadowSm)" stroke="#9fa8da" stroke-width="1"/>
+  <text x="64" y="122" font-size="9" font-weight="600" fill="#3949ab">Component</text>
+  <text x="64" y="137" font-size="8" fill="#546e7a">spec.traits: keda-scaling</text>
+
+  <!-- Controllers box -->
+  <rect x="330" y="104" width="220" height="46" rx="5" fill="url(#controllerGrad)" filter="url(#shadowSm)"/>
+  <text x="440" y="123" text-anchor="middle" font-size="11" font-weight="600" fill="#fff">OpenChoreo Controllers</text>
+  <text x="440" y="137" text-anchor="middle" font-size="8" fill="#c5cae9">render CEL templates + patches</text>
+
+  <!-- ClusterTrait card -->
+  <rect x="598" y="104" width="130" height="46" rx="5" fill="#fff" filter="url(#shadowSm)" stroke="#9fa8da" stroke-width="1"/>
+  <text x="610" y="122" font-size="9" font-weight="600" fill="#3949ab">ClusterTrait</text>
+  <text x="610" y="137" font-size="8" fill="#546e7a">keda-scaling</text>
+
+  <!-- Arrows within control plane -->
+  <line x1="262" y1="127" x2="327" y2="127" stroke="#546e7a" stroke-width="1.5" marker-end="url(#arrowHead)"/>
+  <line x1="598" y1="127" x2="553" y2="127" stroke="#546e7a" stroke-width="1" stroke-dasharray="4,3" marker-end="url(#arrowHead)"/>
+
+  <!-- Arrow: Control Plane -> Data Plane -->
+  <line x1="440" y1="150" x2="440" y2="200" stroke="#546e7a" stroke-width="1.5" marker-end="url(#arrowHead)"/>
+  <text x="452" y="182" font-size="8" fill="#78909c">cluster-agent applies (outbound wss)</text>
+
+  <!-- ==================== DATA PLANE ==================== -->
+  <rect x="40" y="204" width="700" height="296" rx="8" fill="url(#dataPlane)" filter="url(#shadow)" stroke="#b39ddb" stroke-width="1"/>
+  <text x="52" y="222" font-size="9" font-weight="600" fill="#4527a0" letter-spacing="1">DATA PLANE</text>
+
+  <!-- Column divider -->
+  <line x1="496" y1="236" x2="496" y2="476" stroke="#b39ddb" stroke-width="1" stroke-dasharray="4,4"/>
+
+  <!-- ===== Left column: HTTP mode ===== -->
+  <text x="52" y="245" font-size="9" font-weight="600" fill="#00695c" letter-spacing="0.5">HTTP MODE &#x00B7; no trigger.type</text>
+
+  <rect x="52" y="254" width="210" height="44" rx="5" fill="#fff" filter="url(#shadowSm)" stroke="#26a69a" stroke-width="1"/>
+  <text x="64" y="271" font-size="9" font-weight="600" fill="#00897b">InterceptorRoute</text>
+  <text x="64" y="285" font-size="8" fill="#546e7a">Host &#x2192; upstream &#x00B7; request-rate metric</text>
+
+  <rect x="274" y="254" width="210" height="44" rx="5" fill="#fff" filter="url(#shadowSm)" stroke="#26a69a" stroke-width="1"/>
+  <text x="286" y="271" font-size="9" font-weight="600" fill="#00897b">ScaledObject</text>
+  <text x="286" y="285" font-size="8" fill="#546e7a">external-push &#x2190; interceptor scaler</text>
+
+  <rect x="52" y="308" width="210" height="44" rx="5" fill="#fff" filter="url(#shadowSm)" stroke="#7e57c2" stroke-width="1"/>
+  <text x="64" y="325" font-size="9" font-weight="600" fill="#5e35b1">Backend (kgateway)</text>
+  <text x="64" y="339" font-size="8" fill="#546e7a">static host &#x2192; interceptor proxy</text>
+
+  <rect x="274" y="308" width="210" height="44" rx="5" fill="#fff" filter="url(#shadowSm)" stroke="#26a69a" stroke-width="1"/>
+  <text x="286" y="325" font-size="9" font-weight="600" fill="#00897b">Service &#x2039;comp&#x203A;-keda-upstream</text>
+  <text x="286" y="339" font-size="8" fill="#546e7a">ClusterIP &#x2192; the component's pods</text>
+
+  <text x="52" y="376" font-size="8" font-weight="600" fill="#4527a0" letter-spacing="1">PATCHES</text>
+  <rect x="52" y="384" width="432" height="24" rx="4" fill="#e0f2f1" stroke="#80cbc4" stroke-width="0.5"/>
+  <text x="62" y="399" font-size="8" fill="#00695c">Deployment &#x2014; spec.replicas removed &#x00B7; KEDA owns the replica count</text>
+  <rect x="52" y="416" width="432" height="24" rx="4" fill="#e0f2f1" stroke="#80cbc4" stroke-width="0.5"/>
+  <text x="62" y="431" font-size="8" fill="#00695c">HTTPRoute &#x2014; backendRef &#x2192; Backend &#x00B7; adds 120s timeout + Host rewrite</text>
+  <rect x="52" y="448" width="432" height="24" rx="4" fill="#e0f2f1" stroke="#80cbc4" stroke-width="0.5"/>
+  <text x="62" y="463" font-size="8" fill="#00695c">Service &#x2014; type &#x2192; ExternalName &#x00B7; points at the interceptor multiport</text>
+
+  <!-- ===== Right column: Trigger mode ===== -->
+  <text x="512" y="245" font-size="9" font-weight="600" fill="#00695c" letter-spacing="0.5">TRIGGER MODE &#x00B7; trigger.type set</text>
+
+  <rect x="512" y="254" width="216" height="44" rx="5" fill="#fff" filter="url(#shadowSm)" stroke="#26a69a" stroke-width="1"/>
+  <text x="524" y="271" font-size="9" font-weight="600" fill="#00897b">ScaledObject</text>
+  <text x="524" y="285" font-size="8" fill="#546e7a">cron &#x00B7; kafka &#x00B7; rabbitmq &#x00B7; any scaler</text>
+
+  <text x="512" y="322" font-size="8" fill="#78909c">trigger.type and trigger.metadata pass</text>
+  <text x="512" y="335" font-size="8" fill="#78909c">straight through to the ScaledObject,</text>
+  <text x="512" y="348" font-size="8" fill="#78909c">so every KEDA scaler works.</text>
+
+  <text x="512" y="376" font-size="8" font-weight="600" fill="#4527a0" letter-spacing="1">PATCHES</text>
+  <rect x="512" y="384" width="216" height="24" rx="4" fill="#e0f2f1" stroke="#80cbc4" stroke-width="0.5"/>
+  <text x="522" y="399" font-size="8" fill="#00695c">Deployment &#x2014; spec.replicas removed</text>
+
+  <!-- Footer -->
+  <text x="390" y="536" text-anchor="middle" font-size="10" fill="#90a4ae">Attaching the trait activates it; detaching removes everything it rendered.</text>
+</svg>

--- a/autoscaling-keda/keda-scaling-trait.yaml
+++ b/autoscaling-keda/keda-scaling-trait.yaml
@@ -152,6 +152,7 @@ spec:
           rules:
             - hosts:
                 - ${metadata.componentName + "." + metadata.namespace + ".svc.cluster.local"}
+                - ${metadata.componentName + "." + metadata.namespace}
           scalingMetric:
             requestRate:
               targetValue: ${parameters.requestRateTargetValue}
@@ -228,7 +229,7 @@ spec:
         group: gateway.networking.k8s.io
         version: v1
         kind: HTTPRoute
-        where: '${parameters.trigger.type == "" && has(resource.metadata.labels) && resource.metadata.labels["openchoreo.dev/endpoint-visibility"] == "external"}'
+        where: '${parameters.trigger.type == "" && has(resource.metadata.labels) && resource.metadata.labels["openchoreo.dev/endpoint-visibility"] == "external" && resource.spec.rules.exists(r, has(r.backendRefs) && r.backendRefs.exists(b, b.name == metadata.componentName))}'
       operations:
         - op: replace
           path: /spec/rules/[*]/backendRefs/[?(@.name=='${metadata.componentName}')]
@@ -245,7 +246,7 @@ spec:
         group: gateway.networking.k8s.io
         version: v1
         kind: HTTPRoute
-        where: '${parameters.trigger.type == "" && has(resource.metadata.labels) && resource.metadata.labels["openchoreo.dev/endpoint-visibility"] == "external" && has(resource.spec.rules[0].filters) && resource.spec.rules[0].filters.exists(f, f.type == "URLRewrite")}'
+        where: '${parameters.trigger.type == "" && has(resource.metadata.labels) && resource.metadata.labels["openchoreo.dev/endpoint-visibility"] == "external" && resource.spec.rules.exists(r, has(r.backendRefs) && r.backendRefs.exists(b, b.name == metadata.componentName)) && has(resource.spec.rules[0].filters) && resource.spec.rules[0].filters.exists(f, f.type == "URLRewrite")}'
       operations:
         - op: add
           path: /spec/rules/[*]/filters/[?(@.type=='URLRewrite')]/urlRewrite/hostname
@@ -255,7 +256,7 @@ spec:
         group: gateway.networking.k8s.io
         version: v1
         kind: HTTPRoute
-        where: '${parameters.trigger.type == "" && has(resource.metadata.labels) && resource.metadata.labels["openchoreo.dev/endpoint-visibility"] == "external" && !(has(resource.spec.rules[0].filters) && resource.spec.rules[0].filters.exists(f, f.type == "URLRewrite"))}'
+        where: '${parameters.trigger.type == "" && has(resource.metadata.labels) && resource.metadata.labels["openchoreo.dev/endpoint-visibility"] == "external" && resource.spec.rules.exists(r, has(r.backendRefs) && r.backendRefs.exists(b, b.name == metadata.componentName)) && !(has(resource.spec.rules[0].filters) && resource.spec.rules[0].filters.exists(f, f.type == "URLRewrite"))}'
       operations:
         - op: add
           path: /spec/rules/[*]/filters/-

--- a/gateway-wso2-api-platform/README.md
+++ b/gateway-wso2-api-platform/README.md
@@ -437,6 +437,10 @@ The trait uses OpenChoreo's template rendering pipeline to:
 
 4. **Patch the HTTPRoute URL rewrite** — Updates the `URLRewrite` filter's `replacePrefixMatch` to use the derived API context path (`/<environment>-<namespace>-<componentName>`), ensuring the WSO2 router receives the correct path prefix to match the `RestApi` configuration.
 
+#### Composing with KEDA scale-to-zero
+
+The `api-management` trait can share a component with the `keda-scaling` trait (the `autoscaling-keda` module), giving a service both WSO2 API management and scale-to-zero. Because both traits repoint the HTTPRoute `backendRef`, list `api-management` **before** `keda-scaling` in `spec.traits`: `api-management` takes the edge route through the WSO2 router, and `keda-scaling` detects it no longer owns the route, skips its own edge patch, and wires its interceptor behind the component's Service so the WSO2 router's upstream call wakes the pod. Traffic flows kgateway -> WSO2 router -> component ExternalName -> KEDA interceptor -> pod, and the API policies (rate limiting, auth, headers) still apply. See the autoscaling-keda module's `CONFIGURATION.md` ("Composing with an API gateway trait") for the details.
+
 #### Key Differences from Other Gateway Modules
 
 | Feature           | Kong                    | Envoy Gateway                    | Traefik                       | WSO2 API Platform                                                                            |


### PR DESCRIPTION
## What

Two changes to `autoscaling-keda`:

1. **Compose `keda-scaling` with an edge API-management trait** (e.g. `api-management` from `gateway-wso2-api-platform`). Both traits repoint the external HTTPRoute backendRef, so attaching both previously made the second one fail with `RenderingFailed`. keda's three HTTPRoute patches are now guarded on the route still carrying a backendRef named after the component: when an edge trait listed ahead of keda already owns the route, keda skips the edge-route patches and keeps only its Service->ExternalName wiring. The InterceptorRoute also registers the two-label host `<component>.<namespace>` alongside the FQDN, because an edge gateway calls the upstream by that authority. Requires listing the API-gateway trait before `keda-scaling` in `spec.traits`; wrong order fails loudly at render time.

2. **README rework with diagrams.** Two SVGs in the style of the gateway modules: what the trait renders in each mode, and the HTTP wake flow showing the gateway and in-cluster paths meeting at the interceptor, with cluster and namespace boundaries. Also fixes the scale-to-zero timing claim (request-rate window + `cooldownPeriod`, ~90s with the sample's settings, not ~30s) and slims the composing section down to a pointer at CONFIGURATION.md. A follow-up commit dedupes the two docs: the Limitations list and the ReleaseBinding override example now live in one place each, and the README front-matter no longer repeats the Install steps.

## Verified

- End-to-end on a k3d cluster (latest-dev): one component with `api-management` + `keda-scaling` gets WSO2 rate limiting and scale-to-zero together; wake through the full chain (edge gateway -> WSO2 -> ExternalName -> interceptor -> pod) works, as do plain gateway and in-cluster wakes.
- Standalone `keda-scaling` is unaffected: the new `where` guards are a no-op when no edge trait is attached.
- Both SVGs render correctly on GitHub and in the docs.

## Open

- The trait ordering rule is conventional, not enforced; a wrong order fails at render time with the gateway trait's zero-match error rather than silently misrouting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced HTTP interceptor route matching to recognize both full service DNS names and shorter gateway-style hostnames.
  * Improved protection when sharing HTTPRoute endpoints with an API gateway by more selectively applying route rewrites.

* **Documentation**
  * Updated HTTP mode “How it works” guidance with clarified wake-up behavior, rendered-object diagrams, and revised cooldown timing.
  * Added guidance for composing the scaling trait with an API gateway, including required trait ordering and route ownership expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


Closes https://github.com/openchoreo/openchoreo/issues/3104