### PR TITLE
feat(agent-sandbox): add ai-agent-openclaw and ai-agent-claude component types

### DIFF
--- a/agent-sandbox/README.md
+++ b/agent-sandbox/README.md
@@ -27,7 +27,7 @@ HTTP via the annotation URL.
 
 | Component type | Template | Notes |
 |---|---|---|
-| `ai-agent-openclaw` | `templates/create-ai-agent-openclaw.yaml` | Multi-provider OpenClaw agent on a fixed image, always kata-isolated. Prompts for an LLM provider + model, injects the provider's API key env var, optionally sets a gateway token (`OPENCLAW_GATEWAY_TOKEN`) to gate access to the Control UI — falls back to a built-in default if left blank, and mounts `openclaw.json` (via `OPENCLAW_CONFIG_PATH`) to set the default model — usable without `openclaw setup`. |
+| `ai-agent-openclaw` | `templates/create-ai-agent-openclaw.yaml` | Multi-provider OpenClaw agent on a fixed image, always kata-isolated. Prompts for an LLM provider + model, injects the provider's API key env var, requires a gateway token (`OPENCLAW_GATEWAY_TOKEN`) to gate access to the Control UI, and mounts `openclaw.json` (via `OPENCLAW_CONFIG_PATH`) to set the default model — usable without `openclaw setup`. |
 | `ai-agent-claude` | `templates/create-ai-agent-claude.yaml` | Claude Code CLI on the fixed [`docker/sandbox-templates:claude-code`](https://docs.docker.com/ai/sandboxes/agents/claude-code/) image, always kata-isolated. Prompts for an Anthropic model + API key; injects `ANTHROPIC_MODEL` and `ANTHROPIC_API_KEY`. Terminal-only — no HTTP endpoint; the pod runs `sleep infinity` and you attach with `kubectl exec -it <pod> -- claude`. |
 
 ## Upstream CRDs installed

--- a/agent-sandbox/README.md
+++ b/agent-sandbox/README.md
@@ -9,6 +9,26 @@ This module installs the [kubernetes-sigs/agent-sandbox](https://github.com/kube
 - Installs the upstream `kubernetes-sigs/agent-sandbox` controller and CRDs on the data plane cluster via a Helm pre-install hook
 - Grants the data plane `cluster-agent` service account permissions to manage `SandboxTemplate`, `SandboxClaim`, `SandboxWarmPool`, and `Sandbox` resources
 - Registers the `ai-agent` ClusterComponentType (`proxy/ai-agent`) that renders sandbox resources via the standard OpenChoreo pipeline; this module provides the upstream controller that fulfills them on the data plane
+- Bundles agent-specific ClusterComponentTypes with custom portal scaffolder templates (see below)
+
+## Bundled agent component types
+
+In addition to the generic `ai-agent` type, this module ships agent-specific
+`ClusterComponentType`s that reference a fixed, pre-built agent image and a
+tailored Backstage scaffolder template. Each such CCT carries a
+`scaffolder.openchoreo.dev/backstage-template-url` annotation; when the portal
+detects it, it fetches that custom template (which omits the irrelevant Build &
+Deploy steps) instead of auto-generating one.
+
+The `ClusterComponentType` ships in the Helm chart (`helm/templates/`) and is
+applied to the cluster on install. The scaffolder template lives under
+`agent-sandbox/templates/<name>.yaml` (outside the chart) and is served raw over
+HTTP via the annotation URL.
+
+| Component type | Template | Notes |
+|---|---|---|
+| `ai-agent-openclaw` | `templates/create-ai-agent-openclaw.yaml` | Multi-provider OpenClaw agent on a fixed image, always kata-isolated. Prompts for an LLM provider + model, injects the provider's API key env var, optionally sets a gateway token (`OPENCLAW_GATEWAY_TOKEN`) to gate access to the Control UI — falls back to a built-in default if left blank, and mounts `openclaw.json` (via `OPENCLAW_CONFIG_PATH`) to set the default model — usable without `openclaw setup`. |
+| `ai-agent-claude` | `templates/create-ai-agent-claude.yaml` | Claude Code CLI on the fixed [`docker/sandbox-templates:claude-code`](https://docs.docker.com/ai/sandboxes/agents/claude-code/) image, always kata-isolated. Prompts for an Anthropic model + API key; injects `ANTHROPIC_MODEL` and `ANTHROPIC_API_KEY`. Terminal-only — no HTTP endpoint; the pod runs `sleep infinity` and you attach with `kubectl exec -it <pod> -- claude`. |
 
 ## Upstream CRDs installed
 

--- a/agent-sandbox/helm/templates/ai-agent-claude-clustercomponenttype.yaml
+++ b/agent-sandbox/helm/templates/ai-agent-claude-clustercomponenttype.yaml
@@ -1,0 +1,144 @@
+apiVersion: openchoreo.dev/v1alpha1
+kind: ClusterComponentType
+metadata:
+  name: ai-agent-claude
+  annotations:
+    openchoreo.dev/display-name: "AI Agent — Claude Code"
+    openchoreo.dev/description: "Claude Code CLI running in a kernel-isolated sandbox."
+    # Portal fetches this custom scaffolder template instead of auto-generating Build & Deploy steps.
+    scaffolder.openchoreo.dev/backstage-template-url: "https://github.com/openchoreo/community-modules/blob/main/agent-sandbox/templates/create-ai-agent-claude.yaml"
+spec:
+  # Fixed image, kata isolation, terminal-only — no user-tunable parameters.
+  workloadType: proxy
+
+  environmentConfigs:
+    openAPIV3Schema:
+      type: object
+      $defs:
+        ResourceQuantity:
+          type: object
+          default: {}
+          properties:
+            cpu:
+              type: string
+              default: "500m"
+            memory:
+              type: string
+              default: "1Gi"
+        ResourceRequirements:
+          type: object
+          properties:
+            requests:
+              $ref: "#/$defs/ResourceQuantity"
+            limits:
+              $ref: "#/$defs/ResourceQuantity"
+          default: {}
+      properties:
+        resources:
+          $ref: "#/$defs/ResourceRequirements"
+        imagePullPolicy:
+          type: string
+          default: IfNotPresent
+          enum:
+            - Always
+            - IfNotPresent
+            - Never
+
+  resources:
+    # ── SandboxTemplate ──────────────────────────────────────────────────
+    - id: sandbox-template
+      template:
+        apiVersion: extensions.agents.x-k8s.io/v1alpha1
+        kind: SandboxTemplate
+        metadata:
+          name: ${metadata.name}
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+          annotations:
+            openchoreo.dev/sandbox-policy: development
+        spec:
+          podTemplate:
+            metadata:
+              labels: ${metadata.podSelectors}
+            spec:
+              automountServiceAccountToken: false
+              runtimeClassName: kata-qemu
+              nodeSelector:
+                kata-enabled: "true"
+              tolerations:
+                - key: sandbox
+                  operator: Equal
+                  value: "true"
+                  effect: NoSchedule
+              containers:
+                - name: main
+                  image: ${workload.container.image}
+                  imagePullPolicy: ${environmentConfigs.imagePullPolicy}
+                  # `claude` is interactive and exits without a TTY; keep the pod alive for exec.
+                  command: ["sleep", "infinity"]
+                  resources:
+                    requests:
+                      cpu: ${environmentConfigs.resources.requests.cpu}
+                      memory: ${environmentConfigs.resources.requests.memory}
+                    limits:
+                      cpu: ${environmentConfigs.resources.limits.cpu}
+                      memory: ${environmentConfigs.resources.limits.memory}
+                  env: ${dependencies.toContainerEnvs()}
+                  envFrom: ${configurations.toContainerEnvFrom()}
+                  volumeMounts: ${configurations.toContainerVolumeMounts()}
+              volumes: ${configurations.toVolumes()}
+
+    # ── SandboxClaim ─────────────────────────────────────────────────────
+    - id: sandbox-claim
+      template:
+        apiVersion: extensions.agents.x-k8s.io/v1alpha1
+        kind: SandboxClaim
+        metadata:
+          name: ${metadata.name}
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+          annotations:
+            openchoreo.dev/sandbox-policy: development
+        spec:
+          sandboxTemplateRef:
+            name: ${metadata.name}
+
+    # ── ConfigMap: plain env vars (e.g. ANTHROPIC_MODEL) ─────────────────
+    - id: env-config
+      forEach: ${configurations.toConfigEnvsByContainer()}
+      var: envConfig
+      template:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: ${envConfig.resourceName}
+          namespace: ${metadata.namespace}
+        data: |
+          ${envConfig.envs.transformMapEntry(index, env, {env.name: env.value})}
+
+    # ── ExternalSecret: ANTHROPIC_API_KEY injected as an env var ─────────
+    - id: secret-env-external
+      forEach: ${configurations.toSecretEnvsByContainer()}
+      var: secretEnv
+      template:
+        apiVersion: external-secrets.io/v1
+        kind: ExternalSecret
+        metadata:
+          name: ${secretEnv.resourceName}
+          namespace: ${metadata.namespace}
+        spec:
+          refreshInterval: 15s
+          secretStoreRef:
+            name: ${dataplane.secretStore}
+            kind: ClusterSecretStore
+          target:
+            name: ${secretEnv.resourceName}
+            creationPolicy: Owner
+          data: |
+            ${secretEnv.envs.map(secret, {
+              "secretKey": secret.name,
+              "remoteRef": {
+                "key": secret.remoteRef.key,
+                ?"property": secret.remoteRef.?property
+              }
+            })}

--- a/agent-sandbox/helm/templates/ai-agent-claude-clustercomponenttype.yaml
+++ b/agent-sandbox/helm/templates/ai-agent-claude-clustercomponenttype.yaml
@@ -6,7 +6,7 @@ metadata:
     openchoreo.dev/display-name: "AI Agent — Claude Code"
     openchoreo.dev/description: "Claude Code CLI running in a kernel-isolated sandbox."
     # Portal fetches this custom scaffolder template instead of auto-generating Build & Deploy steps.
-    scaffolder.openchoreo.dev/backstage-template-url: "https://github.com/openchoreo/community-modules/blob/main/agent-sandbox/templates/create-ai-agent-claude.yaml"
+    scaffolder.openchoreo.dev/backstage-template-url: "https://raw.githubusercontent.com/openchoreo/community-modules/main/agent-sandbox/templates/create-ai-agent-claude.yaml"
 spec:
   # Fixed image, kata isolation, terminal-only — no user-tunable parameters.
   workloadType: proxy

--- a/agent-sandbox/helm/templates/ai-agent-openclaw-clustercomponenttype.yaml
+++ b/agent-sandbox/helm/templates/ai-agent-openclaw-clustercomponenttype.yaml
@@ -6,7 +6,7 @@ metadata:
     openchoreo.dev/display-name: "AI Agent — OpenClaw"
     openchoreo.dev/description: "Multi-provider OpenClaw AI agent in a kernel-isolated sandbox."
     # Portal fetches this custom scaffolder template instead of auto-generating Build & Deploy steps.
-    scaffolder.openchoreo.dev/backstage-template-url: "https://github.com/openchoreo/community-modules/blob/main/agent-sandbox/templates/create-ai-agent-openclaw.yaml"
+    scaffolder.openchoreo.dev/backstage-template-url: "https://raw.githubusercontent.com/openchoreo/community-modules/main/agent-sandbox/templates/create-ai-agent-openclaw.yaml"
 spec:
   # Fixed image, kata isolation, egress allowed — no user-tunable parameters.
   workloadType: proxy

--- a/agent-sandbox/helm/templates/ai-agent-openclaw-clustercomponenttype.yaml
+++ b/agent-sandbox/helm/templates/ai-agent-openclaw-clustercomponenttype.yaml
@@ -1,0 +1,210 @@
+apiVersion: openchoreo.dev/v1alpha1
+kind: ClusterComponentType
+metadata:
+  name: ai-agent-openclaw
+  annotations:
+    openchoreo.dev/display-name: "AI Agent — OpenClaw"
+    openchoreo.dev/description: "Multi-provider OpenClaw AI agent in a kernel-isolated sandbox."
+    # Portal fetches this custom scaffolder template instead of auto-generating Build & Deploy steps.
+    scaffolder.openchoreo.dev/backstage-template-url: "https://github.com/openchoreo/community-modules/blob/main/agent-sandbox/templates/create-ai-agent-openclaw.yaml"
+spec:
+  # Fixed image, kata isolation, egress allowed — no user-tunable parameters.
+  workloadType: proxy
+
+  validations:
+    - rule: >-
+        ${workload.endpoints.exists(name, ep, "external" in ep.visibility)
+          ? has(gateway.ingress) && has(gateway.ingress.external)
+          : true}
+      message: "Endpoints with 'external' visibility require gateway.ingress.external to be configured on the Environment or DataPlane."
+
+  environmentConfigs:
+    openAPIV3Schema:
+      type: object
+      $defs:
+        ResourceQuantity:
+          type: object
+          default: {}
+          properties:
+            cpu:
+              type: string
+              default: "500m"
+            memory:
+              type: string
+              default: "1Gi"
+        ResourceRequirements:
+          type: object
+          properties:
+            requests:
+              $ref: "#/$defs/ResourceQuantity"
+            limits:
+              $ref: "#/$defs/ResourceQuantity"
+          default: {}
+      properties:
+        resources:
+          $ref: "#/$defs/ResourceRequirements"
+        imagePullPolicy:
+          type: string
+          default: IfNotPresent
+          enum:
+            - Always
+            - IfNotPresent
+            - Never
+
+  resources:
+    # ── SandboxTemplate ──────────────────────────────────────────────────
+    - id: sandbox-template
+      template:
+        apiVersion: extensions.agents.x-k8s.io/v1alpha1
+        kind: SandboxTemplate
+        metadata:
+          name: ${metadata.name}
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+          annotations:
+            openchoreo.dev/sandbox-policy: development
+        spec:
+          podTemplate:
+            metadata:
+              labels: ${metadata.podSelectors}
+            spec:
+              automountServiceAccountToken: false
+              runtimeClassName: kata-qemu
+              nodeSelector:
+                kata-enabled: "true"
+              tolerations:
+                - key: sandbox
+                  operator: Equal
+                  value: "true"
+                  effect: NoSchedule
+              containers:
+                - name: main
+                  image: ${workload.container.image}
+                  imagePullPolicy: ${environmentConfigs.imagePullPolicy}
+                  command: |
+                    ${has(workload.container.command) ? workload.container.command : oc_omit()}
+                  args: |
+                    ${has(workload.container.args) ? workload.container.args : oc_omit()}
+                  resources:
+                    requests:
+                      cpu: ${environmentConfigs.resources.requests.cpu}
+                      memory: ${environmentConfigs.resources.requests.memory}
+                    limits:
+                      cpu: ${environmentConfigs.resources.limits.cpu}
+                      memory: ${environmentConfigs.resources.limits.memory}
+                  env: ${dependencies.toContainerEnvs()}
+                  envFrom: ${configurations.toContainerEnvFrom()}
+                  volumeMounts: ${configurations.toContainerVolumeMounts()}
+              volumes: ${configurations.toVolumes()}
+
+    # ── SandboxClaim ─────────────────────────────────────────────────────
+    - id: sandbox-claim
+      template:
+        apiVersion: extensions.agents.x-k8s.io/v1alpha1
+        kind: SandboxClaim
+        metadata:
+          name: ${metadata.name}
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+          annotations:
+            openchoreo.dev/sandbox-policy: development
+        spec:
+          sandboxTemplateRef:
+            name: ${metadata.name}
+
+    # ── Service (Control UI port, only when endpoints are defined) ────────
+    - id: service
+      includeWhen: ${size(workload.endpoints) > 0}
+      template:
+        apiVersion: v1
+        kind: Service
+        metadata:
+          name: ${metadata.componentName}
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+        spec:
+          type: ClusterIP
+          selector: ${metadata.podSelectors}
+          ports: ${workload.toServicePorts()}
+
+    # ── HTTPRoute: routes the Control UI through the external gateway ─────
+    - id: httproute-external
+      forEach: '${workload.endpoints.transformMap(name, ep, "external" in ep.visibility && ep.type in ["HTTP", "GraphQL", "Websocket"], ep)}'
+      var: endpoint
+      template:
+        apiVersion: gateway.networking.k8s.io/v1
+        kind: HTTPRoute
+        metadata:
+          name: ${oc_generate_name(metadata.componentName, endpoint.key)}
+          namespace: ${metadata.namespace}
+          labels: '${oc_merge(metadata.labels, {"openchoreo.dev/endpoint-name": endpoint.key, "openchoreo.dev/endpoint-visibility": "external"})}'
+        spec:
+          parentRefs:
+            - name: ${gateway.ingress.external.name}
+              namespace: ${gateway.ingress.external.namespace}
+          hostnames: |
+            ${[gateway.ingress.external.?http, gateway.ingress.external.?https]
+              .filter(g, g.hasValue()).map(g, g.value().host).distinct()
+              .map(h, metadata.componentName + "-" + metadata.environmentName + "-" + metadata.componentNamespace + "." + h)}
+          rules:
+          - matches:
+            - path:
+                type: PathPrefix
+                value: /
+            backendRefs:
+            - name: ${metadata.componentName}
+              port: ${endpoint.value.port}
+
+    # ── ConfigMap: plain env vars from the Configuration API ─────────────
+    - id: env-config
+      forEach: ${configurations.toConfigEnvsByContainer()}
+      var: envConfig
+      template:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: ${envConfig.resourceName}
+          namespace: ${metadata.namespace}
+        data: |
+          ${envConfig.envs.transformMapEntry(index, env, {env.name: env.value})}
+
+    # ── ConfigMap: file mounts, e.g. ~/.openclaw/openclaw.json ───────────
+    - id: file-config
+      forEach: ${configurations.toConfigFileList()}
+      var: config
+      template:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: ${config.resourceName}
+          namespace: ${metadata.namespace}
+        data:
+          ${config.name}: |
+            ${config.value}
+
+    # ── ExternalSecret: LLM provider API keys injected as env vars ───────
+    - id: secret-env-external
+      forEach: ${configurations.toSecretEnvsByContainer()}
+      var: secretEnv
+      template:
+        apiVersion: external-secrets.io/v1
+        kind: ExternalSecret
+        metadata:
+          name: ${secretEnv.resourceName}
+          namespace: ${metadata.namespace}
+        spec:
+          refreshInterval: 15s
+          secretStoreRef:
+            name: ${dataplane.secretStore}
+            kind: ClusterSecretStore
+          target:
+            name: ${secretEnv.resourceName}
+            creationPolicy: Owner
+          data: |
+            ${secretEnv.envs.map(secret, {
+              "secretKey": secret.name,
+              "remoteRef": {
+                "key": secret.remoteRef.key,
+                ?"property": secret.remoteRef.?property
+              }
+            })}

--- a/agent-sandbox/templates/create-ai-agent-claude.yaml
+++ b/agent-sandbox/templates/create-ai-agent-claude.yaml
@@ -1,0 +1,99 @@
+apiVersion: scaffolder.backstage.io/v1beta3
+kind: Template
+metadata:
+  name: create-ai-agent-claude
+  title: Claude Code Agent
+  description: Run Claude Code interactively in a kernel-isolated sandbox.
+  tags:
+    - openchoreo
+    - ai-agent
+    - claude
+spec:
+  type: Component
+  owner: openchoreo
+
+  # Injects the logged-in user's token so the create action authorizes as them.
+  EXPERIMENTAL_formDecorators:
+    - id: openchoreo:inject-user-token
+
+  parameters:
+    - title: Component Metadata
+      required:
+        - project_namespace
+        - name
+      properties:
+        project_namespace:
+          title: Project & Namespace
+          type: object
+          description: The OpenChoreo project and namespace to create the component in.
+          ui:field: ProjectNamespaceField
+        name:
+          title: Component Name
+          type: string
+          description: A unique name for the component (lowercase, DNS-compatible).
+          pattern: "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+          maxLength: 63
+          ui:autofocus: true
+        displayName:
+          title: Display Name
+          type: string
+          description: A human-friendly name shown in the portal.
+        description:
+          title: Description
+          type: string
+          description: A short description of what this agent does.
+
+    - title: Agent Configuration
+      required:
+        - model
+        - anthropicApiKey
+      properties:
+        model:
+          title: Model
+          type: string
+          description: The Anthropic model Claude Code runs on (ANTHROPIC_MODEL env var).
+          default: claude-sonnet-4-6
+          enum:
+            - claude-opus-4-8
+            - claude-sonnet-4-6
+            - claude-haiku-4-5
+          enumNames:
+            - Claude Opus 4.8
+            - Claude Sonnet 4.6
+            - Claude Haiku 4.5
+        anthropicApiKey:
+          title: Anthropic API Key
+          type: string
+          description: The Anthropic API key Claude Code uses (ANTHROPIC_API_KEY).
+          ui:field: Secret
+
+  steps:
+    - id: create-component
+      name: Create Component
+      action: openchoreo:component:create
+      input:
+        projectName: ${{ parameters.project_namespace.project_name }}
+        namespaceName: ${{ parameters.project_namespace.namespace_name }}
+        componentName: ${{ parameters.name }}
+        displayName: ${{ parameters.displayName }}
+        description: ${{ parameters.description }}
+        componentType: ai-agent-claude
+        component_type_kind: ClusterComponentType
+        component_type_workload_type: proxy
+        # Must be deploy-from-image, or the action drops the image and env vars.
+        deploymentSource: deploy-from-image
+        containerImage: docker/sandbox-templates:claude-code
+        autoDeploy: true
+        # Terminal-only: no endpoints. Reach it with `kubectl exec -it <pod> -- claude`.
+        workloadDetails:
+          envVars:
+            - key: ANTHROPIC_API_KEY
+              value: ${{ secrets.anthropicApiKey }}
+            - key: ANTHROPIC_MODEL
+              value: ${{ parameters.model }}
+
+  output:
+    links:
+      - title: View Component
+        icon: kind:component
+        entityRef: component:${{ steps['create-component'].output.namespaceName }}/${{ steps['create-component'].output.componentName }}

--- a/agent-sandbox/templates/create-ai-agent-openclaw.yaml
+++ b/agent-sandbox/templates/create-ai-agent-openclaw.yaml
@@ -47,6 +47,7 @@ spec:
       required:
         - llmProvider
         - llmApiKey
+        - gatewayToken
       properties:
         llmProvider:
           title: LLM Provider
@@ -71,7 +72,7 @@ spec:
         gatewayToken:
           title: Gateway Token
           type: string
-          description: Token used to authenticate access to OpenClaw's Control UI. Leave blank to use the built-in default.
+          description: Token used to authenticate access to OpenClaw's Control UI.
           ui:field: Secret
       # Each branch sets the hidden provider key env var (Gemini's is GEMINI_API_KEY).
       dependencies:
@@ -169,7 +170,7 @@ spec:
             - key: ${{ parameters.apiKeyEnvVar }}
               value: ${{ secrets.llmApiKey }}
             - key: OPENCLAW_GATEWAY_TOKEN
-              value: ${{ secrets.gatewayToken | default('openclaw-changeme', true) }}
+              value: ${{ secrets.gatewayToken }}
             # Read-only mounted config; don't mount over ~/.openclaw runtime state or startup breaks.
             - key: OPENCLAW_CONFIG_PATH
               value: /etc/openclaw/openclaw.json

--- a/agent-sandbox/templates/create-ai-agent-openclaw.yaml
+++ b/agent-sandbox/templates/create-ai-agent-openclaw.yaml
@@ -1,0 +1,194 @@
+apiVersion: scaffolder.backstage.io/v1beta3
+kind: Template
+metadata:
+  name: create-ai-agent-openclaw
+  title: OpenClaw AI Agent
+  description: Run the multi-provider OpenClaw agent in a kernel-isolated sandbox.
+  tags:
+    - openchoreo
+    - ai-agent
+    - openclaw
+spec:
+  type: Component
+  owner: openchoreo
+
+  # Injects the logged-in user's token so the create action authorizes as them.
+  EXPERIMENTAL_formDecorators:
+    - id: openchoreo:inject-user-token
+
+  parameters:
+    - title: Component Metadata
+      required:
+        - project_namespace
+        - name
+      properties:
+        project_namespace:
+          title: Project & Namespace
+          type: object
+          description: The OpenChoreo project and namespace to create the component in.
+          ui:field: ProjectNamespaceField
+        name:
+          title: Component Name
+          type: string
+          description: A unique name for the component (lowercase, DNS-compatible).
+          pattern: "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+          maxLength: 63
+          ui:autofocus: true
+        displayName:
+          title: Display Name
+          type: string
+          description: A human-friendly name shown in the portal.
+        description:
+          title: Description
+          type: string
+          description: A short description of what this agent does.
+
+    - title: Agent Configuration
+      required:
+        - llmProvider
+        - llmApiKey
+      properties:
+        llmProvider:
+          title: LLM Provider
+          type: string
+          description: The LLM provider OpenClaw should use.
+          default: anthropic
+          enum:
+            - anthropic
+            - openai
+            - google
+            - openrouter
+          enumNames:
+            - Anthropic (Claude)
+            - OpenAI
+            - Google Gemini
+            - OpenRouter
+        llmApiKey:
+          title: LLM Provider API Key
+          type: string
+          description: The API key for the selected provider.
+          ui:field: Secret
+        gatewayToken:
+          title: Gateway Token
+          type: string
+          description: Token used to authenticate access to OpenClaw's Control UI. Leave blank to use the built-in default.
+          ui:field: Secret
+      # Each branch sets the hidden provider key env var (Gemini's is GEMINI_API_KEY).
+      dependencies:
+        llmProvider:
+          oneOf:
+            - required: [model]
+              properties:
+                llmProvider:
+                  const: anthropic
+                apiKeyEnvVar:
+                  type: string
+                  default: ANTHROPIC_API_KEY
+                  ui:widget: hidden
+                model:
+                  title: Model
+                  type: string
+                  default: anthropic/claude-sonnet-4-6
+                  enum:
+                    - anthropic/claude-opus-4-8
+                    - anthropic/claude-sonnet-4-6
+                    - anthropic/claude-haiku-4-5
+            - required: [model]
+              properties:
+                llmProvider:
+                  const: openai
+                apiKeyEnvVar:
+                  type: string
+                  default: OPENAI_API_KEY
+                  ui:widget: hidden
+                model:
+                  title: Model
+                  type: string
+                  default: openai/gpt-5.5
+                  enum:
+                    - openai/gpt-5.5
+                    - openai/gpt-5.4-mini
+            - required: [model]
+              properties:
+                llmProvider:
+                  const: google
+                apiKeyEnvVar:
+                  type: string
+                  default: GEMINI_API_KEY
+                  ui:widget: hidden
+                model:
+                  title: Model
+                  type: string
+                  default: google/gemini-3.1-pro-preview
+                  enum:
+                    - google/gemini-3.1-pro-preview
+                    - google/gemini-3-flash-preview
+            - required: [model]
+              properties:
+                llmProvider:
+                  const: openrouter
+                apiKeyEnvVar:
+                  type: string
+                  default: OPENROUTER_API_KEY
+                  ui:widget: hidden
+                model:
+                  title: Model
+                  type: string
+                  default: openrouter/openrouter/auto
+                  enum:
+                    - openrouter/openrouter/auto
+                    - openrouter/~anthropic/claude-sonnet-latest
+                    - openrouter/deepseek/deepseek-chat
+
+  steps:
+    - id: create-component
+      name: Create Component
+      action: openchoreo:component:create
+      input:
+        projectName: ${{ parameters.project_namespace.project_name }}
+        namespaceName: ${{ parameters.project_namespace.namespace_name }}
+        componentName: ${{ parameters.name }}
+        displayName: ${{ parameters.displayName }}
+        description: ${{ parameters.description }}
+        componentType: ai-agent-openclaw
+        component_type_kind: ClusterComponentType
+        component_type_workload_type: proxy
+        # Must be deploy-from-image, or the action drops the image and env vars.
+        deploymentSource: deploy-from-image
+        containerImage: alpine/openclaw:2026.6.9
+        autoDeploy: true
+        workloadDetails:
+          # Exposes OpenClaw's token-gated Control UI (18789) via the gateway.
+          endpoints:
+            control-ui:
+              type: HTTP
+              port: 18789
+              visibility:
+                - external
+          envVars:
+            - key: ${{ parameters.apiKeyEnvVar }}
+              value: ${{ secrets.llmApiKey }}
+            - key: OPENCLAW_GATEWAY_TOKEN
+              value: ${{ secrets.gatewayToken | default('openclaw-changeme', true) }}
+            # Read-only mounted config; don't mount over ~/.openclaw runtime state or startup breaks.
+            - key: OPENCLAW_CONFIG_PATH
+              value: /etc/openclaw/openclaw.json
+          # Sets the primary model so the agent works without `openclaw setup`.
+          fileMounts:
+            - key: openclaw.json
+              mountPath: /etc/openclaw
+              value: |
+                {
+                  "gateway": { "mode": "local" },
+                  "agents": {
+                    "defaults": {
+                      "model": { "primary": "${{ parameters.model }}" }
+                    }
+                  }
+                }
+
+  output:
+    links:
+      - title: View Component
+        icon: kind:component
+        entityRef: component:${{ steps['create-component'].output.namespaceName }}/${{ steps['create-component'].output.componentName }}


### PR DESCRIPTION
## Purpose
Adds two new OpenChoreo AI-agent component types to the `agent-sandbox` module, letting portal users spin up interactive AI agents inside kernel-isolated sandboxes:

- **ai-agent-openclaw** — the multi-provider OpenClaw agent (Anthropic, OpenAI, Google, OpenRouter) with its token-gated Control UI exposed through the gateway.
- **ai-agent-claude** — Claude Code running interactively in a sandbox (terminal-only, reached via `kubectl exec`).

## Approach
- Adds `ClusterComponentType` definitions for both agents under `agent-sandbox/helm/templates/`. Both use `workloadType: proxy` and render a `SandboxTemplate` + `SandboxClaim` (kata-qemu isolation, non-mounted SA token).
- OpenClaw additionally renders a `Service`, an external `HTTPRoute`, and ConfigMap/ExternalSecret resources. Each Control UI gets its own hostname (`<component>-<env>-<namespace>.<host>`) and is served at `/` (no URL rewrite), so its root-absolute SPA loads correctly.
- Adds Backstage scaffolder templates (`agent-sandbox/templates/create-ai-agent-*.yaml`) for both, wiring model/provider selection, API-key secrets, and the OpenClaw gateway token.
- LLM provider API keys are injected via `ExternalSecret`; the OpenClaw gateway token is optional and falls back to a built-in default.

## Screen Recording

https://github.com/user-attachments/assets/2e4cf1f6-6d40-4bd1-b235-e2932668a6b0

## Related Issues
_N/A_

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [x] Samples updated (if applicable)

## Remarks
Both CCTs have been validated against a live EKS cluster (`kubectl apply`) and render successfully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Bundled AI agent component types for Claude Code and OpenClaw, delivered via the Helm chart and applied on install.
  - Added guided Backstage creation templates for both agents, including model/provider selection, API key secrets, and gateway authentication options.
  - Claude Code runs terminal-only in a kernel-isolated sandbox; OpenClaw provides an external control UI with routed HTTP access and provider-backed configuration.
  - Added standardized environment/resource configuration and secret-based environment injection for sandbox runtime.

- **Documentation**
  - Expanded README to explain the shipped component types, template sourcing, and key behavior differences between Claude Code and OpenClaw.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->