### PR TITLE
feat(agent-sandbox): add ai-agent-codex and ai-agent-gemini component types

### DIFF
--- a/agent-sandbox/helm/templates/ai-agent-codex-clustercomponenttype.yaml
+++ b/agent-sandbox/helm/templates/ai-agent-codex-clustercomponenttype.yaml
@@ -1,0 +1,144 @@
+apiVersion: openchoreo.dev/v1alpha1
+kind: ClusterComponentType
+metadata:
+  name: ai-agent-codex
+  annotations:
+    openchoreo.dev/display-name: "AI Agent — Codex"
+    openchoreo.dev/description: "OpenAI Codex CLI running in a kernel-isolated sandbox."
+    # Portal fetches this custom scaffolder template instead of auto-generating Build & Deploy steps.
+    scaffolder.openchoreo.dev/backstage-template-url: "https://raw.githubusercontent.com/openchoreo/community-modules/main/agent-sandbox/templates/create-ai-agent-codex.yaml"
+spec:
+  # Fixed image, kata isolation, terminal-only — no user-tunable parameters.
+  workloadType: proxy
+
+  environmentConfigs:
+    openAPIV3Schema:
+      type: object
+      $defs:
+        ResourceQuantity:
+          type: object
+          default: {}
+          properties:
+            cpu:
+              type: string
+              default: "500m"
+            memory:
+              type: string
+              default: "1Gi"
+        ResourceRequirements:
+          type: object
+          properties:
+            requests:
+              $ref: "#/$defs/ResourceQuantity"
+            limits:
+              $ref: "#/$defs/ResourceQuantity"
+          default: {}
+      properties:
+        resources:
+          $ref: "#/$defs/ResourceRequirements"
+        imagePullPolicy:
+          type: string
+          default: IfNotPresent
+          enum:
+            - Always
+            - IfNotPresent
+            - Never
+
+  resources:
+    # ── SandboxTemplate ──────────────────────────────────────────────────
+    - id: sandbox-template
+      template:
+        apiVersion: extensions.agents.x-k8s.io/v1alpha1
+        kind: SandboxTemplate
+        metadata:
+          name: ${metadata.name}
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+          annotations:
+            openchoreo.dev/sandbox-policy: development
+        spec:
+          podTemplate:
+            metadata:
+              labels: ${metadata.podSelectors}
+            spec:
+              automountServiceAccountToken: false
+              runtimeClassName: kata-qemu
+              nodeSelector:
+                kata-enabled: "true"
+              tolerations:
+                - key: sandbox
+                  operator: Equal
+                  value: "true"
+                  effect: NoSchedule
+              containers:
+                - name: main
+                  image: ${workload.container.image}
+                  imagePullPolicy: ${environmentConfigs.imagePullPolicy}
+                  # `codex` is interactive and exits without a TTY; keep the pod alive for exec.
+                  command: ["sleep", "infinity"]
+                  resources:
+                    requests:
+                      cpu: ${environmentConfigs.resources.requests.cpu}
+                      memory: ${environmentConfigs.resources.requests.memory}
+                    limits:
+                      cpu: ${environmentConfigs.resources.limits.cpu}
+                      memory: ${environmentConfigs.resources.limits.memory}
+                  env: ${dependencies.toContainerEnvs()}
+                  envFrom: ${configurations.toContainerEnvFrom()}
+                  volumeMounts: ${configurations.toContainerVolumeMounts()}
+              volumes: ${configurations.toVolumes()}
+
+    # ── SandboxClaim ─────────────────────────────────────────────────────
+    - id: sandbox-claim
+      template:
+        apiVersion: extensions.agents.x-k8s.io/v1alpha1
+        kind: SandboxClaim
+        metadata:
+          name: ${metadata.name}
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+          annotations:
+            openchoreo.dev/sandbox-policy: development
+        spec:
+          sandboxTemplateRef:
+            name: ${metadata.name}
+
+    # ── ConfigMap: plain env vars (e.g. OPENAI_MODEL) ────────────────────
+    - id: env-config
+      forEach: ${configurations.toConfigEnvsByContainer()}
+      var: envConfig
+      template:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: ${envConfig.resourceName}
+          namespace: ${metadata.namespace}
+        data: |
+          ${envConfig.envs.transformMapEntry(index, env, {env.name: env.value})}
+
+    # ── ExternalSecret: OPENAI_API_KEY injected as an env var ────────────
+    - id: secret-env-external
+      forEach: ${configurations.toSecretEnvsByContainer()}
+      var: secretEnv
+      template:
+        apiVersion: external-secrets.io/v1
+        kind: ExternalSecret
+        metadata:
+          name: ${secretEnv.resourceName}
+          namespace: ${metadata.namespace}
+        spec:
+          refreshInterval: 15s
+          secretStoreRef:
+            name: ${dataplane.secretStore}
+            kind: ClusterSecretStore
+          target:
+            name: ${secretEnv.resourceName}
+            creationPolicy: Owner
+          data: |
+            ${secretEnv.envs.map(secret, {
+              "secretKey": secret.name,
+              "remoteRef": {
+                "key": secret.remoteRef.key,
+                ?"property": secret.remoteRef.?property
+              }
+            })}

--- a/agent-sandbox/helm/templates/ai-agent-gemini-clustercomponenttype.yaml
+++ b/agent-sandbox/helm/templates/ai-agent-gemini-clustercomponenttype.yaml
@@ -1,0 +1,144 @@
+apiVersion: openchoreo.dev/v1alpha1
+kind: ClusterComponentType
+metadata:
+  name: ai-agent-gemini
+  annotations:
+    openchoreo.dev/display-name: "AI Agent — Gemini CLI"
+    openchoreo.dev/description: "Gemini CLI running in a kernel-isolated sandbox."
+    # Portal fetches this custom scaffolder template instead of auto-generating Build & Deploy steps.
+    scaffolder.openchoreo.dev/backstage-template-url: "https://raw.githubusercontent.com/openchoreo/community-modules/main/agent-sandbox/templates/create-ai-agent-gemini.yaml"
+spec:
+  # Fixed image, kata isolation, terminal-only — no user-tunable parameters.
+  workloadType: proxy
+
+  environmentConfigs:
+    openAPIV3Schema:
+      type: object
+      $defs:
+        ResourceQuantity:
+          type: object
+          default: {}
+          properties:
+            cpu:
+              type: string
+              default: "500m"
+            memory:
+              type: string
+              default: "1Gi"
+        ResourceRequirements:
+          type: object
+          properties:
+            requests:
+              $ref: "#/$defs/ResourceQuantity"
+            limits:
+              $ref: "#/$defs/ResourceQuantity"
+          default: {}
+      properties:
+        resources:
+          $ref: "#/$defs/ResourceRequirements"
+        imagePullPolicy:
+          type: string
+          default: IfNotPresent
+          enum:
+            - Always
+            - IfNotPresent
+            - Never
+
+  resources:
+    # ── SandboxTemplate ──────────────────────────────────────────────────
+    - id: sandbox-template
+      template:
+        apiVersion: extensions.agents.x-k8s.io/v1alpha1
+        kind: SandboxTemplate
+        metadata:
+          name: ${metadata.name}
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+          annotations:
+            openchoreo.dev/sandbox-policy: development
+        spec:
+          podTemplate:
+            metadata:
+              labels: ${metadata.podSelectors}
+            spec:
+              automountServiceAccountToken: false
+              runtimeClassName: kata-qemu
+              nodeSelector:
+                kata-enabled: "true"
+              tolerations:
+                - key: sandbox
+                  operator: Equal
+                  value: "true"
+                  effect: NoSchedule
+              containers:
+                - name: main
+                  image: ${workload.container.image}
+                  imagePullPolicy: ${environmentConfigs.imagePullPolicy}
+                  # `gemini` is interactive and exits without a TTY; keep the pod alive for exec.
+                  command: ["sleep", "infinity"]
+                  resources:
+                    requests:
+                      cpu: ${environmentConfigs.resources.requests.cpu}
+                      memory: ${environmentConfigs.resources.requests.memory}
+                    limits:
+                      cpu: ${environmentConfigs.resources.limits.cpu}
+                      memory: ${environmentConfigs.resources.limits.memory}
+                  env: ${dependencies.toContainerEnvs()}
+                  envFrom: ${configurations.toContainerEnvFrom()}
+                  volumeMounts: ${configurations.toContainerVolumeMounts()}
+              volumes: ${configurations.toVolumes()}
+
+    # ── SandboxClaim ─────────────────────────────────────────────────────
+    - id: sandbox-claim
+      template:
+        apiVersion: extensions.agents.x-k8s.io/v1alpha1
+        kind: SandboxClaim
+        metadata:
+          name: ${metadata.name}
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+          annotations:
+            openchoreo.dev/sandbox-policy: development
+        spec:
+          sandboxTemplateRef:
+            name: ${metadata.name}
+
+    # ── ConfigMap: plain env vars (e.g. GEMINI_MODEL) ────────────────────
+    - id: env-config
+      forEach: ${configurations.toConfigEnvsByContainer()}
+      var: envConfig
+      template:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: ${envConfig.resourceName}
+          namespace: ${metadata.namespace}
+        data: |
+          ${envConfig.envs.transformMapEntry(index, env, {env.name: env.value})}
+
+    # ── ExternalSecret: GEMINI_API_KEY injected as an env var ────────────
+    - id: secret-env-external
+      forEach: ${configurations.toSecretEnvsByContainer()}
+      var: secretEnv
+      template:
+        apiVersion: external-secrets.io/v1
+        kind: ExternalSecret
+        metadata:
+          name: ${secretEnv.resourceName}
+          namespace: ${metadata.namespace}
+        spec:
+          refreshInterval: 15s
+          secretStoreRef:
+            name: ${dataplane.secretStore}
+            kind: ClusterSecretStore
+          target:
+            name: ${secretEnv.resourceName}
+            creationPolicy: Owner
+          data: |
+            ${secretEnv.envs.map(secret, {
+              "secretKey": secret.name,
+              "remoteRef": {
+                "key": secret.remoteRef.key,
+                ?"property": secret.remoteRef.?property
+              }
+            })}

--- a/agent-sandbox/templates/create-ai-agent-codex.yaml
+++ b/agent-sandbox/templates/create-ai-agent-codex.yaml
@@ -1,0 +1,99 @@
+apiVersion: scaffolder.backstage.io/v1beta3
+kind: Template
+metadata:
+  name: create-ai-agent-codex
+  title: Codex Agent
+  description: Run OpenAI Codex interactively in a kernel-isolated sandbox.
+  tags:
+    - openchoreo
+    - ai-agent
+    - codex
+spec:
+  type: Component
+  owner: openchoreo
+
+  # Injects the logged-in user's token so the create action authorizes as them.
+  EXPERIMENTAL_formDecorators:
+    - id: openchoreo:inject-user-token
+
+  parameters:
+    - title: Component Metadata
+      required:
+        - project_namespace
+        - name
+      properties:
+        project_namespace:
+          title: Project & Namespace
+          type: object
+          description: The OpenChoreo project and namespace to create the component in.
+          ui:field: ProjectNamespaceField
+        name:
+          title: Component Name
+          type: string
+          description: A unique name for the component (lowercase, DNS-compatible).
+          pattern: "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+          maxLength: 63
+          ui:autofocus: true
+        displayName:
+          title: Display Name
+          type: string
+          description: A human-friendly name shown in the portal.
+        description:
+          title: Description
+          type: string
+          description: A short description of what this agent does.
+
+    - title: Agent Configuration
+      required:
+        - model
+        - openaiApiKey
+      properties:
+        model:
+          title: Model
+          type: string
+          description: The OpenAI model Codex runs on (OPENAI_MODEL env var).
+          default: gpt-5.5-codex
+          enum:
+            - gpt-5.5-codex
+            - gpt-5.5
+            - gpt-5.4-mini
+          enumNames:
+            - GPT-5.5 Codex
+            - GPT-5.5
+            - GPT-5.4 Mini
+        openaiApiKey:
+          title: OpenAI API Key
+          type: string
+          description: The OpenAI API key Codex uses (OPENAI_API_KEY).
+          ui:field: Secret
+
+  steps:
+    - id: create-component
+      name: Create Component
+      action: openchoreo:component:create
+      input:
+        projectName: ${{ parameters.project_namespace.project_name }}
+        namespaceName: ${{ parameters.project_namespace.namespace_name }}
+        componentName: ${{ parameters.name }}
+        displayName: ${{ parameters.displayName }}
+        description: ${{ parameters.description }}
+        componentType: ai-agent-codex
+        component_type_kind: ClusterComponentType
+        component_type_workload_type: proxy
+        # Must be deploy-from-image, or the action drops the image and env vars.
+        deploymentSource: deploy-from-image
+        containerImage: docker/sandbox-templates:codex
+        autoDeploy: true
+        # Terminal-only: no endpoints. Reach it with `kubectl exec -it <pod> -- codex`.
+        workloadDetails:
+          envVars:
+            - key: OPENAI_API_KEY
+              value: ${{ secrets.openaiApiKey }}
+            - key: OPENAI_MODEL
+              value: ${{ parameters.model }}
+
+  output:
+    links:
+      - title: View Component
+        icon: kind:component
+        entityRef: component:${{ steps['create-component'].output.namespaceName }}/${{ steps['create-component'].output.componentName }}

--- a/agent-sandbox/templates/create-ai-agent-gemini.yaml
+++ b/agent-sandbox/templates/create-ai-agent-gemini.yaml
@@ -1,0 +1,97 @@
+apiVersion: scaffolder.backstage.io/v1beta3
+kind: Template
+metadata:
+  name: create-ai-agent-gemini
+  title: Gemini Agent
+  description: Run Gemini CLI interactively in a kernel-isolated sandbox.
+  tags:
+    - openchoreo
+    - ai-agent
+    - gemini
+spec:
+  type: Component
+  owner: openchoreo
+
+  # Injects the logged-in user's token so the create action authorizes as them.
+  EXPERIMENTAL_formDecorators:
+    - id: openchoreo:inject-user-token
+
+  parameters:
+    - title: Component Metadata
+      required:
+        - project_namespace
+        - name
+      properties:
+        project_namespace:
+          title: Project & Namespace
+          type: object
+          description: The OpenChoreo project and namespace to create the component in.
+          ui:field: ProjectNamespaceField
+        name:
+          title: Component Name
+          type: string
+          description: A unique name for the component (lowercase, DNS-compatible).
+          pattern: "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+          maxLength: 63
+          ui:autofocus: true
+        displayName:
+          title: Display Name
+          type: string
+          description: A human-friendly name shown in the portal.
+        description:
+          title: Description
+          type: string
+          description: A short description of what this agent does.
+
+    - title: Agent Configuration
+      required:
+        - model
+        - geminiApiKey
+      properties:
+        model:
+          title: Model
+          type: string
+          description: The Google model Gemini CLI runs on (GEMINI_MODEL env var).
+          default: gemini-3.1-pro-preview
+          enum:
+            - gemini-3.1-pro-preview
+            - gemini-3-flash-preview
+          enumNames:
+            - Gemini 3.1 Pro
+            - Gemini 3 Flash
+        geminiApiKey:
+          title: Gemini API Key
+          type: string
+          description: The Google API key Gemini CLI uses (GEMINI_API_KEY).
+          ui:field: Secret
+
+  steps:
+    - id: create-component
+      name: Create Component
+      action: openchoreo:component:create
+      input:
+        projectName: ${{ parameters.project_namespace.project_name }}
+        namespaceName: ${{ parameters.project_namespace.namespace_name }}
+        componentName: ${{ parameters.name }}
+        displayName: ${{ parameters.displayName }}
+        description: ${{ parameters.description }}
+        componentType: ai-agent-gemini
+        component_type_kind: ClusterComponentType
+        component_type_workload_type: proxy
+        # Must be deploy-from-image, or the action drops the image and env vars.
+        deploymentSource: deploy-from-image
+        containerImage: docker/sandbox-templates:gemini
+        autoDeploy: true
+        # Terminal-only: no endpoints. Reach it with `kubectl exec -it <pod> -- gemini`.
+        workloadDetails:
+          envVars:
+            - key: GEMINI_API_KEY
+              value: ${{ secrets.geminiApiKey }}
+            - key: GEMINI_MODEL
+              value: ${{ parameters.model }}
+
+  output:
+    links:
+      - title: View Component
+        icon: kind:component
+        entityRef: component:${{ steps['create-component'].output.namespaceName }}/${{ steps['create-component'].output.componentName }}


### PR DESCRIPTION
## Purpose
Extends the `agent-sandbox` module with two more single-provider, terminal-only AI coding agents, mirroring the existing `ai-agent-claude` component type:

- **ai-agent-codex** — OpenAI Codex CLI in a kernel-isolated sandbox.
- **ai-agent-gemini** — Google Gemini CLI in a kernel-isolated sandbox.

## Approach
- Adds a `ClusterComponentType` for each agent under `agent-sandbox/helm/templates/`, structurally identical to `ai-agent-claude` (kata-qemu `SandboxTemplate` + `SandboxClaim`, non-mounted SA token, env/secret ConfigMap + `ExternalSecret` rendering). Terminal-only: the container runs `sleep infinity` and is reached via `kubectl exec`.
- Adds Backstage scaffolder templates (`agent-sandbox/templates/create-ai-agent-*.yaml`) for both, wiring model selection and the provider API-key secret:
  - Codex → `OPENAI_API_KEY` + `OPENAI_MODEL`.
  - Gemini → `GEMINI_API_KEY` + `GEMINI_MODEL`.
- Each CCT's `scaffolder.openchoreo.dev/backstage-template-url` points at the canonical raw template on `main`, consistent with the existing agent component types.

## Screen recording

https://github.com/user-attachments/assets/eaa6454c-8cfb-434d-acc2-2b03def63b3c

## Related Issues
_N/A_

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [x] Samples updated (if applicable)

## Remarks
Both CCTs render and were validated against a live EKS cluster (`kubectl apply`) and the portal successfully fetches the scaffolder templates.

A few provider-specific values were chosen by analogy to the Claude/OpenClaw templates and are worth a maintainer's confirmation:
- Container image tags: `docker/sandbox-templates:codex` and `docker/sandbox-templates:gemini`.
- Model-selection env vars: `OPENAI_MODEL` / `GEMINI_MODEL` (vs. a CLI flag or config file).
- Model IDs, notably `gpt-5.5-codex`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for creating and running Codex and Gemini AI agent components in isolated sandboxes.
  * Added configuration for selecting models, resource limits, image pull policies, and API keys.
  * AI agents can be automatically deployed and accessed through terminal sessions.
  * Added links to view newly created components after setup.
  * Added secure secret handling and environment variable configuration for agent credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->