### PR TITLE
fix(autoscaling-keda): repoint external route backend after url rewrite

### DIFF
--- a/autoscaling-keda/keda-scaling-trait.yaml
+++ b/autoscaling-keda/keda-scaling-trait.yaml
@@ -229,23 +229,6 @@ spec:
         group: gateway.networking.k8s.io
         version: v1
         kind: HTTPRoute
-        where: '${parameters.trigger.type == "" && has(resource.metadata.labels) && resource.metadata.labels["openchoreo.dev/endpoint-visibility"] == "external" && resource.spec.rules.exists(r, has(r.backendRefs) && r.backendRefs.exists(b, b.name == metadata.componentName))}'
-      operations:
-        - op: replace
-          path: /spec/rules/[*]/backendRefs/[?(@.name=='${metadata.componentName}')]
-          value:
-            group: gateway.kgateway.dev
-            kind: Backend
-            name: ${oc_generate_name(metadata.componentName, "keda-interceptor")}
-            weight: 1
-        - op: add
-          path: /spec/rules/[*]/timeouts
-          value:
-            request: ${parameters.readinessTimeout}
-    - target:
-        group: gateway.networking.k8s.io
-        version: v1
-        kind: HTTPRoute
         where: '${parameters.trigger.type == "" && has(resource.metadata.labels) && resource.metadata.labels["openchoreo.dev/endpoint-visibility"] == "external" && resource.spec.rules.exists(r, has(r.backendRefs) && r.backendRefs.exists(b, b.name == metadata.componentName)) && has(resource.spec.rules[0].filters) && resource.spec.rules[0].filters.exists(f, f.type == "URLRewrite")}'
       operations:
         - op: add
@@ -264,6 +247,24 @@ spec:
             type: URLRewrite
             urlRewrite:
               hostname: ${metadata.componentName + "." + metadata.namespace + ".svc.cluster.local"}
+
+    - target:
+        group: gateway.networking.k8s.io
+        version: v1
+        kind: HTTPRoute
+        where: '${parameters.trigger.type == "" && has(resource.metadata.labels) && resource.metadata.labels["openchoreo.dev/endpoint-visibility"] == "external" && resource.spec.rules.exists(r, has(r.backendRefs) && r.backendRefs.exists(b, b.name == metadata.componentName))}'
+      operations:
+        - op: replace
+          path: /spec/rules/[*]/backendRefs/[?(@.name=='${metadata.componentName}')]
+          value:
+            group: gateway.kgateway.dev
+            kind: Backend
+            name: ${oc_generate_name(metadata.componentName, "keda-interceptor")}
+            weight: 1
+        - op: add
+          path: /spec/rules/[*]/timeouts
+          value:
+            request: ${parameters.readinessTimeout}
 
     - target:
         group: ""


### PR DESCRIPTION
## Purpose
Fix a silent patch-ordering bug in the `keda-scaling` trait. When scaling an external HTTP component to zero, the URLRewrite hostname was not being applied, so the KEDA interceptor forwarded wake requests to the wrong upstream authority.

## Approach
The three HTTPRoute patches in `keda-scaling-trait.yaml` all guard (via their `where` clause) on the external route still carrying a `backendRef` named after the component:

- two patches set/add the `URLRewrite` filter hostname to the component's cluster-local service
- one patch repoints the `backendRef` to the KEDA interceptor `Backend`

The repoint ran first. By the time the two URLRewrite patches evaluated their `where` clause, the `backendRef` had already become the interceptor `Backend`, so the guards matched zero elements and the hostname rewrite was silently skipped.

Move the `backendRef` repoint to run last, after both URLRewrite patches. The rewrite patches now still see the component-named `backendRef` and apply the cluster-local hostname; the repoint then swaps the backend as before. This is a pure reordering of existing patch blocks — no operation changed.

## Related Issues
> None.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
No behavior change for any single patch; only their apply order. Verified the rendered patch list preserves each block verbatim.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved autoscaling behavior by allowing KEDA to manage deployment replica counts directly.
  * Enhanced HTTP routing integration with the KEDA interceptor, including backend routing and readiness timeout handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->