### PR TITLE
feat: set data retention in OpenObserve to 30 days

### DIFF
--- a/observability-logs-openobserve/helm/values.yaml
+++ b/observability-logs-openobserve/helm/values.yaml
@@ -94,6 +94,10 @@ fluent-bit:
 
 openobserve-standalone:
   enabled: true
+
+  config:
+    ZO_COMPACT_DATA_RETENTION_DAYS: "30" # data retention in days
+
   fullnameOverride: "openobserve"
   auth:
     ZO_ROOT_USER_EMAIL: ""
@@ -116,6 +120,10 @@ openobserve-standalone:
 
 openobserve:
   enabled: false
+  
+  config:
+    ZO_COMPACT_DATA_RETENTION_DAYS: "30" # data retention in days
+  
   fullnameOverride: "openobserve"
 
 ## -----------------------------------------------------------

--- a/observability-tracing-openobserve/helm/values.yaml
+++ b/observability-tracing-openobserve/helm/values.yaml
@@ -8,6 +8,10 @@ common:
 
 openobserve-standalone:
   enabled: true
+
+  config:
+    ZO_COMPACT_DATA_RETENTION_DAYS: "30" # data retention in days
+
   fullnameOverride: "openobserve"
   auth:
     ZO_ROOT_USER_EMAIL: ""
@@ -27,6 +31,10 @@ openobserve-standalone:
 
 openobserve:
   enabled: false
+
+  config:
+    ZO_COMPACT_DATA_RETENTION_DAYS: "30" # data retention in days
+
   fullnameOverride: "openobserve"
 
 opentelemetry-collector:


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat: add observability-logs-opensearch module
  fix: handle opensearch startup delay in init script
  docs: update observability-logs-opensearch module installation guide
  chore(deps): bump fluent-bit version in observability-logs-openobserve module

See: https://github.com/openchoreo/openchoreo/blob/main/docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
The default data retention time in OpenObserve is 10 years. This PR updates it to 30 days in OpenChoreo modules

## Approach
Passed `config.ZO_COMPACT_DATA_RETENTION_DAYS: "30"` to the upstream Helm chart values files

## Related Issues
https://github.com/openchoreo/openchoreo/issues/4257

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configured OpenObserve to retain compacted data for 30 days across standalone and standard deployment configurations.
  * Applied the same retention setting to both logging and tracing observability deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->