### PR TITLE
feat: expose OpenObserve through OP gateway for multicluster deployments

### DIFF
--- a/observability-logs-openobserve/README.md
+++ b/observability-logs-openobserve/README.md
@@ -66,7 +66,7 @@ helm upgrade --install observability-logs-openobserve \
   oci://ghcr.io/openchoreo/helm-charts/observability-logs-openobserve \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.5.1
+  --version 0.0.0-latest-dev
 ```
 
 To switch to HA mode, disable the standalone chart and enable the distributed chart:
@@ -75,7 +75,7 @@ To switch to HA mode, disable the standalone chart and enable the distributed ch
 helm upgrade --install observability-logs-openobserve \
   oci://ghcr.io/openchoreo/helm-charts/observability-logs-openobserve \
   --namespace openchoreo-observability-plane \
-  --version 0.5.1 \
+  --version 0.0.0-latest-dev \
   --reuse-values \
   --set openobserve-standalone.enabled=false \
   --set openobserve.enabled=true
@@ -95,7 +95,7 @@ to start collecting logs from the cluster and publish them to OpenObserve:
 helm upgrade observability-logs-openobserve \
   oci://ghcr.io/openchoreo/helm-charts/observability-logs-openobserve \
   --namespace openchoreo-observability-plane \
-  --version 0.5.1 \
+  --version 0.0.0-latest-dev \
   --reuse-values \
   --set fluent-bit.enabled=true
 ```
@@ -103,26 +103,60 @@ helm upgrade observability-logs-openobserve \
 ### Multi-cluster topology
 
 In a **multi-cluster topology**, where the observability plane runs in a separate cluster
-from the data-plane / workflow-plane clusters, install the Helm chart in those clusters with Fluent Bit enabled and OpenObserve components disabled
-to start collecting logs from the cluster and publish them to the observability plane cluster's OpenObserve endpoint.
+from the data-plane / workflow-plane clusters, log data flows from the remote Fluent Bit
+instances, through the observability-plane gateway (`gateway-default`), into OpenObserve.
+You need two things:
+
+1. **On the observability plane cluster**: expose the OpenObserve ingest endpoint through the gateway so remote Fluent Bit instances can reach it.
+2. **On each remote cluster**: install this chart with only Fluent Bit enabled, pointed at the obs cluster's gateway endpoint.
+
+#### Observability plane cluster setup
+
+Install the chart normally, and set `common.httpRouteHostnames` to the gateway
+hostname that remote Fluent Bit instances will target. This creates an `HTTPRoute` on
+`gateway-default` that routes the OpenObserve ingest path (`/api/<org>/<stream>/_json`) to the
+in-cluster `openobserve` Service:
 
 ```bash
 helm upgrade --install observability-logs-openobserve \
   oci://ghcr.io/openchoreo/helm-charts/observability-logs-openobserve \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.5.1 \
+  --version 0.0.0-latest-dev \
+  --set-json common.httpRouteHostnames='["openobserve.<OBS_BASE_DOMAIN>"]'
+```
+
+> **Note:** The observability plane gateway needs an HTTP/HTTPS listener whose hostname matches
+> `openobserve.<OBS_BASE_DOMAIN>`.
+
+#### Remote cluster setup (data-plane / workflow-plane clusters)
+
+Install the chart with only Fluent Bit enabled and the OpenObserve components disabled, pointed at
+the gateway endpoint:
+
+```bash
+helm upgrade --install observability-logs-openobserve \
+  oci://ghcr.io/openchoreo/helm-charts/observability-logs-openobserve \
+  --create-namespace \
+  --namespace openchoreo-observability-plane \
+  --version 0.0.0-latest-dev \
   --set fluent-bit.enabled=true \
   --set openobserve-standalone.enabled=false \
+  --set openobserve.enabled=false \
   --set openObserveSetup.enabled=false \
-  --set adapter.enabled=false
+  --set adapter.enabled=false \
+  --set common.openObserveHost=openobserve.<OBS_BASE_DOMAIN> \
+  --set common.openObservePort=<gateway-port> \
+  --set common.openObserveTls=On
 ```
 
 > **Note:**
 >
-> Make sure the `openobserve-admin-credentials` secret is available in the data-plane / workflow-plane clusters as well,
-> and `fluent-bit.openObserveHost` and `fluent-bit.openObservePort` values are set to the OpenObserve endpoint exposed from the observability plane cluster,
-> while `common.openObserveOrg` and `common.openObserveStream` match the organization and stream configured in the observability plane cluster.
+> - The `openobserve-admin-credentials` secret must exist on the remote clusters as well, because Fluent Bit basic-authenticates directly to OpenObserve. If you don't have a shared secret backend, create it manually (see the [Multi-Cluster Connectivity](https://openchoreo.dev/docs/platform-engineer-guide/multi-cluster-connectivity/) guide).
+> - `common.openObserveHost` and `common.openObservePort` must point at the gateway endpoint exposed from the observability plane cluster, and `common.openObserveHost` should match the gateway hostname (`openobserve.<OBS_BASE_DOMAIN>`).
+> - Set `common.openObserveTls=On` if the obs gateway listener is HTTPS, or `Off` if it is plain HTTP.
+> - `common.openObserveOrg` and `common.openObserveStream` must match the organization and stream configured in the observability plane cluster.
+> - The adapter and setup job are disabled because they only need to run on the observability plane cluster.
 
 ## Dependencies
 

--- a/observability-logs-openobserve/helm/templates/fluent-bit/config.yaml
+++ b/observability-logs-openobserve/helm/templates/fluent-bit/config.yaml
@@ -47,13 +47,13 @@ data:
     [OUTPUT]
         Name http
         Match *
-        Host {{ index .Values "fluent-bit" "openObserveHost" }}
-        Port {{ index .Values "fluent-bit" "openObservePort" }}
+        Host {{ .Values.common.openObserveHost }}
+        Port {{ .Values.common.openObservePort }}
         URI /api/{{ .Values.common.openObserveOrg }}/{{ .Values.common.openObserveStream }}/_json
         Format json
         http_user ${OPENOBSERVE_USERNAME}
         http_passwd ${OPENOBSERVE_PASSWORD}
-        tls {{ index .Values "fluent-bit" "openObserveTls" }}
+        tls {{ .Values.common.openObserveTls }}
 
   parsers.conf: |
     [PARSER]

--- a/observability-logs-openobserve/helm/templates/openobserve/httproute.yaml
+++ b/observability-logs-openobserve/helm/templates/openobserve/httproute.yaml
@@ -1,7 +1,7 @@
 # Copyright 2026 The OpenChoreo Authors
 # SPDX-License-Identifier: Apache-2.0
 
-{{- if (index .Values "openobserve-standalone" "enabled") }}
+{{- if or (index .Values "openobserve-standalone" "enabled") (index .Values "openobserve" "enabled") }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -11,7 +11,7 @@ spec:
   parentRefs:
   - name: gateway-default
     namespace: {{ .Release.Namespace }}
-  {{- with (index .Values "openobserve-standalone" "httpRouteHostnames") }}
+  {{- with .Values.common.httpRouteHostnames }}
   hostnames:
     {{- range . }}
     - {{ . | quote }}
@@ -21,7 +21,7 @@ spec:
   - matches:
     - path:
         type: PathPrefix
-        value: /api/default/container-logs/_json
+        value: /api/{{ .Values.common.openObserveOrg }}/{{ .Values.common.openObserveStream }}/_json
     backendRefs:
     - name: openobserve
       port: 5080

--- a/observability-logs-openobserve/helm/values.yaml
+++ b/observability-logs-openobserve/helm/values.yaml
@@ -5,6 +5,15 @@ common:
   openObserveOrg: "default"
   openObserveStream: "default"
   openObserveEventsStream: "k8s_events"
+  # Hostnames placed on the OpenObserve ingest HTTPRoute (gateway-default). Set this
+  # to the gateway hostname remote Fluent Bit instances target in a multi-cluster setup.
+  # Applies regardless of whether the standalone or HA OpenObserve chart is used.
+  httpRouteHostnames: []
+  # OpenObserve endpoint the Fluent Bit config ships logs to. Defaults to the in-cluster
+  # Service; override in a multi-cluster setup to point remote Fluent Bit at the gateway.
+  openObserveHost: "openobserve"
+  openObservePort: 5080
+  openObserveTls: "Off"
 
 fluent-bit:
   enabled: true
@@ -87,11 +96,6 @@ fluent-bit:
     - name: db
       mountPath: /var/lib/fluent-bit/db
 
-  # Values for fluent-bit config map
-  openObserveHost: "openobserve"
-  openObservePort: 5080
-  openObserveTls: "Off"
-
 openobserve-standalone:
   enabled: true
   fullnameOverride: "openobserve"
@@ -110,9 +114,6 @@ openobserve-standalone:
     requests:
       cpu: 20m
       memory: 500Mi
-
-  ## OpenChoreo specific values. These are not passed to the upstream chart
-  httpRouteHostnames: []
 
 openobserve:
   enabled: false


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat: add observability-logs-opensearch module
  fix: handle opensearch startup delay in init script
  docs: update observability-logs-opensearch module installation guide
  chore(deps): bump fluent-bit version in observability-logs-openobserve module

See: https://github.com/openchoreo/openchoreo/blob/main/docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
Expose OpenObserve through the observability plane gateway to support multicluster deployments

## Approach
Updated the HTTPRoute custom resource and the wiring from values file to it

## Related Issues
https://github.com/openchoreo/openchoreo/issues/4264

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multi-cluster log collection through a dedicated observability gateway.
  * Added configurable OpenObserve organization, stream, hostname, port, and TLS settings.
  * Enabled HTTP routing for both standalone and highly available OpenObserve deployments.

* **Documentation**
  * Updated installation guidance and expanded multi-cluster setup instructions.
  * Clarified remote-cluster configuration, gateway requirements, and credential setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->