### PR TITLE
feat: add multi-cluster support to the OpenObserve tracing module

### DIFF
--- a/observability-logs-openobserve/README.md
+++ b/observability-logs-openobserve/README.md
@@ -6,6 +6,8 @@
 
 This module collects container logs using [Fluent Bit](https://fluentbit.io) and stores them in [OpenObserve](https://openobserve.ai).
 
+> **Note:** The commands in this README install the latest module version. Refer to the [Compatibility](#compatibility) table below for the module version compatible with your OpenChoreo version.
+
 ## Prerequisites
 
 - [OpenChoreo](https://openchoreo.dev) must be installed with the **observability plane** enabled for this module to work. Deploy the `openchoreo-observability-plane` helm chart with the helm value `observer.logsAdapter.enabled="true"` to enable the observer to fetch data from this logs module.

--- a/observability-tracing-openobserve/README.md
+++ b/observability-tracing-openobserve/README.md
@@ -6,6 +6,8 @@
 
 This module collects distributed traces using [OpenTelemetry collector](https://opentelemetry.io) and stores them in [OpenObserve](https://openobserve.ai).
 
+> **Note:** The commands in this README install the latest module version. Refer to the [Compatibility](#compatibility) table below for the module version compatible with your OpenChoreo version.
+
 ## Prerequisites
 
 - [OpenChoreo](https://openchoreo.dev) must be installed with the **observability plane** enabled for this module to work. Deploy the `openchoreo-observability-plane` helm chart with the helm value `observer.tracingAdapter.enabled="true"` to enable the observer to fetch data from this tracing module.
@@ -66,7 +68,7 @@ helm upgrade --install observability-tracing-openobserve \
   oci://ghcr.io/openchoreo/helm-charts/observability-tracing-openobserve \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.2.4
+  --version 0.0.0-latest-dev
 ```
 
 To switch to HA mode, disable the standalone chart and enable the distributed chart:
@@ -75,7 +77,7 @@ To switch to HA mode, disable the standalone chart and enable the distributed ch
 helm upgrade --install observability-tracing-openobserve \
   oci://ghcr.io/openchoreo/helm-charts/observability-tracing-openobserve \
   --namespace openchoreo-observability-plane \
-  --version 0.2.4 \
+  --version 0.0.0-latest-dev \
   --reuse-values \
   --set openobserve-standalone.enabled=false \
   --set openobserve.enabled=true
@@ -90,10 +92,79 @@ Refer to the [openobserve Helm chart documentation](https://github.com/openobser
 >  oci://ghcr.io/openchoreo/helm-charts/observability-tracing-openobserve \
 >  --create-namespace \
 >  --namespace openchoreo-observability-plane \
->  --version 0.2.4 \
+>  --version 0.0.0-latest-dev \
 >  --set openobserve-standalone.enabled=false
 > ```
 
+## Enable trace collection
+
+### Installation modes
+
+This chart supports three `global.installationMode` values:
+
+- **`singleCluster`**: Deploy everything (OpenTelemetry Collector + OpenObserve) into a single cluster (used when the data plane and observability plane are in the same cluster).
+- **`multiClusterReceiver`**: Deploy the OpenTelemetry Collector as a central receiver into the observability plane cluster. It accepts OTLP from remote clusters and writes traces to OpenObserve.
+- **`multiClusterExporter`**: Deploy the OpenTelemetry Collector as an exporter into each data-plane cluster. It receives OTLP from in-cluster workloads and exports it to the receiver in the observability plane cluster over OTLP.
+
+#### Single-cluster topology
+
+In a **single-cluster topology**, where the observability plane runs in the same cluster
+as the data-plane / workflow-plane clusters, the default `singleCluster` install (above) already
+collects traces and writes them to the in-cluster OpenObserve.
+
+#### Multi-cluster topology
+
+In a **multi-cluster topology**, where the observability plane runs in a separate cluster
+from the data-plane / workflow-plane clusters, trace data flows from the exporter collectors on
+the remote clusters, through the observability-plane gateway (`gateway-default`), into the receiver
+collector, which writes to OpenObserve. You typically install:
+
+- **Receiver (observability plane cluster)**: `global.installationMode=multiClusterReceiver`
+- **Exporter (each data-plane cluster)**: `global.installationMode=multiClusterExporter`
+
+##### 1) Install the receiver (observability plane cluster)
+
+Install the chart in the observability plane cluster. Set `opentelemetryCollectorCustomizations.http.hostnames` to the gateway hostname that
+remote exporters will target, so the receiver's `HTTPRoute` is created on `gateway-default`:
+
+```bash
+helm upgrade --install observability-tracing-openobserve \
+  oci://ghcr.io/openchoreo/helm-charts/observability-tracing-openobserve \
+  --create-namespace \
+  --namespace openchoreo-observability-plane \
+  --version 0.0.0-latest-dev \
+  --set global.installationMode="multiClusterReceiver" \
+  --set-json opentelemetryCollectorCustomizations.http.hostnames='["opentelemetry.<OBS_BASE_DOMAIN>"]'
+```
+
+> **Note:** If OpenObserve is already installed by another module (e.g., `observability-logs-openobserve`), add `--set openobserve-standalone.enabled=false` to avoid conflicts.
+
+##### 2) Install an exporter (each data-plane cluster)
+
+Install the chart in each data-plane cluster. The exporter does **not** need OpenObserve, the adapter, or
+the `openobserve-admin-credentials` secret — those credentials live only on the receiver. It only needs to
+export OTLP to the receiver.
+
+Set `opentelemetryCollectorCustomizations.http.observabilityPlaneUrl` to the receiver endpoint exposed
+through the observability-plane gateway (for example: `http://opentelemetry.<OBS_BASE_DOMAIN>:<port>`).
+If the gateway is exposed over a TLS/HTTPS listener, use the `https://` scheme instead. Also set
+`opentelemetryCollectorCustomizations.http.observabilityPlaneVirtualHost` when `observabilityPlaneUrl`
+differs from the gateway hostname.
+
+```bash
+helm upgrade --install observability-tracing-openobserve \
+  oci://ghcr.io/openchoreo/helm-charts/observability-tracing-openobserve \
+  --create-namespace \
+  --namespace openchoreo-observability-plane \
+  --version 0.0.0-latest-dev \
+  --set global.installationMode="multiClusterExporter" \
+  --set openobserve-standalone.enabled=false \
+  --set openobserve.enabled=false \
+  --set adapter.enabled=false \
+  --set-json opentelemetry-collector.extraEnvs='[]' \
+  --set opentelemetryCollectorCustomizations.http.observabilityPlaneUrl="http://opentelemetry.<OBS_BASE_DOMAIN>:<port>" \
+  --set opentelemetryCollectorCustomizations.http.observabilityPlaneVirtualHost="opentelemetry.<OBS_BASE_DOMAIN>"
+```
 
 ## Dependencies
 

--- a/observability-tracing-openobserve/helm/templates/_helpers.tpl
+++ b/observability-tracing-openobserve/helm/templates/_helpers.tpl
@@ -1,0 +1,18 @@
+{{/*
+Copyright 2026 The OpenChoreo Authors
+SPDX-License-Identifier: Apache-2.0
+*/}}
+
+{{- define "observability-tracing-openobserve.validate" -}}
+{{- $mode := (default "" .Values.global.installationMode) -}}
+{{- $allowed := list "singleCluster" "multiClusterExporter" "multiClusterReceiver" -}}
+{{- if not (has $mode $allowed) -}}
+{{- fail (printf "global.installationMode must be one of [%s] (got %q)" (join ", " $allowed) $mode) -}}
+{{- end -}}
+
+{{- if eq $mode "multiClusterExporter" -}}
+{{- if not .Values.opentelemetryCollectorCustomizations.http.observabilityPlaneUrl -}}
+{{- fail "opentelemetryCollectorCustomizations.http.observabilityPlaneUrl is required when global.installationMode is set to \"multiClusterExporter\"." -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/observability-tracing-openobserve/helm/templates/adapter/deployment.yaml
+++ b/observability-tracing-openobserve/helm/templates/adapter/deployment.yaml
@@ -1,6 +1,7 @@
 # Copyright 2026 The OpenChoreo Authors
 # SPDX-License-Identifier: Apache-2.0
 
+{{- if .Values.adapter.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -54,3 +55,4 @@ spec:
           requests:
             cpu: {{ .Values.adapter.resources.requests.cpu }}
             memory: {{ .Values.adapter.resources.requests.memory }}
+{{- end }}

--- a/observability-tracing-openobserve/helm/templates/adapter/service.yaml
+++ b/observability-tracing-openobserve/helm/templates/adapter/service.yaml
@@ -1,6 +1,7 @@
 # Copyright 2026 The OpenChoreo Authors
 # SPDX-License-Identifier: Apache-2.0
 
+{{- if .Values.adapter.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -17,3 +18,4 @@ spec:
     name: http
   selector:
     app: tracing-adapter-openobserve
+{{- end }}

--- a/observability-tracing-openobserve/helm/templates/opentelemetry-collector/configMap.yaml
+++ b/observability-tracing-openobserve/helm/templates/opentelemetry-collector/configMap.yaml
@@ -18,21 +18,35 @@ data:
             endpoint: 0.0.0.0:4318
 
     exporters:
+      {{- if or (eq .Values.global.installationMode "singleCluster") (eq .Values.global.installationMode "multiClusterReceiver") }}
       otlphttp:
         traces_endpoint: http://openobserve:5080/api/{{ .Values.common.openObserveOrg }}/traces
         auth:
           authenticator: basicauth/openobserve
+      {{- end }}
+      {{- if eq .Values.global.installationMode "multiClusterExporter" }}
+      otlp:
+        endpoint: {{ .Values.opentelemetryCollectorCustomizations.http.observabilityPlaneUrl }}
+        tls:
+          insecure: true
+        {{- with .Values.opentelemetryCollectorCustomizations.http.observabilityPlaneVirtualHost }}
+        headers:
+          Host: {{ . | quote }}
+        {{- end }}
+      {{- end }}
 
     extensions:
+      {{- if or (eq .Values.global.installationMode "singleCluster") (eq .Values.global.installationMode "multiClusterReceiver") }}
       basicauth/openobserve:
         client_auth:
           username: ${OPENOBSERVE_USERNAME}
           password: ${OPENOBSERVE_PASSWORD}
+      {{- end }}
       health_check:
         endpoint: ${env:MY_POD_IP}:13133
-  
+
     processors:
-      {{- if eq .Values.opentelemetryCollectorCustomizations.installationMode "singleCluster" }}
+      {{- if or (eq .Values.global.installationMode "singleCluster") (eq .Values.global.installationMode "multiClusterExporter") }}
       k8sattributes:
         auth_type: "serviceAccount"
         passthrough: false
@@ -42,7 +56,7 @@ data:
             - tag_name: $$1
               key_regex: (.*)
               from: pod
-            
+
           metadata:
             - k8s.pod.name
             - k8s.pod.uid
@@ -68,12 +82,17 @@ data:
       {{- end }}
 
     service:
+      {{- if or (eq .Values.global.installationMode "singleCluster") (eq .Values.global.installationMode "multiClusterReceiver") }}
       extensions: [basicauth/openobserve, health_check]
+      {{- end }}
+      {{- if eq .Values.global.installationMode "multiClusterExporter" }}
+      extensions: [health_check]
+      {{- end }}
       pipelines:
         traces:
           receivers: [otlp]
           {{- $processors := list }}
-          {{- if eq .Values.opentelemetryCollectorCustomizations.installationMode "singleCluster" }}
+          {{- if or (eq .Values.global.installationMode "singleCluster") (eq .Values.global.installationMode "multiClusterExporter") }}
           {{- $processors = append $processors "k8sattributes" }}
           {{- end }}
           {{- if .Values.opentelemetryCollectorCustomizations.tailSampling.enabled }}
@@ -82,5 +101,10 @@ data:
           {{- if $processors }}
           processors: [{{ join ", " $processors }}]
           {{- end }}
+          {{- if or (eq .Values.global.installationMode "singleCluster") (eq .Values.global.installationMode "multiClusterReceiver") }}
           exporters: [otlphttp]
+          {{- end }}
+          {{- if eq .Values.global.installationMode "multiClusterExporter" }}
+          exporters: [otlp]
+          {{- end }}
 {{- end }}

--- a/observability-tracing-openobserve/helm/templates/opentelemetry-collector/httproute.yaml
+++ b/observability-tracing-openobserve/helm/templates/opentelemetry-collector/httproute.yaml
@@ -1,0 +1,41 @@
+# Copyright 2026 The OpenChoreo Authors
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if eq .Values.global.installationMode "multiClusterReceiver" }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: opentelemetry-collector
+  namespace: {{ .Release.Namespace }}
+spec:
+  parentRefs:
+    - name: gateway-default
+      namespace: {{ .Release.Namespace }}
+  {{- with .Values.opentelemetryCollectorCustomizations.http.hostnames }}
+  hostnames:
+    {{- range . }}
+    - {{ . | quote }}
+    {{- end }}
+  {{- end }}
+  rules:
+    # OTLP gRPC (4317): match gRPC traffic and route to gRPC receiver.
+    - matches:
+        - headers:
+            - name: content-type
+              value: application/grpc
+        - headers:
+            - name: content-type
+              value: application/grpc+proto
+      backendRefs:
+        - name: opentelemetry-collector
+          port: 4317
+
+    # OTLP HTTP (4318): default route for HTTP OTLP endpoints like /v1/traces.
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: opentelemetry-collector
+          port: 4318
+{{- end }}

--- a/observability-tracing-openobserve/helm/templates/validate.yaml
+++ b/observability-tracing-openobserve/helm/templates/validate.yaml
@@ -1,0 +1,4 @@
+# Copyright 2026 The OpenChoreo Authors
+# SPDX-License-Identifier: Apache-2.0
+
+{{- include "observability-tracing-openobserve.validate" . -}}

--- a/observability-tracing-openobserve/helm/values.yaml
+++ b/observability-tracing-openobserve/helm/values.yaml
@@ -1,6 +1,10 @@
 # Copyright 2026 The OpenChoreo Authors
 # SPDX-License-Identifier: Apache-2.0
 
+global:
+  # Supports "singleCluster", "multiClusterExporter", "multiClusterReceiver"
+  installationMode: "singleCluster"
+
 common:
   openObserveOrg: "default"
   openObserveStream: "default"
@@ -74,14 +78,15 @@ opentelemetry-collector:
       memory: 100Mi
 
   service:
-    type: LoadBalancer
-      
+    type: ClusterIP
+
 
 ## -----------------------------------------------------------
 ## Values for OpenChoreo specific customizations and workloads
 ## -----------------------------------------------------------
 
 adapter:
+  enabled: true
   image:
     repository: "ghcr.io/openchoreo/observability-tracing-openobserve-adapter"
     tag: ""  # Defaults to Chart.AppVersion via the template
@@ -97,11 +102,18 @@ adapter:
 
 
 opentelemetryCollectorCustomizations:
-  installationMode: "singleCluster"
   openSearchQueue:
     numConsumers: 5
     queueSize: 1000
     sizer: items
+
+  # Used when global.installationMode is "multiClusterExporter" (dataplane) or
+  # "multiClusterReceiver" (observability plane). The exporter relays OTLP to the
+  # receiver collector through the observability-plane gateway.
+  http:
+    observabilityPlaneUrl: ""          # OTLP endpoint of the receiver, via the gateway
+    observabilityPlaneVirtualHost: ""  # Host header / gateway vhost
+    hostnames: []                      # hostnames placed on the receiver HTTPRoute
 
   tailSampling:
     enabled: true


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat: add observability-logs-opensearch module
  fix: handle opensearch startup delay in init script
  docs: update observability-logs-opensearch module installation guide
  chore(deps): bump fluent-bit version in observability-logs-openobserve module

See: https://github.com/openchoreo/openchoreo/blob/main/docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
Add multi cluster support for the OpenObserve tracing module

## Approach
1. Expose OpenTelemetry collector in observability plane via the gateway
2. Add instructions on how to install the OpenTelemetry collector in dataplanes and observability plane

## Related Issues
https://github.com/openchoreo/openchoreo/issues/4158

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for single-cluster and multi-cluster trace collection modes.
  * Added multi-cluster receiver routing for OTLP over HTTP and gRPC.
  * Added configurable observability-plane forwarding for exporter deployments.
  * Added deployment validation with clear errors for unsupported modes or missing settings.
  * Added the ability to disable the tracing adapter.

* **Documentation**
  * Updated OpenObserve installation instructions and expanded multi-cluster setup guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->