### PR TITLE
chore: upgrade OpenObserve helm chart to version 0.91.1 in logs and tracing modules

### DIFF
--- a/observability-logs-openobserve/helm/Chart.lock
+++ b/observability-logs-openobserve/helm/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 0.56.0
 - name: openobserve-standalone
   repository: https://charts.openobserve.ai
-  version: 0.80.3
+  version: 0.91.1
 - name: openobserve
   repository: https://charts.openobserve.ai
-  version: 0.80.3
-digest: sha256:ae682237fb41771cc856e433bd22ec142efec76d08f71497bfb1c3ad3c8b434e
-generated: "2026-06-16T09:16:51.89439566Z"
+  version: 0.91.1
+digest: sha256:22e172413fdcb6658939ac8f8f10548b6a87c00c1d905346b235b85160be312d
+generated: "2026-07-22T17:10:53.021309+05:30"

--- a/observability-logs-openobserve/helm/Chart.yaml
+++ b/observability-logs-openobserve/helm/Chart.yaml
@@ -21,10 +21,10 @@ dependencies:
     repository: https://fluent.github.io/helm-charts
     condition: fluent-bit.enabled
   - name: openobserve-standalone
-    version: 0.80.3
+    version: 0.91.1
     repository: https://charts.openobserve.ai
     condition: openobserve-standalone.enabled
   - name: openobserve
-    version: 0.80.3
+    version: 0.91.1
     repository: https://charts.openobserve.ai
     condition: openobserve.enabled

--- a/observability-tracing-openobserve/helm/Chart.lock
+++ b/observability-tracing-openobserve/helm/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 0.158.2
 - name: openobserve-standalone
   repository: https://charts.openobserve.ai
-  version: 0.80.3
+  version: 0.91.1
 - name: openobserve
   repository: https://charts.openobserve.ai
-  version: 0.80.3
-digest: sha256:7c4707fd44a66926463ae8ad6b85e017c7a3c661dbeb965b618b9b2b26f46b24
-generated: "2026-07-03T16:17:23.512176094Z"
+  version: 0.91.1
+digest: sha256:0ceaed3408048dcc8f02b88a705915421ab8c92e6d4201b6563fc01f8d8647a8
+generated: "2026-07-22T17:11:13.322049+05:30"

--- a/observability-tracing-openobserve/helm/Chart.yaml
+++ b/observability-tracing-openobserve/helm/Chart.yaml
@@ -21,10 +21,10 @@ dependencies:
     version: 0.158.2
     condition: opentelemetry-collector.enabled
   - name: openobserve-standalone
-    version: 0.80.3
+    version: 0.91.1
     repository: https://charts.openobserve.ai
     condition: openobserve-standalone.enabled
   - name: openobserve
-    version: 0.80.3
+    version: 0.91.1
     repository: https://charts.openobserve.ai
     condition: openobserve.enabled


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat: add observability-logs-opensearch module
  fix: handle opensearch startup delay in init script
  docs: update observability-logs-opensearch module installation guide
  chore(deps): bump fluent-bit version in observability-logs-openobserve module

See: https://github.com/openchoreo/openchoreo/blob/main/docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
Upgrade OpenObserve Helm chart to version 0.91.1 

## Approach
Updated the dependent chart versions in module Helm chart.yaml files and updated the Chart.lock files 

## Related Issues
https://github.com/openchoreo/openchoreo/issues/4271

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated OpenObserve chart components to version 0.91.1 for logging and tracing deployments.
  * Existing repository settings and enablement conditions remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->