### PR TITLE
feat: update configuration passing capabilities in OpenObserve modules

### DIFF
--- a/observability-tracing-openobserve/helm/templates/_helpers.tpl
+++ b/observability-tracing-openobserve/helm/templates/_helpers.tpl
@@ -15,4 +15,8 @@ SPDX-License-Identifier: Apache-2.0
 {{- fail "opentelemetryCollectorCustomizations.http.observabilityPlaneUrl is required when global.installationMode is set to \"multiClusterExporter\"." -}}
 {{- end -}}
 {{- end -}}
+
+{{- if .Values.adapter.openObserveUrl -}}
+{{- fail "adapter.openObserveUrl is deprecated and no longer used. Set common.openObserveHost and common.openObservePort instead." -}}
+{{- end -}}
 {{- end -}}

--- a/observability-tracing-openobserve/helm/templates/adapter/configmap.yaml
+++ b/observability-tracing-openobserve/helm/templates/adapter/configmap.yaml
@@ -5,15 +5,13 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: logs-adapter-openobserve
+  name: tracing-adapter-openobserve
   namespace: {{ .Release.Namespace }}
   labels:
-    app: logs-adapter-openobserve
+    app: tracing-adapter-openobserve
 data:
-  SERVER_PORT: "9098"
+  SERVER_PORT: {{ .Values.adapter.serverPort | quote }}
   OPENOBSERVE_URL: "http://{{ .Values.common.openObserveHost }}:{{ .Values.common.openObservePort }}"
   OPENOBSERVE_ORG: {{ .Values.common.openObserveOrg | quote }}
   OPENOBSERVE_STREAM: {{ .Values.common.openObserveStream | quote }}
-  OPENOBSERVE_EVENTS_STREAM: {{ .Values.common.openObserveEventsStream | quote }}
-  OBSERVER_URL: {{ .Values.adapter.observerUrl | quote }}
 {{- end }}

--- a/observability-tracing-openobserve/helm/templates/adapter/deployment.yaml
+++ b/observability-tracing-openobserve/helm/templates/adapter/deployment.yaml
@@ -16,6 +16,8 @@ spec:
       app: tracing-adapter-openobserve
   template:
     metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/adapter/configmap.yaml") . | sha256sum }}
       labels:
         app: tracing-adapter-openobserve
     spec:
@@ -29,15 +31,10 @@ spec:
         imagePullPolicy: {{ .Values.adapter.image.pullPolicy | default "IfNotPresent" }}
         ports:
         - containerPort: 9100
+        envFrom:
+        - configMapRef:
+            name: tracing-adapter-openobserve
         env:
-        - name: SERVER_PORT
-          value: {{ .Values.adapter.serverPort | quote }}
-        - name: OPENOBSERVE_URL
-          value: {{ .Values.adapter.openObserveUrl | quote }}
-        - name: OPENOBSERVE_ORG
-          value: {{ .Values.common.openObserveOrg | quote }}
-        - name: OPENOBSERVE_STREAM
-          value: {{ .Values.common.openObserveStream | quote }}
         - name: OPENOBSERVE_USER
           valueFrom:
             secretKeyRef:

--- a/observability-tracing-openobserve/helm/templates/opentelemetry-collector/configMap.yaml
+++ b/observability-tracing-openobserve/helm/templates/opentelemetry-collector/configMap.yaml
@@ -20,7 +20,7 @@ data:
     exporters:
       {{- if or (eq .Values.global.installationMode "singleCluster") (eq .Values.global.installationMode "multiClusterReceiver") }}
       otlphttp:
-        traces_endpoint: http://openobserve:5080/api/{{ .Values.common.openObserveOrg }}/traces
+        traces_endpoint: http://{{ .Values.common.openObserveHost }}:{{ .Values.common.openObservePort }}/api/{{ .Values.common.openObserveOrg }}/traces
         auth:
           authenticator: basicauth/openobserve
       {{- end }}

--- a/observability-tracing-openobserve/helm/values.yaml
+++ b/observability-tracing-openobserve/helm/values.yaml
@@ -8,6 +8,8 @@ global:
 common:
   openObserveOrg: "default"
   openObserveStream: "default"
+  openObserveHost: "openobserve"
+  openObservePort: 5080
 
 
 openobserve-standalone:
@@ -90,7 +92,6 @@ adapter:
   image:
     repository: "ghcr.io/openchoreo/observability-tracing-openobserve-adapter"
     tag: ""  # Defaults to Chart.AppVersion via the template
-  openObserveUrl: "http://openobserve:5080"
   resources:
     limits:
       cpu: 200m


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat: add observability-logs-opensearch module
  fix: handle opensearch startup delay in init script
  docs: update observability-logs-opensearch module installation guide
  chore(deps): bump fluent-bit version in observability-logs-openobserve module

See: https://github.com/openchoreo/openchoreo/blob/main/docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
Make the OpenObserve URL configurable in OpenObserve based observability modules

## Approach
- Refactored the configMap of the OpenObserve logs module to read the OpenObserve URL from Helm values
- Refactored the OpenObserve tracing module to set configurations in a configMap and pass the entire configMap in the adapter deployment instead of passing each environment variable directly.
- Made the OpenObserve URL configurable in the tracing module 
- Added Helm input validation using the `fail` function to stop chart deployment if users use deprecated values

## Related Issues
https://github.com/openchoreo/openchoreo/issues/4298

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable OpenObserve host and port settings for logs and tracing integrations.
  - Added managed configuration for the OpenTelemetry tracing adapter, including server, organization, and stream settings.
  - Configuration updates now automatically trigger adapter rollouts.

- **Bug Fixes**
  - Replaced fixed OpenObserve endpoints with configurable connection details.

- **Deprecations**
  - The adapter URL setting is deprecated; use the OpenObserve host and port settings instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->