### PR TITLE
feat: make OpenObserve URL configurable in setup-logs job

### DIFF
--- a/observability-logs-openobserve/helm/templates/openobserve-setup/configmap.yaml
+++ b/observability-logs-openobserve/helm/templates/openobserve-setup/configmap.yaml
@@ -1,0 +1,15 @@
+# Copyright 2026 The OpenChoreo Authors
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.openObserveSetup.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: openobserve-setup-logs
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: openobserve-setup-logs
+data:
+  OPENOBSERVE_URL: "http://{{ .Values.common.openObserveHost }}:{{ .Values.common.openObservePort }}"
+  OPENOBSERVE_ORG: {{ .Values.common.openObserveOrg | quote }}
+{{- end }}

--- a/observability-logs-openobserve/helm/templates/openobserve-setup/job.yaml
+++ b/observability-logs-openobserve/helm/templates/openobserve-setup/job.yaml
@@ -24,6 +24,9 @@ spec:
       - name: openobserve-setup-logs
         image: "{{ .Values.openObserveSetup.image.repository }}:{{ .Values.openObserveSetup.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.openObserveSetup.image.pullPolicy | default "IfNotPresent" }}
+        envFrom:
+        - configMapRef:
+            name: openobserve-setup-logs
         env:
         - name: OPENOBSERVE_USERNAME
           valueFrom:
@@ -35,6 +38,4 @@ spec:
             secretKeyRef:
               name: openobserve-admin-credentials
               key: ZO_ROOT_USER_PASSWORD
-        - name: OPENOBSERVE_ORG
-          value: {{ .Values.common.openObserveOrg | quote }}
 {{- end }}

--- a/observability-logs-openobserve/init/setup-openobserve.sh
+++ b/observability-logs-openobserve/init/setup-openobserve.sh
@@ -8,8 +8,8 @@
 # Read configuration from environment variables
 OPENOBSERVE_PASSWORD="${OPENOBSERVE_PASSWORD}"
 OPENOBSERVE_USERNAME="${OPENOBSERVE_USERNAME}"
-
-OPENOBSERVE_URL="http://openobserve:5080"
+OPENOBSERVE_URL="${OPENOBSERVE_URL}"
+OPENOBSERVE_ORG="${OPENOBSERVE_ORG}"
 
 
 # 1. Check OpenObserve status and wait for it to become ready. Any API calls to configure
@@ -54,7 +54,6 @@ fi
 
 ## 2. Create an alert template in OpenObserve (required before creating a destination)
 
-OPENOBSERVE_ORG="default"
 TEMPLATE_NAME="openchoreo"
 
 echo "Configuring alert template..."


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat: add observability-logs-opensearch module
  fix: handle opensearch startup delay in init script
  docs: update observability-logs-opensearch module installation guide
  chore(deps): bump fluent-bit version in observability-logs-openobserve module

See: https://github.com/openchoreo/openchoreo/blob/main/docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
Make OpenObserve URL configurable in setup-logs job

## Approach
Reads the OpenObserve URL and org name from the helm values file and creates a configMap from them. Then passes the configMap to the setup-logs job

## Related Issues
https://github.com/openchoreo/openchoreo/issues/4298

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added scheme-aware OpenObserve connectivity using a boolean TLS enablement value, affecting URLs used by adapters and ingest components.
  * OpenObserve setup now reads connection URL and organization from environment configuration when creating alert templates and webhook destinations.
* **Bug Fixes**
  * Removed hardcoded OpenObserve URL and default organization values to better support customized deployments.
  * Fluent Bit and OpenTelemetry trace exporter now correctly switch between HTTP/HTTPS based on TLS enablement.
* **Documentation**
  * Updated multi-cluster remote setup notes and compatibility tables.
* **Chores**
  * Bumped module versions (logs: 0.6.0, tracing: 0.3.0).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->