### PR TITLE
fix: use the actual cost to derive the cost for the recommendation by scaling

### DIFF
--- a/finops-opencost/internal/handlers.go
+++ b/finops-opencost/internal/handlers.go
@@ -200,7 +200,6 @@ func (h *CostHandler) GetRecommendations(ctx context.Context, request gen.GetRec
 	}
 
 	components := collectComponents(sets)
-	windowHours := params.EndTime.Sub(params.StartTime).Hours()
 
 	results := make([]*gen.ComponentRecommendation, len(components))
 	jobs := make(chan int)
@@ -210,7 +209,7 @@ func (h *CostHandler) GetRecommendations(ctx context.Context, request gen.GetRec
 		go func() {
 			defer wg.Done()
 			for i := range jobs {
-				results[i] = h.recommendComponent(ctx, token, request, params, components[i], windowHours)
+				results[i] = h.recommendComponent(ctx, token, request, params, components[i])
 			}
 		}()
 	}
@@ -239,7 +238,6 @@ func (h *CostHandler) recommendComponent(
 	request gen.GetRecommendationsRequestObject,
 	params gen.GetRecommendationsParams,
 	comp componentPricing,
-	windowHours float64,
 ) *gen.ComponentRecommendation {
 	metrics, err := h.observer.QueryResourceMetrics(ctx, token, observer.ComponentSearchScope{
 		Namespace:   request.Namespace,
@@ -265,7 +263,6 @@ func (h *CostHandler) recommendComponent(
 	}
 	recommended := recommend.Compute(usage, current, h.recommendCfg)
 
-	cpuPrice, ramPrice := comp.unitPrices()
 	return &gen.ComponentRecommendation{
 		ComponentUid:   parseUUID(comp.componentUID),
 		Component:      comp.component,
@@ -274,12 +271,18 @@ func (h *CostHandler) recommendComponent(
 		ProjectUid:     parseUUID(comp.projectUID),
 		Project:        comp.project,
 		Namespace:      request.Namespace,
-		// Current cost is the actual spend reported by OpenCost. The
-		// recommendation cost is projected from the recommended request at
-		// the same unit price, since no actual spend exists for it yet.
 		Current:        buildProfile(current, comp.cpuCost, comp.ramCost),
-		Recommendation: buildProfile(recommended, recommended.CPURequest*windowHours*cpuPrice, recommended.MemRequest*windowHours*ramPrice),
+		Recommendation: buildProfile(recommended,
+			scaleCost(comp.cpuCost, quantizeCores(recommended.CPURequest), quantizeCores(current.CPURequest)),
+			scaleCost(comp.ramCost, quantizeBytes(recommended.MemRequest), quantizeBytes(current.MemRequest))),
 	}
+}
+
+func scaleCost(currentCost, recRequest, curRequest float64) float64 {
+	if curRequest <= 0 {
+		return currentCost
+	}
+	return currentCost * recRequest / curRequest
 }
 
 type componentPricing struct {
@@ -288,19 +291,7 @@ type componentPricing struct {
 	project      string
 	projectUID   string
 	cpuCost      float64
-	cpuCoreHours float64
 	ramCost      float64
-	ramByteHours float64
-}
-
-func (c componentPricing) unitPrices() (cpuPerCoreHour, ramPerByteHour float64) {
-	if c.cpuCoreHours > 0 {
-		cpuPerCoreHour = c.cpuCost / c.cpuCoreHours
-	}
-	if c.ramByteHours > 0 {
-		ramPerByteHour = c.ramCost / c.ramByteHours
-	}
-	return cpuPerCoreHour, ramPerByteHour
 }
 
 func collectComponents(sets []map[string]opencost.Allocation) []componentPricing {
@@ -324,9 +315,7 @@ func collectComponents(sets []map[string]opencost.Allocation) []componentPricing
 				order = append(order, uid)
 			}
 			c.cpuCost += alloc.CPUCost
-			c.cpuCoreHours += alloc.CPUCoreHours
 			c.ramCost += alloc.RAMCost
-			c.ramByteHours += alloc.RAMByteHours
 		}
 	}
 	result := make([]componentPricing, 0, len(order))
@@ -389,14 +378,20 @@ func values(items []observer.TimeSeriesItem) []float64 {
 	return out
 }
 
+func millicores(cores float64) int64 { return int64(cores*1000 + 0.5) }
+
+func mebibytes(bytes float64) int64 { return int64(bytes/(1024*1024) + 0.5) }
+
+func quantizeCores(cores float64) float64 { return float64(millicores(cores)) / 1000 }
+
+func quantizeBytes(bytes float64) float64 { return float64(mebibytes(bytes)) * 1024 * 1024 }
+
 func coresToQuantity(cores float64) string {
-	millicores := int64(cores*1000 + 0.5)
-	return fmt.Sprintf("%dm", millicores)
+	return fmt.Sprintf("%dm", millicores(cores))
 }
 
 func bytesToQuantity(bytes float64) string {
-	mib := int64(bytes/(1024*1024) + 0.5)
-	return fmt.Sprintf("%dMi", mib)
+	return fmt.Sprintf("%dMi", mebibytes(bytes))
 }
 
 func parseUUID(s string) openapi_types.UUID {

--- a/finops-opencost/internal/handlers_test.go
+++ b/finops-opencost/internal/handlers_test.go
@@ -197,6 +197,61 @@ func TestGetRecommendationsHappyPath(t *testing.T) {
 	}
 }
 
+func TestGetRecommendationsScalesCostByRequestRatio(t *testing.T) {
+	openCostSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"code":200,"data":[{
+		  "pod-a": {"properties":{"labels":{
+		      "openchoreo_dev_component_uid":"`+componentUID+`",
+		      "openchoreo_dev_component":"checkout",
+		      "openchoreo_dev_project_uid":"`+projectUID+`",
+		      "openchoreo_dev_project":"gcp"}},
+		    "cpuCost":10.0,"ramCost":10.0}
+		}]}`)
+	}))
+	defer openCostSrv.Close()
+
+	observerSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{
+		  "cpuUsage":[{"value":0.1},{"value":0.12},{"value":0.15}],
+		  "cpuRequests":[{"value":1.0}],
+		  "cpuLimits":[{"value":2.0}],
+		  "memoryUsage":[{"value":900000000},{"value":950000000}],
+		  "memoryRequests":[{"value":100000000}],
+		  "memoryLimits":[{"value":100000000}]
+		}`)
+	}))
+	defer observerSrv.Close()
+
+	h := newTestHandler(openCostSrv.URL, observerSrv.URL)
+	ctx := context.WithValue(context.Background(), bearerTokenKey, "test-token")
+	resp, err := h.GetRecommendations(ctx, gen.GetRecommendationsRequestObject{
+		Namespace:      "default",
+		EnvironmentUid: openapi_types.UUID(mustUUID(environmentUID)),
+		Params: gen.GetRecommendationsParams{
+			StartTime:   time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC),
+			EndTime:     time.Date(2026, 7, 2, 0, 0, 0, 0, time.UTC),
+			Environment: "development",
+		},
+	})
+	if err != nil {
+		t.Fatalf("GetRecommendations error: %v", err)
+	}
+	ok := resp.(gen.GetRecommendations200JSONResponse)
+	rec := ok.Items[0]
+
+	if rec.Recommendation.MemoryRequest != rec.Current.MemoryRequest {
+		t.Fatalf("memory request changed: cur=%q rec=%q", rec.Current.MemoryRequest, rec.Recommendation.MemoryRequest)
+	}
+	if rec.Recommendation.MemoryCost != rec.Current.MemoryCost {
+		t.Errorf("memory request unchanged but cost differs: cur=%v rec=%v", rec.Current.MemoryCost, rec.Recommendation.MemoryCost)
+	}
+
+	// cpu cost = 10 * (P95(0.1,0.12,0.15)*1.2) / 1.0 = 10 * 0.18 = 1.8
+	if got := rec.Recommendation.CpuCost; got < 1.79 || got > 1.81 {
+		t.Errorf("recommended cpu cost = %v, want ~1.8", got)
+	}
+}
+
 func TestGetComponentCostsRejectsComponentWithoutProject(t *testing.T) {
 	h := newTestHandler("http://unused", "http://unused")
 	cuid := openapi_types.UUID(mustUUID(componentUID))


### PR DESCRIPTION


<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat: add observability-logs-opensearch module
  fix: handle opensearch startup delay in init script
  docs: update observability-logs-opensearch module installation guide
  chore(deps): bump fluent-bit version in observability-logs-openobserve module

See: https://github.com/openchoreo/openchoreo/blob/main/docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
The /recommendations API returned inconsistent costs. An unchanged resource request still reported a different recommendation cost than current cost. This is because the cost for the recommended request value was calculated using the full time window. But this gave inconsistent values if pods only ran for part of the time window. This PR fixes it by deriving the cost for the recommendation by scaling it from the actual cost.

## Approach
Added a function which scales the actual OpenCost spend by the recommended-to-current request ratio to obtain the cost for the recommendation

## Related Issues
https://github.com/openchoreo/openchoreo/issues/3699

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recommendation cost projections by scaling current CPU and memory costs according to recommended resource requests.
  * Preserved current costs when resource requests are unavailable or non-positive.
  * Improved resource quantity rounding and formatting for more consistent cost calculations.

* **Tests**
  * Added coverage for recommendation cost scaling when CPU and memory requests change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->