### PR TITLE
fix: perform client side accumulation of cost values and update default helm values

### DIFF
--- a/finops-opencost/helm/values.yaml
+++ b/finops-opencost/helm/values.yaml
@@ -19,11 +19,11 @@ opencost:
       replicas: 1
       resources:
         requests:
-          cpu: "10m"
-          memory: "60Mi"
-        limits:
           cpu: "50m"
-          memory: "80Mi"
+          memory: "90Mi"
+        limits:
+          cpu: "200m"
+          memory: "200Mi"
       persistence:
         enabled: false
 
@@ -31,9 +31,9 @@ opencost:
       enabled: true
       costModel:
         description: Modified prices based on your internal pricing
-        CPU: 0.03
-        RAM: 0.004
-        storage: 0.00005
+        CPU: 1.25
+        RAM: 0.5
+        storage: 0.25
 
     metrics:
       kubeStateMetrics:

--- a/finops-opencost/internal/opencost/client.go
+++ b/finops-opencost/internal/opencost/client.go
@@ -40,12 +40,14 @@ func (c *Client) QueryAllocations(ctx context.Context, q AllocationQuery) ([]map
 	params.Set("window", BuildWindow(q.Start, q.End))
 	params.Set("aggregate", "pod")
 	params.Set("filter", BuildFilter(q.Namespace, q.EnvironmentUID, q.ProjectUID, q.ComponentUID))
+	// Always accumulate client-side. OpenCost's server-side accumulation
+	// (accumulate=true) errors with "empty AssetSet in accumulation" when the
+	// window reaches past the data it has, so we request the raw sets and let
+	// the handlers sum them.
 	if q.Step != "" {
 		params.Set("step", q.Step)
-		params.Set("accumulate", "false")
-	} else {
-		params.Set("accumulate", "true")
 	}
+	params.Set("accumulate", "false")
 
 	endpoint := c.baseURL + "/allocation/compute?" + params.Encode()
 	c.logger.Debug("querying OpenCost allocations", slog.String("url", endpoint))

--- a/finops-opencost/internal/opencost/client_test.go
+++ b/finops-opencost/internal/opencost/client_test.go
@@ -72,8 +72,11 @@ func TestQueryAllocations(t *testing.T) {
 	if alloc.Label(LabelComponentUID) != "14e6fe2a-820a-481e-9a96-018e86a241fa" {
 		t.Errorf("unexpected component uid label: %q", alloc.Label(LabelComponentUID))
 	}
-	if !contains(gotQuery, "accumulate=true") {
-		t.Errorf("expected accumulate=true in query, got %q", gotQuery)
+	if !contains(gotQuery, "accumulate=false") {
+		t.Errorf("expected accumulate=false in query, got %q", gotQuery)
+	}
+	if contains(gotQuery, "step=") {
+		t.Errorf("expected no step in query when Step is empty, got %q", gotQuery)
 	}
 }
 


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat: add observability-logs-opensearch module
  fix: handle opensearch startup delay in init script
  docs: update observability-logs-opensearch module installation guide
  chore(deps): bump fluent-bit version in observability-logs-openobserve module

See: https://github.com/openchoreo/openchoreo/blob/main/docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
When we query cost insights for a time range longer than when opencost/component ran, OpenCost returns the error `ERR error accumulating by all: error accumulating all:AllocationSetRange has empty AssetSet in accumulation`. The error originates in OpenCost's server-side accumulation (accumulate=true)

## Approach
- Stopped relying on server-side accumulation and sums the allocation sets client-side (adapter) instead
- Updated the requests and limits of OpenCost as the current values were a bottleneck
- Updated default custom cost values

## Related Issues
https://github.com/openchoreo/openchoreo/issues/3699

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Increased CPU and memory resources allocated to the OpenCost exporter for improved processing capacity.
  - Updated custom pricing values for CPU, memory, and storage calculations.
  - Allocation queries now return non-accumulated data by default, with time-step filtering applied only when configured.
  - This improves the consistency and accuracy of allocation data presented by the exporter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->