### PR TITLE
feat: add Kubewarden security policy integration

### DIFF
--- a/security-kubewarden/README.md
+++ b/security-kubewarden/README.md
@@ -1,0 +1,387 @@
+# Kubewarden Integration for OpenChoreo Data Plane
+
+This integration enforces security policies on OpenChoreo workloads using
+[Kubewarden](https://kubewarden.io/), with policies from
+[Artifact Hub](https://artifacthub.io/packages/search?kind=13).
+
+Kubewarden runs in the data plane and validates the Kubernetes resources OpenChoreo applies there.
+When a policy rejects a resource, the deployment fails and the reason appears on the component's
+`ReleaseBinding`.
+
+## Features
+
+- Enforce admission policies on the Kubernetes resources OpenChoreo deploys to the data plane
+- Scope policies by namespace, project, environment, or a platform-engineer-defined label, using
+  labels OpenChoreo already sets on cell namespaces
+- Attach a baseline policy to a `ProjectType` so it is promoted between environments with the
+  project
+
+## Install
+
+Install the Kubewarden admission controller into the cluster running the OpenChoreo **data plane**.
+
+From version 1.37 Kubewarden ships as a single chart, `kubewarden/admission-controller`. The older
+`kubewarden-controller`, `kubewarden-crds`, and `kubewarden-defaults` charts are still published but
+stop at appVersion 1.36. Use the single chart.
+
+```bash
+helm repo add kubewarden https://charts.kubewarden.io
+helm repo update kubewarden
+
+helm upgrade --install kubewarden kubewarden/admission-controller \
+  --namespace kubewarden --create-namespace \
+  --wait
+```
+
+This installs the controller, a `PolicyServer` named `default`, and an audit scanner CronJob that
+re-evaluates running workloads hourly. Confirm the policy server is running before creating
+policies:
+
+```bash
+kubectl get policyservers
+kubectl get pods -n kubewarden
+```
+
+## Scoping policies to OpenChoreo workloads
+
+> [!WARNING]
+> A `ClusterAdmissionPolicy` applies to the whole cluster unless you scope it. The data plane
+> cluster runs more than your workloads: OpenChoreo's own components live in
+> `openchoreo-data-plane`, and in a single-cluster setup such as the k3d quick start, the control
+> plane, identity provider, and observability plane run there too. An unscoped policy governs all of
+> them, and a restrictive one can stop OpenChoreo from working.
+
+Scope every policy to the cell namespaces that hold your workloads.
+
+Projects live in a namespace on the control plane. For each (namespace, project, environment),
+OpenChoreo creates a **cell namespace** in the data plane and labels it:
+
+| Label | Value |
+| :---- | :---- |
+| `openchoreo.dev/managed-by` | `renderedrelease-controller` |
+| `openchoreo.dev/namespace` | Namespace the project belongs to |
+| `openchoreo.dev/project` | Project name |
+| `openchoreo.dev/environment` | Environment name |
+
+A `ClusterAdmissionPolicy` selects cell namespaces with these labels, using `matchExpressions`.
+
+After creating a policy, check that its webhook carries the selector you expect:
+
+```bash
+kubectl get validatingwebhookconfiguration clusterwide-<policy-name> \
+  -o jsonpath='{.webhooks[0].namespaceSelector}'
+```
+
+Common scopes:
+
+```yaml
+# All OpenChoreo cell namespaces, every project and environment
+namespaceSelector:
+  matchExpressions:
+    - key: openchoreo.dev/managed-by
+      operator: In
+      values: ["renderedrelease-controller"]
+```
+
+```yaml
+# Production only
+namespaceSelector:
+  matchExpressions:
+    - key: openchoreo.dev/managed-by
+      operator: In
+      values: ["renderedrelease-controller"]
+    - key: openchoreo.dev/environment
+      operator: In
+      values: ["production"]
+```
+
+```yaml
+# One project, all environments
+namespaceSelector:
+  matchExpressions:
+    - key: openchoreo.dev/managed-by
+      operator: In
+      values: ["renderedrelease-controller"]
+    - key: openchoreo.dev/namespace
+      operator: In
+      values: ["acme"]
+    - key: openchoreo.dev/project
+      operator: In
+      values: ["checkout"]
+```
+
+`openchoreo.dev/project` holds the project *name*, which is unique within a namespace but not across
+namespaces. Pair it with `openchoreo.dev/namespace` when more than one namespace is in use.
+
+Keep `openchoreo.dev/managed-by` in every selector, so a policy only applies to namespaces
+OpenChoreo created.
+
+### Scoping by a custom label
+
+Namespace, project, and environment do not always describe which policies a workload needs. Some
+projects have to meet stricter rules than the rest of the platform, and they will not always share a
+namespace or an environment.
+
+The default `ClusterProjectType` merges `environmentConfigs.namespaceLabels` into the cell
+namespace, so you can label the cells that need the stricter rules and scope a policy to that label.
+
+Label the cells, per environment, on the `ProjectReleaseBinding`:
+
+```yaml
+spec:
+  environmentConfigs:
+    namespaceLabels:
+      compliance-tier: strict
+```
+
+Then scope the policy to the label instead of an environment name:
+
+```yaml
+namespaceSelector:
+  matchExpressions:
+    - key: openchoreo.dev/managed-by
+      operator: In
+      values: ["renderedrelease-controller"]
+    - key: compliance-tier
+      operator: In
+      values: ["strict"]
+```
+
+Because the label is set per binding, the same project can carry the stricter policy in production
+and not in development.
+
+## Applying policies directly
+
+The [`policies/`](policies) directory has three examples, each wrapping a policy from Artifact Hub
+and scoped to OpenChoreo cell namespaces. Edit the settings to match your own rules before applying.
+
+| File | Enforces |
+| :--- | :------- |
+| [`no-latest-tag.yaml`](policies/no-latest-tag.yaml) | Rejects the mutable `latest` tag, all cell namespaces |
+| [`trusted-registry.yaml`](policies/trusted-registry.yaml) | Restricts images to an approved registry list |
+| [`production-only.yaml`](policies/production-only.yaml) | Same tag rule, scoped to the `production` environment only |
+
+Each starts in `monitor` mode, where the policy evaluates every matching resource but never blocks
+it. Violations are written to the policy server log on the data plane:
+
+```bash
+kubectl apply -f policies/no-latest-tag.yaml
+
+# A policy takes up to about a minute to become active while its module is pulled.
+# It evaluates nothing during that window.
+kubectl get clusteradmissionpolicy openchoreo-no-latest-tag -o wide
+
+kubectl logs -n kubewarden -l kubewarden/policy-server=default | grep "policy evaluation"
+```
+
+Deploy the components you expect to pass and the ones you expect to fail, then read that log. Switch
+to enforcement once it reports violations only for the workloads you intend to block:
+
+```bash
+kubectl patch clusteradmissionpolicy openchoreo-no-latest-tag \
+  --type=merge -p '{"spec":{"mode":"protect"}}'
+```
+
+Enforcement begins once the policy server finishes rolling a new pod, which takes a few moments
+after the patch. Note that `protect` cannot be changed back to `monitor`; relaxing a policy means
+deleting and recreating it.
+
+## Delivering policies through a ProjectType
+
+The policies above are `ClusterAdmissionPolicy` resources that a platform engineer applies directly
+to the data plane. A second option is to declare a namespaced `AdmissionPolicy` inside a
+`ProjectType`, so every project built on that type receives the policy in each of its cell
+namespaces.
+
+The two approaches serve different purposes and can be used together.
+
+| | `ClusterAdmissionPolicy` | ProjectType `AdmissionPolicy` |
+| :--- | :--- | :--- |
+| Applies to | Any namespace, including ones OpenChoreo does not manage | Cell namespaces of projects using that ProjectType |
+| Rollout | Applied directly, takes effect immediately | Cut as a new ProjectRelease, promoted per environment |
+| Scoping | `namespaceSelector` | Inherent to the namespace, nothing to configure |
+
+Use cluster-wide policies for platform guardrails that must hold everywhere, and ProjectType
+policies for a baseline that belongs to the project definition and should move through environments
+with it.
+
+> [!IMPORTANT]
+> `Project.spec.type` is immutable. An existing project cannot be moved to a different ProjectType,
+> so to add a policy to projects that already exist you must edit the ProjectType they already
+> reference. Applying a new ProjectType only affects projects created against it afterwards.
+
+To use the ProjectType approach:
+
+1. Grant the data-plane agent permission to manage Kubewarden policy resources. It has none by
+   default, and without this the ProjectReleaseBinding reports an apply failure.
+
+   ```bash
+   kubectl apply -f cluster-agent-kubewarden-rbac.yaml
+   ```
+
+2. Add the policy to a ProjectType.
+
+   **For projects that already exist**, add this resource to the `spec.resources` of the
+   ProjectType they reference, alongside the existing `cell-namespace` entry:
+
+   ```yaml
+   - id: cell-baseline-policy
+     template:
+       apiVersion: policies.kubewarden.io/v1
+       kind: AdmissionPolicy
+       metadata:
+         name: cell-trusted-registry
+         namespace: ${metadata.namespace}
+       spec:
+         policyServer: default
+         module: ghcr.io/kubewarden/policies/trusted-repos:v2.1.3
+         mode: monitor
+         mutating: false
+         rules:
+           - apiGroups: ["apps"]
+             apiVersions: ["v1"]
+             resources: ["deployments"]
+             operations: ["CREATE", "UPDATE"]
+         settings:
+           registries:
+             allow: ["ghcr.io"]
+   ```
+
+   **For new projects**, apply
+   [`samples/projecttype-with-baseline-policy.yaml`](samples/projecttype-with-baseline-policy.yaml),
+   a complete ProjectType that provisions the cell namespace and this policy, then set
+   `spec.type` on new Projects to reference it.
+
+   Either way, the Project controller cuts a new `ProjectRelease` once the referenced ProjectType
+   changes.
+
+3. Point each `ProjectReleaseBinding` at the new `ProjectRelease` when you are ready for that
+   environment to pick up the policy.
+
+   ```bash
+   kubectl get projectreleases -n <namespace>
+   kubectl patch projectreleasebinding <project>-<environment> -n <namespace> \
+     --type=merge -p '{"spec":{"projectRelease":"<new-release>"}}'
+   ```
+
+A namespaced `AdmissionPolicy` only evaluates resources in its own namespace, so it needs no
+selector.
+
+When removing this setup, revert the ProjectType and let the bindings finish cleaning up **before**
+deleting the RBAC. If the agent loses `delete` permission while policies still exist, cleanup fails
+silently and leaves an enforcing policy that OpenChoreo can no longer remove.
+
+## What a rejection looks like
+
+When a policy rejects a manifest, the apply fails and the message reaches the `ReleaseBinding` for
+the affected component and environment:
+
+```bash
+kubectl get releasebinding <component>-<environment> -n <namespace> \
+  -o jsonpath='{.status.conditions[?(@.type=="Ready")].message}'
+```
+
+```
+Failed to apply resources to target plane: failed to apply resource
+deployment-checkout-development-a43512ee: admission webhook
+"clusterwide-openchoreo-no-latest-tag.kubewarden.admission" denied the request:
+not allowed, reported errors: tags not allowed: latest
+```
+
+In the OpenChoreo portal the environment shows a failed state on the component's **Deploy** tab,
+and **View details** shows the full message including the policy that rejected it.
+
+Two things to know about the resulting state:
+
+- The rejected resource keeps its previous version, so a running workload continues to serve while
+  a new deployment is blocked. Runtime health stays healthy even though the deployment failed.
+- Resources are applied in order and the apply stops at the first rejection, so resources earlier in
+  the release may already be updated. Correct the violation and the next reconcile applies the
+  release in full.
+
+## Where policy results appear
+
+A `protect` rejection reaches OpenChoreo, because the apply fails. A `monitor` violation does not,
+because the apply succeeds. To see what a policy is flagging, read the audit scanner's reports on
+the data plane:
+
+```bash
+kubectl get reports.openreports.io -A -o jsonpath=\
+'{range .items[*]}{.scope.kind}/{.scope.name}{"\n"}{range .results[?(@.result=="fail")]}    {.properties.policy-name}: {.message}{"\n"}{end}{end}'
+```
+
+```text
+Deployment/echo-websocket-service-development-a43512ee
+    openchoreo-trusted-registry: not allowed, reported errors: registries not allowed: docker.io
+```
+
+Each report carries one result per policy that evaluated the resource, passes included, so the
+filter above is what limits the output to violations. A resource with no failures prints its name
+with nothing under it.
+
+The scanner rewrites these on each run, hourly by default, so a report lags a change by up to that
+interval. For immediate feedback while testing a policy, read the policy server log instead:
+
+```bash
+kubectl logs -n kubewarden -l kubewarden/policy-server=default
+```
+
+Reports cover every namespace on the cluster, including ones OpenChoreo does not manage, and reading
+them needs data plane access rather than anything surfaced through OpenChoreo. Kubewarden also ships
+[Policy Reporter](https://kyverno.github.io/policy-reporter/), a dashboard over the same reports,
+which is not installed by default (`auditScanner.policyReporter`). The reports above carry
+everything it displays, so it is optional. See the
+[Kubewarden audit scanner documentation](https://docs.kubewarden.io/admission-controller/1.37/en/howtos/audit-scanner.html).
+
+## Choosing policies
+
+[Artifact Hub](https://artifacthub.io/packages/search?kind=13) hosts the Kubewarden policy library.
+Useful starting points for OpenChoreo workloads:
+
+| Policy | Enforces |
+| :----- | :------- |
+| [trusted-repos](https://artifacthub.io/packages/kubewarden/kubewarden-policy-library/trusted-repos) | Images come from approved registries, or reject mutable tags such as `latest` |
+| [pod-privileged-policy](https://artifacthub.io/packages/kubewarden/kubewarden-policy-library/pod-privileged-policy) | No privileged containers |
+| [host-namespaces-psp](https://artifacthub.io/packages/kubewarden/kubewarden-policy-library/host-namespaces-psp) | No `hostNetwork`, `hostPID`, or `hostIPC` |
+| [hostpaths-psp](https://artifacthub.io/packages/kubewarden/kubewarden-policy-library/hostpaths-psp) | No `hostPath` volumes |
+| [env-variable-secrets-scanner](https://artifacthub.io/packages/kubewarden/kubewarden-policy-library/env-variable-secrets-scanner) | No secrets pasted into environment variables |
+
+These all target what a developer controls through a Workload: the image, and what the container
+asks of the node.
+
+> [!NOTE]
+> The built-in `deployment/service` ComponentType sets no `securityContext`. A policy requiring
+> `runAsNonRoot`, `allowPrivilegeEscalation: false`, or a seccomp profile therefore rejects every
+> component built with it. Set those fields in the ComponentType, or use a mutating policy to add
+> them.
+
+## Uninstall
+
+Delete the policies first, then the controller. Removing the chart while policies still exist leaves
+webhooks that reject all matching requests.
+
+If you used the ProjectType approach, revert the ProjectType and let the bindings finish cleaning up
+first. The agent needs its RBAC grant to delete the policies it created, so removing that grant too
+early strands them.
+
+```bash
+# 1. If used: revert the ProjectType, re-pin bindings, and confirm the policies are gone
+kubectl get admissionpolicies.policies.kubewarden.io -A
+
+# 2. Remove cluster-wide policies
+kubectl delete clusteradmissionpolicies --all
+
+# 3. Remove the agent RBAC grant, if it was applied
+kubectl delete -f cluster-agent-kubewarden-rbac.yaml --ignore-not-found
+
+# 4. Remove Kubewarden
+helm uninstall kubewarden -n kubewarden
+kubectl delete namespace kubewarden
+```
+
+## Compatibility
+
+| Component | Compatible version | Notes |
+| :-------- | :----------------- | :---- |
+| **Kubewarden** | `1.37.x` | Chart `kubewarden/admission-controller` 6.x. Earlier versions use three separate charts. |
+| **OpenChoreo** | `1.2.x` | Verified against 1.2.2. Requires the `openchoreo.dev/*` labels on cell namespaces. |

--- a/security-kubewarden/README.md
+++ b/security-kubewarden/README.md
@@ -177,6 +177,7 @@ produces nothing until its next deployment. To check what a new policy would do 
 already on the cluster, run the audit scanner instead of waiting for its hourly schedule:
 
 ```bash
+kubectl delete job -n kubewarden audit-now --ignore-not-found
 kubectl create job -n kubewarden audit-now --from=cronjob/audit-scanner
 kubectl wait --for=condition=complete job/audit-now -n kubewarden --timeout=5m
 ```
@@ -326,6 +327,7 @@ The scanner rewrites these on each run, hourly by default, so reports lag a chan
 interval and there are none at all until the first run. Trigger a scan when you do not want to wait:
 
 ```bash
+kubectl delete job -n kubewarden audit-now --ignore-not-found
 kubectl create job -n kubewarden audit-now --from=cronjob/audit-scanner
 ```
 

--- a/security-kubewarden/README.md
+++ b/security-kubewarden/README.md
@@ -162,7 +162,7 @@ and scoped to OpenChoreo cell namespaces. Edit the settings to match your own ru
 | [`production-only.yaml`](policies/production-only.yaml) | Same tag rule, scoped to the `production` environment only |
 
 Each starts in `monitor` mode, where the policy evaluates every matching resource but never blocks
-it. Violations are written to the policy server log on the data plane:
+it.
 
 ```bash
 kubectl apply -f policies/no-latest-tag.yaml
@@ -170,12 +170,19 @@ kubectl apply -f policies/no-latest-tag.yaml
 # A policy takes up to about a minute to become active while its module is pulled.
 # It evaluates nothing during that window.
 kubectl get clusteradmissionpolicy openchoreo-no-latest-tag -o wide
-
-kubectl logs -n kubewarden -l kubewarden/policy-server=default | grep "policy evaluation"
 ```
 
-Deploy the components you expect to pass and the ones you expect to fail, then read that log. Switch
-to enforcement once it reports violations only for the workloads you intend to block:
+A policy only sees a workload when something is applied, so a component that is already running
+produces nothing until its next deployment. To check what a new policy would do to workloads
+already on the cluster, run the audit scanner instead of waiting for its hourly schedule:
+
+```bash
+kubectl create job -n kubewarden audit-now --from=cronjob/audit-scanner
+kubectl wait --for=condition=complete job/audit-now -n kubewarden --timeout=5m
+```
+
+Read the results as described in [Where policy results appear](#where-policy-results-appear), then
+switch to enforcement once only the workloads you intend to block are reported:
 
 ```bash
 kubectl patch clusteradmissionpolicy openchoreo-no-latest-tag \
@@ -252,8 +259,7 @@ To use the ProjectType approach:
    a complete ProjectType that provisions the cell namespace and this policy, then set
    `spec.type` on new Projects to reference it.
 
-   Either way, the Project controller cuts a new `ProjectRelease` once the referenced ProjectType
-   changes.
+   Either way, the Project controller produces a `ProjectRelease` for the updated ProjectType.
 
 3. Point each `ProjectReleaseBinding` at the new `ProjectRelease` when you are ready for that
    environment to pick up the policy.
@@ -289,12 +295,13 @@ not allowed, reported errors: tags not allowed: latest
 ```
 
 In the OpenChoreo portal the environment shows a failed state on the component's **Deploy** tab,
-and **View details** shows the full message including the policy that rejected it.
+and **View details** shows the full message including the policy that rejected it. The **Runtime
+Health** card stays green, because the previous version is still serving.
 
 Two things to know about the resulting state:
 
 - The rejected resource keeps its previous version, so a running workload continues to serve while
-  a new deployment is blocked. Runtime health stays healthy even though the deployment failed.
+  a new deployment is blocked.
 - Resources are applied in order and the apply stops at the first rejection, so resources earlier in
   the release may already be updated. Correct the violation and the next reconcile applies the
   release in full.
@@ -315,12 +322,14 @@ Deployment/echo-websocket-service-development-a43512ee
     openchoreo-trusted-registry: not allowed, reported errors: registries not allowed: docker.io
 ```
 
-Each report carries one result per policy that evaluated the resource, passes included, so the
-filter above is what limits the output to violations. A resource with no failures prints its name
-with nothing under it.
+The scanner rewrites these on each run, hourly by default, so reports lag a change by up to that
+interval and there are none at all until the first run. Trigger a scan when you do not want to wait:
 
-The scanner rewrites these on each run, hourly by default, so a report lags a change by up to that
-interval. For immediate feedback while testing a policy, read the policy server log instead:
+```bash
+kubectl create job -n kubewarden audit-now --from=cronjob/audit-scanner
+```
+
+The policy server log has the individual admission decisions:
 
 ```bash
 kubectl logs -n kubewarden -l kubewarden/policy-server=default
@@ -365,11 +374,14 @@ first. The agent needs its RBAC grant to delete the policies it created, so remo
 early strands them.
 
 ```bash
-# 1. If used: revert the ProjectType, re-pin bindings, and confirm the policies are gone
+# 1. If used: remove the policy from your ProjectType and re-pin each binding to the
+#    ProjectRelease that matches the updated type. An existing release is reused when the
+#    content matches, so a new one does not always appear. Confirm the policies are gone:
+kubectl get projectreleases -n <namespace>
 kubectl get admissionpolicies.policies.kubewarden.io -A
 
-# 2. Remove cluster-wide policies
-kubectl delete clusteradmissionpolicies --all
+# 2. Remove this integration's policies
+kubectl delete clusteradmissionpolicies -l app.kubernetes.io/name=security-kubewarden
 
 # 3. Remove the agent RBAC grant, if it was applied
 kubectl delete -f cluster-agent-kubewarden-rbac.yaml --ignore-not-found
@@ -378,6 +390,8 @@ kubectl delete -f cluster-agent-kubewarden-rbac.yaml --ignore-not-found
 helm uninstall kubewarden -n kubewarden
 kubectl delete namespace kubewarden
 ```
+
+`helm uninstall` keeps the Kubewarden CRDs, so a later reinstall finds them already in place.
 
 ## Compatibility
 

--- a/security-kubewarden/cluster-agent-kubewarden-rbac.yaml
+++ b/security-kubewarden/cluster-agent-kubewarden-rbac.yaml
@@ -1,0 +1,49 @@
+# Copyright 2026 The OpenChoreo Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Only required for the ProjectType-delivered policy approach (see the README).
+# Cluster-wide policies applied directly by a platform engineer do not need this.
+#
+# Lets the OpenChoreo data-plane agent manage Kubewarden policy resources, so a
+# ProjectType can carry an AdmissionPolicy into each cell namespace it creates.
+#
+# The subject below is the standard data-plane agent ServiceAccount
+# (`cluster-agent-dataplane` in `openchoreo-data-plane`). If your data plane uses a
+# different ServiceAccount name or namespace, edit the ClusterRoleBinding subject.
+# Apply this on the cluster running the OpenChoreo data plane.
+#
+# Note on removal: keep this grant in place until the policies have been cleaned
+# up. If the agent loses `delete` while policies still exist, stale-resource
+# cleanup fails silently and leaves an enforcing policy that OpenChoreo can no
+# longer remove.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: openchoreo-cluster-agent-kubewarden
+  labels:
+    app.kubernetes.io/name: security-kubewarden
+    app.kubernetes.io/part-of: openchoreo
+    app.kubernetes.io/component: cluster-agent
+rules:
+  - apiGroups: ["policies.kubewarden.io"]
+    resources:
+      - admissionpolicies
+      - admissionpolicygroups
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: openchoreo-cluster-agent-kubewarden
+  labels:
+    app.kubernetes.io/name: security-kubewarden
+    app.kubernetes.io/part-of: openchoreo
+    app.kubernetes.io/component: cluster-agent
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: openchoreo-cluster-agent-kubewarden
+subjects:
+  - kind: ServiceAccount
+    name: cluster-agent-dataplane
+    namespace: openchoreo-data-plane

--- a/security-kubewarden/policies/no-latest-tag.yaml
+++ b/security-kubewarden/policies/no-latest-tag.yaml
@@ -16,6 +16,9 @@ apiVersion: policies.kubewarden.io/v1
 kind: ClusterAdmissionPolicy
 metadata:
   name: openchoreo-no-latest-tag
+  labels:
+    app.kubernetes.io/name: security-kubewarden
+    app.kubernetes.io/part-of: openchoreo
 spec:
   policyServer: default
   module: ghcr.io/kubewarden/policies/trusted-repos:v2.1.3

--- a/security-kubewarden/policies/no-latest-tag.yaml
+++ b/security-kubewarden/policies/no-latest-tag.yaml
@@ -1,0 +1,37 @@
+# Copyright 2026 The OpenChoreo Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Rejects container images that use the mutable `latest` tag, across every
+# OpenChoreo cell namespace.
+#
+# Starts in `monitor` mode: violations are recorded, nothing is blocked. Switch to
+# `protect` once the reported violations look right. Note that `protect` cannot be
+# changed back to `monitor`; relaxing the policy means deleting and recreating it.
+#
+# `rules` below covers Deployments only. Add the kinds your ComponentTypes render,
+# or the policy passes them without checking. The built-in `scheduled-task` renders
+# a `batch/v1 CronJob`, and `statefulset/*` and `job/*` ComponentTypes render
+# StatefulSets and Jobs.
+apiVersion: policies.kubewarden.io/v1
+kind: ClusterAdmissionPolicy
+metadata:
+  name: openchoreo-no-latest-tag
+spec:
+  policyServer: default
+  module: ghcr.io/kubewarden/policies/trusted-repos:v2.1.3
+  mode: monitor
+  mutating: false
+  namespaceSelector:
+    matchExpressions:
+      - key: openchoreo.dev/managed-by
+        operator: In
+        values: ["renderedrelease-controller"]
+  rules:
+    - apiGroups: ["apps"]
+      apiVersions: ["v1"]
+      resources: ["deployments"]
+      operations: ["CREATE", "UPDATE"]
+  settings:
+    tags:
+      reject:
+        - latest

--- a/security-kubewarden/policies/production-only.yaml
+++ b/security-kubewarden/policies/production-only.yaml
@@ -1,0 +1,41 @@
+# Copyright 2026 The OpenChoreo Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Example of scoping a policy to a single environment. This one applies only to
+# cell namespaces whose Environment is named `production`, leaving development and
+# staging free to deploy images that would be rejected in production.
+#
+# The same pattern works for other axes by swapping the second matchExpression:
+#
+#   openchoreo.dev/namespace     namespace the project belongs to
+#   openchoreo.dev/project       project name (unique within a namespace)
+#   openchoreo.dev/environment   environment name
+#
+# Expressions are ANDed, so add more entries to narrow further. Keep the
+# `managed-by` entry so the policy only governs OpenChoreo-managed cells.
+apiVersion: policies.kubewarden.io/v1
+kind: ClusterAdmissionPolicy
+metadata:
+  name: openchoreo-production-no-latest-tag
+spec:
+  policyServer: default
+  module: ghcr.io/kubewarden/policies/trusted-repos:v2.1.3
+  mode: monitor
+  mutating: false
+  namespaceSelector:
+    matchExpressions:
+      - key: openchoreo.dev/managed-by
+        operator: In
+        values: ["renderedrelease-controller"]
+      - key: openchoreo.dev/environment
+        operator: In
+        values: ["production"]
+  rules:
+    - apiGroups: ["apps"]
+      apiVersions: ["v1"]
+      resources: ["deployments"]
+      operations: ["CREATE", "UPDATE"]
+  settings:
+    tags:
+      reject:
+        - latest

--- a/security-kubewarden/policies/production-only.yaml
+++ b/security-kubewarden/policies/production-only.yaml
@@ -17,6 +17,9 @@ apiVersion: policies.kubewarden.io/v1
 kind: ClusterAdmissionPolicy
 metadata:
   name: openchoreo-production-no-latest-tag
+  labels:
+    app.kubernetes.io/name: security-kubewarden
+    app.kubernetes.io/part-of: openchoreo
 spec:
   policyServer: default
   module: ghcr.io/kubewarden/policies/trusted-repos:v2.1.3

--- a/security-kubewarden/policies/trusted-registry.yaml
+++ b/security-kubewarden/policies/trusted-registry.yaml
@@ -1,0 +1,35 @@
+# Copyright 2026 The OpenChoreo Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Restricts container images to an approved registry list, across every OpenChoreo
+# cell namespace.
+#
+# Replace the registries under `settings.registries.allow` with your own before
+# applying. Any image from a registry not on the list is rejected, including the
+# public samples that pull from docker.io.
+#
+# Starts in `monitor` mode. See policies/no-latest-tag.yaml for notes on switching
+# to `protect` and on covering workload kinds beyond Deployment.
+apiVersion: policies.kubewarden.io/v1
+kind: ClusterAdmissionPolicy
+metadata:
+  name: openchoreo-trusted-registry
+spec:
+  policyServer: default
+  module: ghcr.io/kubewarden/policies/trusted-repos:v2.1.3
+  mode: monitor
+  mutating: false
+  namespaceSelector:
+    matchExpressions:
+      - key: openchoreo.dev/managed-by
+        operator: In
+        values: ["renderedrelease-controller"]
+  rules:
+    - apiGroups: ["apps"]
+      apiVersions: ["v1"]
+      resources: ["deployments"]
+      operations: ["CREATE", "UPDATE"]
+  settings:
+    registries:
+      allow:
+        - ghcr.io

--- a/security-kubewarden/policies/trusted-registry.yaml
+++ b/security-kubewarden/policies/trusted-registry.yaml
@@ -14,6 +14,9 @@ apiVersion: policies.kubewarden.io/v1
 kind: ClusterAdmissionPolicy
 metadata:
   name: openchoreo-trusted-registry
+  labels:
+    app.kubernetes.io/name: security-kubewarden
+    app.kubernetes.io/part-of: openchoreo
 spec:
   policyServer: default
   module: ghcr.io/kubewarden/policies/trusted-repos:v2.1.3

--- a/security-kubewarden/samples/projecttype-with-baseline-policy.yaml
+++ b/security-kubewarden/samples/projecttype-with-baseline-policy.yaml
@@ -25,9 +25,9 @@
 # A namespaced AdmissionPolicy only evaluates resources in its own namespace, so no
 # namespaceSelector is needed.
 #
-# Changing a ProjectType cuts a new ProjectRelease. Existing ProjectReleaseBindings
-# stay pinned to their current release until you point them at the new one, so the
-# policy rolls out per environment on your schedule.
+# Adding this resource produces a new ProjectRelease. Existing ProjectReleaseBindings
+# stay pinned to their current release until you point them at it, so the policy rolls
+# out per environment on your schedule.
 apiVersion: openchoreo.dev/v1alpha1
 kind: ClusterProjectType
 metadata:

--- a/security-kubewarden/samples/projecttype-with-baseline-policy.yaml
+++ b/security-kubewarden/samples/projecttype-with-baseline-policy.yaml
@@ -1,0 +1,89 @@
+# Copyright 2026 The OpenChoreo Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+# A ClusterProjectType that provisions the cell namespace and a baseline Kubewarden
+# policy inside it. Every project using this type gets the policy in each of its
+# cell namespaces, and the policy is promoted between environments the same way any
+# other release is.
+#
+# This is the `default` ClusterProjectType with one extra resource,
+# `cell-baseline-policy`.
+#
+# NOTE: applying this file only affects projects created against it afterwards.
+# `Project.spec.type` is immutable, so an existing project cannot be switched to
+# this type. To add the policy to projects that already exist, copy the
+# `cell-baseline-policy` resource below into the ProjectType they already
+# reference; the Project controller then cuts a new ProjectRelease.
+#
+# Prerequisites:
+#
+#   1. Kubewarden installed on the data plane.
+#   2. cluster-agent-kubewarden-rbac.yaml applied, otherwise the agent cannot
+#      create the AdmissionPolicy and the ProjectReleaseBinding will report an
+#      apply failure.
+#
+# A namespaced AdmissionPolicy only evaluates resources in its own namespace, so no
+# namespaceSelector is needed.
+#
+# Changing a ProjectType cuts a new ProjectRelease. Existing ProjectReleaseBindings
+# stay pinned to their current release until you point them at the new one, so the
+# policy rolls out per environment on your schedule.
+apiVersion: openchoreo.dev/v1alpha1
+kind: ClusterProjectType
+metadata:
+  name: governed
+  annotations:
+    openchoreo.dev/display-name: Governed Project Type
+    openchoreo.dev/description: >-
+      Provisions the cell namespace and a baseline Kubewarden admission policy per
+      environment. Use as a starting point for projects that must enforce a
+      security baseline as part of the project definition rather than through a
+      cluster-wide policy.
+  labels:
+    openchoreo.dev/name: governed
+spec:
+  environmentConfigs:
+    openAPIV3Schema:
+      type: object
+      properties:
+        namespaceLabels:
+          type: object
+          additionalProperties:
+            type: string
+          default: {}
+        namespaceAnnotations:
+          type: object
+          additionalProperties:
+            type: string
+          default: {}
+  resources:
+    - id: cell-namespace
+      template:
+        apiVersion: v1
+        kind: Namespace
+        metadata:
+          name: ${metadata.namespace}
+          labels: ${oc_merge(metadata.labels, environmentConfigs.namespaceLabels)}
+          annotations: ${environmentConfigs.namespaceAnnotations}
+
+    - id: cell-baseline-policy
+      template:
+        apiVersion: policies.kubewarden.io/v1
+        kind: AdmissionPolicy
+        metadata:
+          name: cell-trusted-registry
+          namespace: ${metadata.namespace}
+        spec:
+          policyServer: default
+          module: ghcr.io/kubewarden/policies/trusted-repos:v2.1.3
+          mode: monitor
+          mutating: false
+          rules:
+            - apiGroups: ["apps"]
+              apiVersions: ["v1"]
+              resources: ["deployments"]
+              operations: ["CREATE", "UPDATE"]
+          settings:
+            registries:
+              allow:
+                - ghcr.io


### PR DESCRIPTION
## Purpose

Kubewarden maintainers proposed integrating Kubewarden with OpenChoreo in openchoreo/openchoreo#3856. The agreed first phase is the admission controller in the data plane: Kubewarden validates the Kubernetes resources the control plane applies, so existing policies from Artifact Hub work without any OpenChoreo-side changes.

This adds the integration docs and the supporting manifests.

## Approach

- README covering install, scoping policies to OpenChoreo cell namespaces, what a rejection looks like to a developer, and where policy results appear
- Three sample `ClusterAdmissionPolicy` manifests under `policies/`, each scoped to cell namespaces and starting in `monitor` mode
- `cluster-agent-kubewarden-rbac.yaml` granting the data-plane agent permission to manage Kubewarden policy resources
- `samples/projecttype-with-baseline-policy.yaml` showing a ProjectType that carries a baseline policy into each cell namespace, so it is promoted between environments with the project

Verified end to end on a k3d OpenChoreo 1.2.2 install: policy scoping by namespace, project and environment; rejection messages reaching the component's `ReleaseBinding` and the Backstage Deploy tab; recovery once the violation is fixed; and ProjectType-delivered policies promoting per environment.

## Related Issues

Related openchoreo/openchoreo#4272
Related openchoreo/openchoreo#3856

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [x] Samples updated (if applicable)
- [x] This PR includes AI-generated code or content

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Kubernetes admission policies to block mutable `latest` image tags.
  * Added trusted-registry enforcement, initially allowing images from `ghcr.io`.
  * Added a sample governed project type that applies baseline deployment policies.
  * Added required permissions for data-plane agents to manage admission policies.

* **Documentation**
  * Added setup, configuration, rollout, audit, cleanup, and compatibility guidance for Kubewarden integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->