### PR TITLE
feat(agent-sandbox): values-driven extraAllowedTraits for ai-agent

### DIFF
--- a/agent-sandbox/helm/templates/agent-clustercomponenttype.yaml
+++ b/agent-sandbox/helm/templates/agent-clustercomponenttype.yaml
@@ -22,6 +22,9 @@ spec:
   allowedTraits:
     - kind: ClusterTrait
       name: observability-alert-rule
+    {{- with (index .Values.componentTypes.extraAllowedTraits "ai-agent") }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 
   parameters:
     openAPIV3Schema:

--- a/agent-sandbox/helm/templates/agent-clustercomponenttype.yaml
+++ b/agent-sandbox/helm/templates/agent-clustercomponenttype.yaml
@@ -22,7 +22,7 @@ spec:
   allowedTraits:
     - kind: ClusterTrait
       name: observability-alert-rule
-    {{- with (index .Values.componentTypes.extraAllowedTraits "ai-agent") }}
+    {{- with (index .Values.componentTypes "ai-agent" "extraAllowedTraits") }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
 

--- a/agent-sandbox/helm/templates/ai-agent-claude-clustercomponenttype.yaml
+++ b/agent-sandbox/helm/templates/ai-agent-claude-clustercomponenttype.yaml
@@ -12,6 +12,11 @@ spec:
   # Fixed image, kata isolation, terminal-only — no user-tunable parameters.
   workloadType: proxy
 
+  {{- with (index .Values.componentTypes "ai-agent-claude" "extraAllowedTraits") }}
+  allowedTraits:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+
   environmentConfigs:
     openAPIV3Schema:
       type: object

--- a/agent-sandbox/helm/templates/ai-agent-codex-clustercomponenttype.yaml
+++ b/agent-sandbox/helm/templates/ai-agent-codex-clustercomponenttype.yaml
@@ -12,6 +12,11 @@ spec:
   # Fixed image, kata isolation, terminal-only — no user-tunable parameters.
   workloadType: proxy
 
+  {{- with (index .Values.componentTypes "ai-agent-codex" "extraAllowedTraits") }}
+  allowedTraits:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+
   environmentConfigs:
     openAPIV3Schema:
       type: object

--- a/agent-sandbox/helm/templates/ai-agent-copilot-clustercomponenttype.yaml
+++ b/agent-sandbox/helm/templates/ai-agent-copilot-clustercomponenttype.yaml
@@ -12,6 +12,11 @@ spec:
   # Fixed image, kata isolation, terminal-only — no user-tunable parameters.
   workloadType: proxy
 
+  {{- with (index .Values.componentTypes "ai-agent-copilot" "extraAllowedTraits") }}
+  allowedTraits:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+
   environmentConfigs:
     openAPIV3Schema:
       type: object

--- a/agent-sandbox/helm/templates/ai-agent-cursor-clustercomponenttype.yaml
+++ b/agent-sandbox/helm/templates/ai-agent-cursor-clustercomponenttype.yaml
@@ -12,6 +12,11 @@ spec:
   # Fixed image, kata isolation, terminal-only — no user-tunable parameters.
   workloadType: proxy
 
+  {{- with (index .Values.componentTypes "ai-agent-cursor" "extraAllowedTraits") }}
+  allowedTraits:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+
   environmentConfigs:
     openAPIV3Schema:
       type: object

--- a/agent-sandbox/helm/templates/ai-agent-gemini-clustercomponenttype.yaml
+++ b/agent-sandbox/helm/templates/ai-agent-gemini-clustercomponenttype.yaml
@@ -12,6 +12,11 @@ spec:
   # Fixed image, kata isolation, terminal-only — no user-tunable parameters.
   workloadType: proxy
 
+  {{- with (index .Values.componentTypes "ai-agent-gemini" "extraAllowedTraits") }}
+  allowedTraits:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+
   environmentConfigs:
     openAPIV3Schema:
       type: object

--- a/agent-sandbox/helm/templates/ai-agent-openclaw-clustercomponenttype.yaml
+++ b/agent-sandbox/helm/templates/ai-agent-openclaw-clustercomponenttype.yaml
@@ -12,6 +12,11 @@ spec:
   # Fixed image, kata isolation, egress allowed — no user-tunable parameters.
   workloadType: proxy
 
+  {{- with (index .Values.componentTypes "ai-agent-openclaw" "extraAllowedTraits") }}
+  allowedTraits:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+
   validations:
     - rule: >-
         ${workload.endpoints.exists(name, ep, "external" in ep.visibility)

--- a/agent-sandbox/helm/templates/ai-agent-opencode-clustercomponenttype.yaml
+++ b/agent-sandbox/helm/templates/ai-agent-opencode-clustercomponenttype.yaml
@@ -12,6 +12,11 @@ spec:
   # Fixed image, kata isolation, terminal-only — no user-tunable parameters.
   workloadType: proxy
 
+  {{- with (index .Values.componentTypes "ai-agent-opencode" "extraAllowedTraits") }}
+  allowedTraits:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+
   environmentConfigs:
     openAPIV3Schema:
       type: object

--- a/agent-sandbox/helm/values.yaml
+++ b/agent-sandbox/helm/values.yaml
@@ -19,15 +19,29 @@ dataPlaneServiceAccount: cluster-agent-dataplane
 # *control plane* resources; set to false on a data-plane-only install.
 componentTypes:
   enabled: true
-  # ai-agent groups per-component-type customizations for the ai-agent
+  # Each block below groups per-component-type customizations for that
   # ClusterComponentType. extraAllowedTraits appends additional entries to
   # its allowedTraits. Defaults to empty — no behavior change unless set.
   # Lets consumers attach platform-specific traits (credential injection,
-  # hardening, etc.) to ai-agent without forking the ClusterComponentType.
+  # hardening, etc.) without forking the ClusterComponentType.
   ai-agent:
     extraAllowedTraits: []
     #   - kind: ClusterTrait
     #     name: my-platform-trait
+  ai-agent-claude:
+    extraAllowedTraits: []
+  ai-agent-codex:
+    extraAllowedTraits: []
+  ai-agent-copilot:
+    extraAllowedTraits: []
+  ai-agent-cursor:
+    extraAllowedTraits: []
+  ai-agent-gemini:
+    extraAllowedTraits: []
+  ai-agent-openclaw:
+    extraAllowedTraits: []
+  ai-agent-opencode:
+    extraAllowedTraits: []
 
 # rbac controls the openchoreo-agent-sandbox-access ClusterRole/Binding that
 # grants the data plane cluster-agent access to sandbox resources. This is a

--- a/agent-sandbox/helm/values.yaml
+++ b/agent-sandbox/helm/values.yaml
@@ -19,6 +19,15 @@ dataPlaneServiceAccount: cluster-agent-dataplane
 # *control plane* resources; set to false on a data-plane-only install.
 componentTypes:
   enabled: true
+  # extraAllowedTraits appends additional entries to a ClusterComponentType's
+  # allowedTraits, keyed by component type name. Defaults to empty — no
+  # behavior change unless set. Lets consumers attach platform-specific
+  # traits (credential injection, hardening, etc.) to ai-agent without
+  # forking the ClusterComponentType.
+  extraAllowedTraits: {}
+  #   ai-agent:
+  #     - kind: ClusterTrait
+  #       name: my-platform-trait
 
 # rbac controls the openchoreo-agent-sandbox-access ClusterRole/Binding that
 # grants the data plane cluster-agent access to sandbox resources. This is a

--- a/agent-sandbox/helm/values.yaml
+++ b/agent-sandbox/helm/values.yaml
@@ -19,15 +19,15 @@ dataPlaneServiceAccount: cluster-agent-dataplane
 # *control plane* resources; set to false on a data-plane-only install.
 componentTypes:
   enabled: true
-  # extraAllowedTraits appends additional entries to a ClusterComponentType's
-  # allowedTraits, keyed by component type name. Defaults to empty — no
-  # behavior change unless set. Lets consumers attach platform-specific
-  # traits (credential injection, hardening, etc.) to ai-agent without
-  # forking the ClusterComponentType.
-  extraAllowedTraits: {}
-  #   ai-agent:
-  #     - kind: ClusterTrait
-  #       name: my-platform-trait
+  # ai-agent groups per-component-type customizations for the ai-agent
+  # ClusterComponentType. extraAllowedTraits appends additional entries to
+  # its allowedTraits. Defaults to empty — no behavior change unless set.
+  # Lets consumers attach platform-specific traits (credential injection,
+  # hardening, etc.) to ai-agent without forking the ClusterComponentType.
+  ai-agent:
+    extraAllowedTraits: []
+    #   - kind: ClusterTrait
+    #     name: my-platform-trait
 
 # rbac controls the openchoreo-agent-sandbox-access ClusterRole/Binding that
 # grants the data plane cluster-agent access to sandbox resources. This is a


### PR DESCRIPTION
Closes openchoreo/openchoreo#4566. Follows on from [openchoreo/openchoreo#4543](https://github.com/openchoreo/openchoreo/discussions/4543).

### What

Adds `componentTypes.extraAllowedTraits.ai-agent` as an additive, values-driven list appended to `ClusterComponentType/ai-agent`'s hardcoded `allowedTraits` baseline (`observability-alert-rule`). Defaults to empty — no behavior change for existing installs.

### Why

`ai-agent`'s `allowedTraits` has no `values.yaml` override today, so any consumer needing to attach a platform-specific trait (credential injection, hardening, an LLM-gateway trait, etc.) has to fork the whole `ClusterComponentType` object — permanently losing this chart's future updates unless the fork is manually re-diffed on every version bump. Full rationale and the alternatives ruled out (a live `kubectl patch`, a partial Server-Side-Apply manifest) are in the linked issue/discussion.

### Scope

This PR touches `ai-agent` only (`agent-clustercomponenttype.yaml`) — that's the template we consume. The same pattern would apply cleanly to the other seven `ClusterComponentType` templates this chart ships (`ai-agent-claude`, `-codex`, `-copilot`, `-cursor`, `-gemini`, `-openclaw`, `-opencode`). If this PR is acceptable, we'll open a follow-on PR extending it to those — keeping this one narrow and reviewable is deliberate.

### Testing

Verified via `helm template`:
- With no override set, the full rendered chart output is byte-identical to the pre-change output (confirmed via a direct diff against the same render on `main`).
- With `componentTypes.extraAllowedTraits.ai-agent` set, the rendered `ClusterComponentType/ai-agent`'s `spec.allowedTraits` correctly contains both the existing `observability-alert-rule` entry and the configured additions, with matching indentation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable support for additional traits across all AI agent component types.
  * Extra allowed traits can now be defined separately for each supported component type.
  * Configured traits are automatically included in the component type specifications.
  * Included example configuration to help enable additional capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->