### PR TITLE
fix(ai-gateway-agentgateway): native Bedrock provider, TLS/routing bugs, SandboxTemplate patches

### DIFF
--- a/ai-gateway-agentgateway/README.md
+++ b/ai-gateway-agentgateway/README.md
@@ -8,11 +8,16 @@ providing AI-native gateway capabilities for components.
 ### 1. Unified LLM Routing (`ai-llm-routing` ClusterTrait)
 
 Route LLM API calls through a single OpenAI-compatible endpoint to multiple
-providers — OpenAI, Anthropic, Vertex AI/Gemini, Groq, or any OpenAI-compatible
-API.
+providers — OpenAI, Anthropic, Vertex AI/Gemini, AWS Bedrock, Groq, or any
+OpenAI-compatible API.
 
-- **Single endpoint**: All providers share one `OPENAI_BASE_URL`; apps use the standard OpenAI SDK
-- **Provider switching**: Change the `model` field in the request — no code changes, no redeployment
+- **Single endpoint**: All providers share one `OPENAI_BASE_URL` (ends in
+  `/v1`); apps use the standard OpenAI SDK
+- **Provider failover**: Enabled providers form an ordered priority list —
+  the first is primary, later ones are pure standby, only used once the
+  primary's backends are evicted as unhealthy. This is NOT per-request
+  model-based selection — a client cannot pick a specific provider via the
+  `model` field. See [Agent Gateway's failover docs](https://agentgateway.dev/docs/kubernetes/main/llm/failover/).
 - **Cost control**: Per-environment rate limiting (requests/minute) via ReleaseBinding
 - **PII guardrails**: Block/mask credit cards, SSNs, emails in requests and responses
 - **API key management**: Keys stored in OpenBao, injected via External Secrets Operator
@@ -40,7 +45,7 @@ and call tools from many backends without knowing where each tool lives.
   │  │  Component Pod    │       │  Agent Gateway Proxy      │   │
   │  │                  │       │  (agentgateway-proxy)     │   │
   │  │  OPENAI_BASE_URL ├──────▶│                           │   │
-  │  │  = http://gw:80  │  LLM  │  ┌─ OpenAI ──▶ api.openai│   │
+  │  │  = http://gw:80/v1│  LLM │  ┌─ OpenAI ──▶ api.openai│   │
   │  │                  │       │  ├─ Anthropic ▶ api.anthr │   │
   │  │  MCP_GATEWAY_URL ├──────▶│  └─ Groq ────▶ api.groq  │   │
   │  │  = http://gw:3000│  MCP  │                           │   │
@@ -228,10 +233,12 @@ format and gets responses back. Everything else happens at the gateway layer:
 
 - **API key management** — Keys are stored in OpenBao and pulled via
   ExternalSecret. The app never sees or handles credentials.
-- **Provider switching** — Changing from OpenAI to Anthropic to Groq is a
-  configuration change on the trait. At request time, Agent Gateway reads the
-  `model` field to route to the correct provider — no code changes, no
-  redeployment.
+- **Provider failover** — Adding a standby provider (e.g. Anthropic behind
+  OpenAI, or Bedrock behind a self-hosted LiteLLM proxy) is a configuration
+  change on the trait, no code changes. Agent Gateway automatically fails
+  over to the next configured provider once the primary's backends are
+  evicted as unhealthy — this is priority-ordered failover, not a
+  per-request `model`-based choice a client can make.
 - **PII guardrails** — Credit card numbers, SSNs, and emails are automatically
   blocked in requests and masked in responses at the gateway, before they reach
   the LLM provider. The app doesn't need to implement this.
@@ -394,8 +401,16 @@ spec:
           apiKeyRef: anthropic-api-key
 ```
 
-Your app receives `OPENAI_BASE_URL` and calls it with the standard OpenAI SDK.
-To switch providers, just change the `model` in the request body.
+Your app receives `OPENAI_BASE_URL` (already ending in `/v1`) and
+`OPENAI_API_KEY` (a placeholder — auth is handled entirely gateway-side, but
+the OpenAI SDK requires a non-empty key just to construct a client) and
+calls it with the standard OpenAI SDK. It also receives
+`X_OPENCHOREO_COMPONENT` as an env var — nothing sends this as the
+`x-openchoreo-component` HTTP header the gateway routes on automatically;
+your app must read the env var and set it itself, e.g. via the OpenAI
+Python SDK's `default_headers` option. Anthropic here is a pure standby —
+it's only ever used if OpenAI's own backends are evicted as unhealthy, not
+selectable per request.
 
 ### Attaching the MCP Federation Trait
 
@@ -475,6 +490,11 @@ spec:
 | `openaiCompatible.port`       | int    | `443`                      | API port                                 |
 | `openaiCompatible.pathPrefix` | string | `/openai/v1`               | API path prefix                          |
 | `openaiCompatible.apiKeyRef`  | string | —                          | OpenBao secret key name                  |
+| `openaiCompatible.tls`        | bool   | `true`                     | Whether the provider host speaks TLS — set `false` for a plain-HTTP, in-cluster-only target |
+| `bedrock.enabled`             | bool   | `false`                    | Enable AWS Bedrock provider (native SigV4 auth, not a Bearer API key) |
+| `bedrock.model`               | string | —                          | Bedrock model/inference-profile id (e.g. `us.anthropic.claude-sonnet-5`) |
+| `bedrock.region`              | string | `us-east-1`                | AWS region for the Bedrock endpoint      |
+| `bedrock.credentialsVaultPath`| string | —                          | OpenBao path with `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` |
 
 **Environment Configs** (per-environment via ReleaseBinding):
 
@@ -513,11 +533,11 @@ spec:
 
 | Resource                   | Purpose                                                     |
 |----------------------------|-------------------------------------------------------------|
-| `ExternalSecret`           | Pulls API key from OpenBao, formats as Authorization header |
-| `AgentgatewayBackend`      | Configures the LLM provider (model, auth)                   |
+| `ExternalSecret`           | Pulls credentials from OpenBao — formats as an `Authorization` Bearer header for `openai`/`anthropic`/`vertex`/`openaiCompatible`, or as `accessKey`/`secretKey` for `bedrock` (AWS SigV4, a different auth shape) |
+| `AgentgatewayBackend`      | Configures each enabled provider as a priority/failover group (model, auth) |
 | `HTTPRoute`                | Routes component traffic to the provider backend            |
 | `AgentgatewayPolicy`       | Applies rate limiting + PII guardrails to the route         |
-| `AgentgatewayPolicy` (TLS) | TLS to upstream (openaiCompatible providers only)           |
+| `AgentgatewayPolicy` (TLS) | TLS to upstream (`openaiCompatible` providers only, and only when `openaiCompatible.tls` is `true`) |
 
 ### `ai-mcp-federation`
 
@@ -530,8 +550,15 @@ spec:
 
 ## Injected Environment Variables
 
+Injected into both an `apps/v1` `Deployment`'s `spec.template.spec` and an
+`extensions.agents.x-k8s.io/v1alpha1` `SandboxTemplate`'s
+`spec.podTemplate.spec` (e.g. `kubernetes-sigs/agent-sandbox`'s `ai-agent`
+`ClusterComponentType`) — whichever the target Component actually renders
+as.
+
 | Variable                 | Trait               | Value                                          |
 |--------------------------|---------------------|------------------------------------------------|
-| `OPENAI_BASE_URL`        | `ai-llm-routing`    | `http://<gatewayName>.<gatewayNamespace>`      |
+| `OPENAI_BASE_URL`        | `ai-llm-routing`    | `http://<gatewayName>.<gatewayNamespace>/v1`   |
+| `OPENAI_API_KEY`         | `ai-llm-routing`    | `managed-by-gateway` (placeholder — auth is gateway-side; only present so OpenAI-SDK clients can construct without erroring) |
 | `MCP_GATEWAY_URL`        | `ai-mcp-federation` | `http://<gatewayName>.<gatewayNamespace>:3000` |
-| `X_OPENCHOREO_COMPONENT` | Both                | Component name (for per-component routing)     |
+| `X_OPENCHOREO_COMPONENT` | Both                | Component name — set as an env var only. Your app must read it and send it itself as the `x-openchoreo-component` HTTP header (the value the `HTTPRoute` actually matches on) for routing to work at all. |

--- a/ai-gateway-agentgateway/ai-llm-routing-trait.yaml
+++ b/ai-gateway-agentgateway/ai-llm-routing-trait.yaml
@@ -2,19 +2,24 @@
 #
 # Unified LLM gateway trait — attach to any component to route LLM API calls
 # through Agent Gateway. Provides a single OpenAI-compatible endpoint that can
-# reach multiple providers (OpenAI, Anthropic, Vertex/Gemini, or any
-# OpenAI-compatible API such as Groq, Together AI, Azure OpenAI, etc.).
+# reach multiple providers (OpenAI, Anthropic, Vertex/Gemini, AWS Bedrock, or
+# any OpenAI-compatible API such as Groq, Together AI, Azure OpenAI, etc.).
 #
 # Features:
-#   - Multi-provider routing via a single OPENAI_BASE_URL endpoint
-#   - Provider switching without code changes (change the model name in request)
+#   - Multi-provider failover via a single OPENAI_BASE_URL endpoint
 #   - Per-environment rate limiting (requests/minute)
 #   - PII guardrails (credit cards, SSNs, emails) with per-environment toggle
 #   - API key management via OpenBao / External Secrets Operator
 #
 # The trait creates a single AgentgatewayBackend with all enabled providers in
-# one groups block. Agent Gateway uses the "model" field in the request to
-# route to the correct provider automatically.
+# one groups block. IMPORTANT: `groups` is a PRIORITY/FAILOVER list, not a
+# per-request model-based router — the group listed first is primary and
+# serves every request while healthy; later groups are pure standby, only
+# used once all backends in an earlier group are evicted as unhealthy. There
+# is no way for a client's request `model` field to select a specific group.
+# (Load balancing WITHIN a single group, across multiple providers in that
+# group's own `providers` list, does use Power of Two Choices — see
+# https://agentgateway.dev/docs/kubernetes/main/llm/failover/.)
 #
 apiVersion: openchoreo.dev/v1alpha1
 kind: ClusterTrait
@@ -125,6 +130,48 @@ spec:
             apiKeyRef:
               type: string
               description: "OpenBao secret key name containing the provider API key"
+            tls:
+              type: boolean
+              default: true
+              description: >-
+                Whether the provider host speaks TLS. Defaults to true (most
+                openaiCompatible providers, e.g. Groq, are genuine external
+                HTTPS APIs) — set false for a plain-HTTP, in-cluster-only
+                target (e.g. a self-hosted LiteLLM proxy). Leaving this true
+                against a plain-HTTP backend produces a TLS/plaintext
+                protocol-mismatch error, not an obvious TLS error.
+
+        # --- AWS Bedrock (native SigV4 auth, not a Bearer API key) ---
+        bedrock:
+          type: object
+          default:
+            enabled: false
+            region: "us-east-1"
+            credentialsVaultPath: ""
+          description: "AWS Bedrock provider (native agentgateway support)"
+          properties:
+            enabled:
+              type: boolean
+              default: false
+              description: "Enable this LLM provider"
+            model:
+              type: string
+              description: >-
+                Bedrock model/inference-profile id, e.g.
+                us.anthropic.claude-sonnet-5 (many current models require a
+                cross-region inference profile id, prefixed us./eu./apac.,
+                rather than the bare model id — check
+                `aws bedrock get-foundation-model` for
+                `inferenceTypesSupported`)
+            region:
+              type: string
+              default: "us-east-1"
+              description: "AWS region for the Bedrock endpoint"
+            credentialsVaultPath:
+              type: string
+              description: >-
+                OpenBao/Vault KV path containing AWS_ACCESS_KEY_ID and
+                AWS_SECRET_ACCESS_KEY properties
 
   # Per-environment overrides set via ReleaseBinding.spec.traitEnvironmentConfigs.
   environmentConfigs:
@@ -160,7 +207,8 @@ spec:
         ${parameters.openai.enabled
           || parameters.anthropic.enabled
           || parameters.vertex.enabled
-          || parameters.openaiCompatible.enabled}
+          || parameters.openaiCompatible.enabled
+          || parameters.bedrock.enabled}
       message: "At least one LLM provider must be enabled"
     - rule: "${!parameters.openai.enabled || size(parameters.openai.apiKeyRef) > 0}"
       message: "openai.apiKeyRef must be set when openai.enabled is true"
@@ -170,6 +218,10 @@ spec:
       message: "vertex.apiKeyRef must be set when vertex.enabled is true"
     - rule: "${!parameters.openaiCompatible.enabled || size(parameters.openaiCompatible.apiKeyRef) > 0}"
       message: "openaiCompatible.apiKeyRef must be set when openaiCompatible.enabled is true"
+    - rule: "${!parameters.bedrock.enabled || size(parameters.bedrock.model) > 0}"
+      message: "bedrock.model must be set when bedrock.enabled is true"
+    - rule: "${!parameters.bedrock.enabled || size(parameters.bedrock.credentialsVaultPath) > 0}"
+      message: "bedrock.credentialsVaultPath must be set when bedrock.enabled is true"
 
   creates:
     # ==================================================================
@@ -280,9 +332,45 @@ spec:
                 key: ${parameters.openaiCompatible.apiKeyRef}
                 property: value
 
+    - targetPlane: dataplane
+      includeWhen: ${parameters.bedrock.enabled}
+      template:
+        apiVersion: external-secrets.io/v1
+        kind: ExternalSecret
+        metadata:
+          name: ${metadata.name}-${trait.instanceName}-bedrock-auth
+          namespace: ${metadata.namespace}
+        spec:
+          refreshInterval: 1h
+          secretStoreRef:
+            kind: ClusterSecretStore
+            name: ${dataplane.secretStore}
+          target:
+            name: ${metadata.name}-${trait.instanceName}-bedrock-auth
+            creationPolicy: Owner
+            template:
+              type: Opaque
+              data:
+                # agentgateway's bedrock auth policy expects accessKey/secretKey,
+                # NOT a Bearer Authorization header (AWS SigV4, not a static
+                # API key — different shape from every other provider above).
+                accessKey: "{{ .accessKeyId | toString }}"
+                secretKey: "{{ .secretAccessKey | toString }}"
+          data:
+            - secretKey: accessKeyId
+              remoteRef:
+                key: ${parameters.bedrock.credentialsVaultPath}
+                property: AWS_ACCESS_KEY_ID
+            - secretKey: secretAccessKey
+              remoteRef:
+                key: ${parameters.bedrock.credentialsVaultPath}
+                property: AWS_SECRET_ACCESS_KEY
+
     # ==================================================================
-    #  Single AgentgatewayBackend — all enabled providers in one backend
-    #  Agent Gateway routes by "model" field in the request body.
+    #  Single AgentgatewayBackend — all enabled providers in one backend.
+    #  Each entry in `groups` is a priority/failover tier: the first group
+    #  is primary, later groups are standby only. This is NOT model-based
+    #  routing — see the file header.
     # ==================================================================
 
     - targetPlane: dataplane
@@ -318,6 +406,11 @@ spec:
                        "port": parameters.openaiCompatible.port,
                        "pathPrefix": parameters.openaiCompatible.pathPrefix,
                        "policies": {"auth": {"secretRef": {"name": metadata.name + "-" + trait.instanceName + "-" + parameters.openaiCompatible.name + "-auth"}}}}]}
+                  : oc_omit(),
+                parameters.bedrock.enabled
+                  ? {"providers": [{"name": "bedrock",
+                       "bedrock": {"model": parameters.bedrock.model, "region": parameters.bedrock.region},
+                       "policies": {"auth": {"aws": {"secretRef": {"name": metadata.name + "-" + trait.instanceName + "-bedrock-auth"}}}}}]}
                   : oc_omit()
               ]}
 
@@ -353,7 +446,7 @@ spec:
     # ==================================================================
 
     - targetPlane: dataplane
-      includeWhen: ${parameters.openaiCompatible.enabled}
+      includeWhen: ${parameters.openaiCompatible.enabled && parameters.openaiCompatible.tls}
       template:
         apiVersion: agentgateway.dev/v1alpha1
         kind: AgentgatewayPolicy
@@ -421,7 +514,28 @@ spec:
                   unit: Minutes
 
   # ------------------------------------------------------------------
-  #  Patches — inject gateway env vars into the component Deployment
+  #  Patches — inject gateway env vars into the component workload.
+  #
+  #  OPENAI_BASE_URL ends in /v1: agentgateway accepts standard OpenAI-
+  #  formatted requests at /v1/chat/completions, and the OpenAI SDK appends
+  #  only /chat/completions to whatever base_url it's given (no /v1 of its
+  #  own). OPENAI_API_KEY is a placeholder: auth is entirely gateway-side
+  #  (per-provider secretRef, attached by agentgateway itself), but the
+  #  OpenAI SDK requires a non-empty key just to construct a client.
+  #
+  #  X_OPENCHOREO_COMPONENT is only injected as an env var here — nothing
+  #  makes a client send it as the x-openchoreo-component HTTP header the
+  #  HTTPRoute above actually matches on. Client code must read this env
+  #  var and set it as a request header itself (e.g. via the OpenAI SDK's
+  #  default_headers option) for routing to work at all.
+  #
+  #  Two target kinds are patched because not every workload renders as an
+  #  apps/v1 Deployment — e.g. kubernetes-sigs/agent-sandbox's own ai-agent
+  #  ClusterComponentType renders as an
+  #  extensions.agents.x-k8s.io/v1alpha1 SandboxTemplate, wrapping its pod
+  #  spec at spec.podTemplate.spec instead of spec.template.spec. A
+  #  Deployment-only patch silently no-ops (dropped, not rejected) for any
+  #  such workload.
   # ------------------------------------------------------------------
   patches:
     - target:
@@ -429,15 +543,38 @@ spec:
         version: v1
         kind: Deployment
       operations:
-        # OPENAI_BASE_URL — the unified LLM endpoint (OpenAI-compatible API)
         - op: add
           path: /spec/template/spec/containers/0/env/-
           value:
             name: OPENAI_BASE_URL
-            value: "http://${parameters.gatewayName}.${parameters.gatewayNamespace}"
-        # X_OPENCHOREO_COMPONENT — header value for per-component routing
+            value: "http://${parameters.gatewayName}.${parameters.gatewayNamespace}/v1"
         - op: add
           path: /spec/template/spec/containers/0/env/-
+          value:
+            name: OPENAI_API_KEY
+            value: "managed-by-gateway"
+        - op: add
+          path: /spec/template/spec/containers/0/env/-
+          value:
+            name: X_OPENCHOREO_COMPONENT
+            value: ${metadata.componentName}
+    - target:
+        group: extensions.agents.x-k8s.io
+        kind: SandboxTemplate
+        version: v1alpha1
+      operations:
+        - op: add
+          path: /spec/podTemplate/spec/containers/0/env/-
+          value:
+            name: OPENAI_BASE_URL
+            value: "http://${parameters.gatewayName}.${parameters.gatewayNamespace}/v1"
+        - op: add
+          path: /spec/podTemplate/spec/containers/0/env/-
+          value:
+            name: OPENAI_API_KEY
+            value: "managed-by-gateway"
+        - op: add
+          path: /spec/podTemplate/spec/containers/0/env/-
           value:
             name: X_OPENCHOREO_COMPONENT
             value: ${metadata.componentName}

--- a/ai-gateway-agentgateway/ai-mcp-federation-trait.yaml
+++ b/ai-gateway-agentgateway/ai-mcp-federation-trait.yaml
@@ -199,7 +199,15 @@ spec:
                   unit: Minutes
 
   # ------------------------------------------------------------------
-  #  Patches — inject MCP gateway env vars into the component Deployment
+  #  Patches — inject MCP gateway env vars into the component workload.
+  #
+  #  Two target kinds are patched because not every workload renders as an
+  #  apps/v1 Deployment — e.g. kubernetes-sigs/agent-sandbox's own ai-agent
+  #  ClusterComponentType renders as an
+  #  extensions.agents.x-k8s.io/v1alpha1 SandboxTemplate, wrapping its pod
+  #  spec at spec.podTemplate.spec instead of spec.template.spec. A
+  #  Deployment-only patch silently no-ops (dropped, not rejected) for any
+  #  such workload.
   # ------------------------------------------------------------------
   patches:
     - target:
@@ -210,6 +218,16 @@ spec:
         # MCP_GATEWAY_URL — the federated MCP endpoint
         - op: add
           path: /spec/template/spec/containers/0/env/-
+          value:
+            name: MCP_GATEWAY_URL
+            value: "http://${parameters.gatewayName}.${parameters.gatewayNamespace}:3000"
+    - target:
+        group: extensions.agents.x-k8s.io
+        kind: SandboxTemplate
+        version: v1alpha1
+      operations:
+        - op: add
+          path: /spec/podTemplate/spec/containers/0/env/-
           value:
             name: MCP_GATEWAY_URL
             value: "http://${parameters.gatewayName}.${parameters.gatewayNamespace}:3000"

--- a/ai-gateway-agentgateway/samples/llm-routing/component.yaml
+++ b/ai-gateway-agentgateway/samples/llm-routing/component.yaml
@@ -8,11 +8,15 @@
 #   - Per-component rate limiting (60 req/min default, overridden per environment;
 #     the AgentgatewayPolicy in ai-llm-routing-trait.yaml targets the HTTPRoute,
 #     so the limit is enforced per-component across all providers, not per-provider)
-#   - Provider switching by changing the "model" field in the API request
+#   - Provider failover: enabled providers form an ordered priority list —
+#     the first one is primary, later ones are pure standby, only used once
+#     the primary's backends are evicted as unhealthy. This is NOT selectable
+#     per request via the "model" field.
 #
-# The application code sends requests to OPENAI_BASE_URL (injected by the trait)
-# using the standard OpenAI SDK format. The Agent Gateway routes to the correct
-# provider based on the model name.
+# The application code sends requests to OPENAI_BASE_URL (injected by the
+# trait, already ending in /v1) using the standard OpenAI SDK format. The
+# Agent Gateway serves every request from the primary (first-listed) enabled
+# provider while it's healthy, failing over to the next one only if it isn't.
 #
 # Prerequisites:
 #   - Agent Gateway installed (CRDs + controller + Gateway resource)


### PR DESCRIPTION
## Purpose
Closes openchoreo/openchoreo#4619. Six real gaps found deploying `ai-llm-routing`/`ai-mcp-federation` against a real `ai-agent` (`SandboxTemplate`-shaped) workload with a real AWS Bedrock backend and a plain-HTTP in-cluster LiteLLM proxy — every fix here was root-caused and confirmed working live, not just inferred from reading the code. Full detail in openchoreo/openchoreo#4619.

## Approach
- `ai-llm-routing-trait.yaml`:
  - Add a native `bedrock` provider block (AWS SigV4 auth via `policies.auth.aws.secretRef`, a different shape from every other provider's Bearer token) — `AgentgatewayBackend` already supports this natively, the trait just never exposed it.
  - Add `openaiCompatible.tls` (default `true`, preserving existing behavior) so the TLS `AgentgatewayPolicy` is conditional instead of unconditional — it was breaking any plain-HTTP in-cluster target with a confusing `InvalidContentType` error instead of an obvious TLS error.
  - Inject `OPENAI_API_KEY="managed-by-gateway"` — the OpenAI SDK requires a non-empty key to construct a client even though auth is entirely gateway-side.
  - `OPENAI_BASE_URL` now ends in `/v1`, matching agentgateway's own documented `/v1/chat/completions` expectation — every request 404'd without it, for any provider, so this isn't a behavior change for anyone with a genuinely working deployment.
  - Clarify in the file header and README that `spec.ai.groups` is priority/failover, not per-request model-based routing.
- Both traits: add a second `patches` entry targeting `extensions.agents.x-k8s.io/v1alpha1` `SandboxTemplate` (`spec.podTemplate.spec`) alongside the existing `apps/v1` `Deployment` patch — `kubernetes-sigs/agent-sandbox`'s own `ai-agent` `ClusterComponentType` renders as `SandboxTemplate`, so the `Deployment`-only patch was silently no-op'ing (dropped, not rejected) for that workload type. Purely additive — has no effect on `Deployment`-based consumers.
- `README.md`: updated parameter tables, injected-env-vars table, and prose to match, including the failover-not-routing correction.

## Related Issues
Closes openchoreo/openchoreo#4619

## Checklist
- [x] All six fixes proven working live against a real cluster (OpenChoreo v1.2.3, `agentgateway` v1.1.0) — real LLM completions from both a plain-HTTP in-cluster LiteLLM proxy and AWS Bedrock, real MCP tool discovery+invocation against a live MCP server
- [x] No automated test suite exists for this module's trait YAML as far as we could find — happy to add one if there's a preferred format/harness

## Remarks
Every new capability is gated to be a no-op when unused: `bedrock.enabled` defaults `false` (all its resources/validations are conditioned on it), `openaiCompatible.tls` defaults `true` (the existing behavior), and the `SandboxTemplate` patch targets a distinct resource kind that never touches `Deployment`-based consumers. The `/v1` and `OPENAI_API_KEY` fixes are unconditional because they were pure bugs, not optional behavior — see PR discussion if useful.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added priority-ordered provider failover for AI model routing.
  * Added AWS Bedrock provider support, including model, region, and credential configuration.
  * Added optional TLS control for OpenAI-compatible providers.
  * Added support for injecting required gateway and API credentials into Deployments and SandboxTemplates.
  * Added MCP gateway configuration support for SandboxTemplate workloads.

* **Documentation**
  * Clarified `/v1` endpoint usage, component-header routing, failover behavior, and environment-variable configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->