### PR TITLE
refactor: replace the GET method based span detail fetching API with a POST method based one in Azure Application Insights tracing adapter

### DIFF
--- a/observability-tracing-azure-appinsights/internal/api/gen/models.gen.go
+++ b/observability-tracing-azure-appinsights/internal/api/gen/models.gen.go
@@ -63,6 +63,11 @@ type SpanStatus struct {
 // SpanStatusCode The status code of the span. One of "ok", "error", or "unset".
 type SpanStatusCode string
 
+// TraceSpanDetailsRequest defines model for TraceSpanDetailsRequest.
+type TraceSpanDetailsRequest struct {
+	SearchScope ComponentSearchScope `json:"searchScope"`
+}
+
 // TraceSpanDetailsResponse defines model for TraceSpanDetailsResponse.
 type TraceSpanDetailsResponse struct {
 	// Attributes The span attributes as a key/value map
@@ -201,3 +206,6 @@ type QueryTracesJSONRequestBody = TracesQueryRequest
 
 // QuerySpansForTraceJSONRequestBody defines body for QuerySpansForTrace for application/json ContentType.
 type QuerySpansForTraceJSONRequestBody = TracesQueryRequest
+
+// QuerySpanDetailsForTraceJSONRequestBody defines body for QuerySpanDetailsForTrace for application/json ContentType.
+type QuerySpanDetailsForTraceJSONRequestBody = TraceSpanDetailsRequest

--- a/observability-tracing-azure-appinsights/internal/api/gen/server.gen.go
+++ b/observability-tracing-azure-appinsights/internal/api/gen/server.gen.go
@@ -31,8 +31,8 @@ type ServerInterface interface {
 	// (POST /api/v1alpha1/traces/{traceId}/spans/query)
 	QuerySpansForTrace(w http.ResponseWriter, r *http.Request, traceId string)
 	// Get details of a span for a trace
-	// (GET /api/v1alpha1/traces/{traceId}/spans/{spanId})
-	GetSpanDetailsForTrace(w http.ResponseWriter, r *http.Request, traceId string, spanId string)
+	// (POST /api/v1alpha1/traces/{traceId}/spans/{spanId})
+	QuerySpanDetailsForTrace(w http.ResponseWriter, r *http.Request, traceId string, spanId string)
 	// Health check
 	// (GET /healthz)
 	Health(w http.ResponseWriter, r *http.Request)
@@ -86,8 +86,8 @@ func (siw *ServerInterfaceWrapper) QuerySpansForTrace(w http.ResponseWriter, r *
 	handler.ServeHTTP(w, r)
 }
 
-// GetSpanDetailsForTrace operation middleware
-func (siw *ServerInterfaceWrapper) GetSpanDetailsForTrace(w http.ResponseWriter, r *http.Request) {
+// QuerySpanDetailsForTrace operation middleware
+func (siw *ServerInterfaceWrapper) QuerySpanDetailsForTrace(w http.ResponseWriter, r *http.Request) {
 
 	var err error
 
@@ -110,7 +110,7 @@ func (siw *ServerInterfaceWrapper) GetSpanDetailsForTrace(w http.ResponseWriter,
 	}
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.GetSpanDetailsForTrace(w, r, traceId, spanId)
+		siw.Handler.QuerySpanDetailsForTrace(w, r, traceId, spanId)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -256,7 +256,7 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 
 	m.HandleFunc("POST "+options.BaseURL+"/api/v1alpha1/traces/query", wrapper.QueryTraces)
 	m.HandleFunc("POST "+options.BaseURL+"/api/v1alpha1/traces/{traceId}/spans/query", wrapper.QuerySpansForTrace)
-	m.HandleFunc("GET "+options.BaseURL+"/api/v1alpha1/traces/{traceId}/spans/{spanId}", wrapper.GetSpanDetailsForTrace)
+	m.HandleFunc("POST "+options.BaseURL+"/api/v1alpha1/traces/{traceId}/spans/{spanId}", wrapper.QuerySpanDetailsForTrace)
 	m.HandleFunc("GET "+options.BaseURL+"/healthz", wrapper.Health)
 
 	return m
@@ -369,54 +369,55 @@ func (response QuerySpansForTrace500JSONResponse) VisitQuerySpansForTraceRespons
 	return json.NewEncoder(w).Encode(response)
 }
 
-type GetSpanDetailsForTraceRequestObject struct {
+type QuerySpanDetailsForTraceRequestObject struct {
 	TraceId string `json:"traceId"`
 	SpanId  string `json:"spanId"`
+	Body    *QuerySpanDetailsForTraceJSONRequestBody
 }
 
-type GetSpanDetailsForTraceResponseObject interface {
-	VisitGetSpanDetailsForTraceResponse(w http.ResponseWriter) error
+type QuerySpanDetailsForTraceResponseObject interface {
+	VisitQuerySpanDetailsForTraceResponse(w http.ResponseWriter) error
 }
 
-type GetSpanDetailsForTrace200JSONResponse TraceSpanDetailsResponse
+type QuerySpanDetailsForTrace200JSONResponse TraceSpanDetailsResponse
 
-func (response GetSpanDetailsForTrace200JSONResponse) VisitGetSpanDetailsForTraceResponse(w http.ResponseWriter) error {
+func (response QuerySpanDetailsForTrace200JSONResponse) VisitQuerySpanDetailsForTraceResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
 
 	return json.NewEncoder(w).Encode(response)
 }
 
-type GetSpanDetailsForTrace400JSONResponse ErrorResponse
+type QuerySpanDetailsForTrace400JSONResponse ErrorResponse
 
-func (response GetSpanDetailsForTrace400JSONResponse) VisitGetSpanDetailsForTraceResponse(w http.ResponseWriter) error {
+func (response QuerySpanDetailsForTrace400JSONResponse) VisitQuerySpanDetailsForTraceResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(400)
 
 	return json.NewEncoder(w).Encode(response)
 }
 
-type GetSpanDetailsForTrace401JSONResponse ErrorResponse
+type QuerySpanDetailsForTrace401JSONResponse ErrorResponse
 
-func (response GetSpanDetailsForTrace401JSONResponse) VisitGetSpanDetailsForTraceResponse(w http.ResponseWriter) error {
+func (response QuerySpanDetailsForTrace401JSONResponse) VisitQuerySpanDetailsForTraceResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(401)
 
 	return json.NewEncoder(w).Encode(response)
 }
 
-type GetSpanDetailsForTrace403JSONResponse ErrorResponse
+type QuerySpanDetailsForTrace403JSONResponse ErrorResponse
 
-func (response GetSpanDetailsForTrace403JSONResponse) VisitGetSpanDetailsForTraceResponse(w http.ResponseWriter) error {
+func (response QuerySpanDetailsForTrace403JSONResponse) VisitQuerySpanDetailsForTraceResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(403)
 
 	return json.NewEncoder(w).Encode(response)
 }
 
-type GetSpanDetailsForTrace500JSONResponse ErrorResponse
+type QuerySpanDetailsForTrace500JSONResponse ErrorResponse
 
-func (response GetSpanDetailsForTrace500JSONResponse) VisitGetSpanDetailsForTraceResponse(w http.ResponseWriter) error {
+func (response QuerySpanDetailsForTrace500JSONResponse) VisitQuerySpanDetailsForTraceResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(500)
 
@@ -462,8 +463,8 @@ type StrictServerInterface interface {
 	// (POST /api/v1alpha1/traces/{traceId}/spans/query)
 	QuerySpansForTrace(ctx context.Context, request QuerySpansForTraceRequestObject) (QuerySpansForTraceResponseObject, error)
 	// Get details of a span for a trace
-	// (GET /api/v1alpha1/traces/{traceId}/spans/{spanId})
-	GetSpanDetailsForTrace(ctx context.Context, request GetSpanDetailsForTraceRequestObject) (GetSpanDetailsForTraceResponseObject, error)
+	// (POST /api/v1alpha1/traces/{traceId}/spans/{spanId})
+	QuerySpanDetailsForTrace(ctx context.Context, request QuerySpanDetailsForTraceRequestObject) (QuerySpanDetailsForTraceResponseObject, error)
 	// Health check
 	// (GET /healthz)
 	Health(ctx context.Context, request HealthRequestObject) (HealthResponseObject, error)
@@ -562,26 +563,33 @@ func (sh *strictHandler) QuerySpansForTrace(w http.ResponseWriter, r *http.Reque
 	}
 }
 
-// GetSpanDetailsForTrace operation middleware
-func (sh *strictHandler) GetSpanDetailsForTrace(w http.ResponseWriter, r *http.Request, traceId string, spanId string) {
-	var request GetSpanDetailsForTraceRequestObject
+// QuerySpanDetailsForTrace operation middleware
+func (sh *strictHandler) QuerySpanDetailsForTrace(w http.ResponseWriter, r *http.Request, traceId string, spanId string) {
+	var request QuerySpanDetailsForTraceRequestObject
 
 	request.TraceId = traceId
 	request.SpanId = spanId
 
+	var body QuerySpanDetailsForTraceJSONRequestBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		sh.options.RequestErrorHandlerFunc(w, r, fmt.Errorf("can't decode JSON body: %w", err))
+		return
+	}
+	request.Body = &body
+
 	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
-		return sh.ssi.GetSpanDetailsForTrace(ctx, request.(GetSpanDetailsForTraceRequestObject))
+		return sh.ssi.QuerySpanDetailsForTrace(ctx, request.(QuerySpanDetailsForTraceRequestObject))
 	}
 	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "GetSpanDetailsForTrace")
+		handler = middleware(handler, "QuerySpanDetailsForTrace")
 	}
 
 	response, err := handler(r.Context(), w, r, request)
 
 	if err != nil {
 		sh.options.ResponseErrorHandlerFunc(w, r, err)
-	} else if validResponse, ok := response.(GetSpanDetailsForTraceResponseObject); ok {
-		if err := validResponse.VisitGetSpanDetailsForTraceResponse(w); err != nil {
+	} else if validResponse, ok := response.(QuerySpanDetailsForTraceResponseObject); ok {
+		if err := validResponse.VisitQuerySpanDetailsForTraceResponse(w); err != nil {
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
 	} else if response != nil {
@@ -616,36 +624,37 @@ func (sh *strictHandler) Health(w http.ResponseWriter, r *http.Request) {
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+xaUXPbNhL+KxjczeSFlmSndw96c52057k2Tmvd3EPthxW5MlGDAAIs7age/fcbAKRE",
-	"SqAixXEebvxkkVgsFrv7fVgs/cRzXRmtUJHj0yfu8hIrCD8v2oFrBJuX17k26N8bqw1aEhik1tP9Ay29",
-	"CHdkhbrjq4yjehBWq2poXEGFzkCOyVFj9Z+Yp2auMm7xUy0sFnz6R0fNbdaK6nmYu8r4e2u1/R2d0col",
-	"dlAggZDxl8utMCS04lM+K5Ghn8oqdA7ukGccP0NlpFf/q3BOqDvWmsEWAmXh2BtHYGkmKnzDQBXsDaoi",
-	"PPEs4R6v/kIXuG/1XBfIFlZXTM8d2ge0zP8Red+gqx+vT2YnZ2epdUiQxAN3qOrKu3QOxe/4qUZHPOO1",
-	"gppKbcVfWPCML7Sdi6JAxTMuFKFVIK+DZcHVnSB04rUTlmsD6pqAardr2fvPmNf+N3NBgukFoxKZM6Ay",
-	"ttBS6kfvff/uyqCaocQKyS6DBItqWaULlCOe7aTskMObxYLHOyuO2JUKL264vr/hGbuJkfM/tWU3vFYO",
-	"6YaPOv7T97yJb/CfQ0q4JeOt43fMeYcPKL3VJwvI/VbLugJ1YhEKmMu1qZ1JIzZbGpGDlEvmkJhWcske",
-	"S1RxP8JtzB7xgyI0s5CjD9O7ABE3jCEgsmJeU/NUFMJbBPJjR4psjVnK6T5iGwUMHAN2j8vxA8gaWQWG",
-	"J2wragteyQeXDmU73o0jE4opUNphrlXhYiZXQHzq0/ifP2zW8Vl9hzZSWMDvAHpUwUhUvWzpqi2A8MQL",
-	"pFBpwHp2NaAui7T6KBFtv3yX0mHR6drmeP6MALQ6jg+C22P7HqP90L+FGph4L1Sx5c+khg8wFBV/HHxR",
-	"Q0vTg0xg6etD69a89neLCz7lfxtvztlxc8iOOwy4H3/uF+FoGH3etAEYSOHI7yCKZFwQVu4Vv6/4fcXv",
-	"y+O3eQHWwjI8a33/60C+B1MJ7lEx0uxTjXa5Ntv5xK+ElGKT+buJTppgoIwNQ0zV1Ryt90cFlJe+qAja",
-	"M5aDMVgwIHY6mUwS2gfZ6QvM9DU7pqD3xbYc1R+w54xH0f3E2sgMMuuxPBf0vTzRhWUOhkMJLlT2iT38",
-	"t0Qq0TJQyzVHb/ZReh5SzSUjgqpTe861lggq8KDWHSbdpclmuGWdQYGWVJKMc6HreA9NUM46UdaA67pp",
-	"19tH889xHg/SQ9QcfZvm5jB2GLVubW7fTaDPZMNs8JtHcXtv3MHCURkaCOFgfwmVy7rYOkYLXEAtiU8X",
-	"IN3O0dlmLmnWzN4pZZossA2/jdi7qNH5SUFpOpulqAT1LDidTFJHdwWfRVVXnfQLNOLVW6Ta+hOrkQk6",
-	"JhmvhGoek2nZ79XsO72S/R2vQlu6sgXa3gaC8TxZ/2lLTPsJ26Fr78Kwnpm8Ax8NpWNSY6tTtFlrQ5h9",
-	"r+12kFYhvxY69g4UQWxJqQAyfmVQXZTaomYzhCrUtlt7EI6df7xkzmAuFiKPfF/gQih0YUNeq4WcGJVA",
-	"DAIy/VkFBRhCy6raEROVkVihohsVUpbwzgIhexRUrhshjSVXTadodOMzSIocm+O5MfrcQF4iOxv5g6+2",
-	"kk95SWTcdDx+fHwcQRgeaXs3bua68S+XF+8/XL8/ORtNRiVVstNX4jsrw1xIQUs2azZy3mzk/OMlz/gD",
-	"Whd9czqajCZekzaowAg+5W9Hk9Fb7qtrKgOKx2DE+OEUpCnhdBzP23FMAc8w2iUo/bdYTcRKIvTOvIMS",
-	"/TNPTyEenmvjtFl7otvIYz/qYtmGvuljgjGyieP4T+dXbDunXwJdgiZX/Rz1VX68GATOCS44m0y+sQW9",
-	"si1YsJW00XXezQIL5uo8R+cWtZShkv3hGxrUb88mbLlUDyBFwWzrML/+6fdb/z/d7mdY/O33W/ynda91",
-	"lfF/fF+3x84ui61dFnu7Xs7VVQUefj2cee6FO+dZtoHQrRdOwvepqW9W41BuHQbnWJkttG0YEo9Fdmil",
-	"/KTtrCl8DFiokNDXtX88ceGX8rTDs5Yn2zJsG6BZx8nbB87t/zVz7LajEqkThF7J45U8DiCPHVQ/h0ee",
-	"Ykdr5e2/wwST/IzE4ge/8E0JYsnfX73PHD8jdT6BvDh7ZElNTaPuaBp6aSbY/jA0wAVrl79Swisl7KOE",
-	"Q+CZJIcSQVL51yDuL0rM70OpECW3vitvX7iGyoh/hcn8mdDa+nqz7jVvPuZHI5eHNGcSiIvGM+FYqyfE",
-	"+u0zjIxfsns2tj6bQ36Pqpj6W6zCPFxuFyBk+FeBPZ31jaZafav9bjT18yrGjeU+Czop1ITzNihtXj6l",
-	"bkLMIlmBDyAZqsJoocht2LnJRM/d/bndZVMTm/VXt6v/BQAA//+WTBKviCMAAA==",
+	"H4sIAAAAAAAC/+xaX3PjthH/Khi0M/dCU7Iv7YPeHN+l9TQ5X2J1+hD7YUWuTMQgwAOW9ikeffcO/lCi",
+	"JFAnxedrJ+Mni8Risdjd3w+LpZ94oetGK1Rk+eSJ26LCGvzPi27gGsEU1XWhG3TvG6MbNCTQS62muwda",
+	"OBFuyQh1x5cZR/UgjFb10LiCGm0DBSZHG6N/wyI1c5lxg59aYbDkk197am6zTlTP/Nxlxt8bo80vaBut",
+	"bGIHJRIIGX7ZwoiGhFZ8wqcVMnRTWY3Wwh3yjONnqBvp1P8krBXqjnVmsLlAWVr2xhIYmooa3zBQJXuD",
+	"qvRPPEu4x6m/0CXuW73QJbK50TXTM4vmAQ1zf0SxadDV99cn05Ozs9Q6JEjigTtUbe1cOoPyF/zUoiWe",
+	"8VZBS5U24ncsecbn2sxEWaLiGReK0CiQ194y7+peEHrx2gnLdQPqmoBau2vZ+89YtO43s16C6TmjCplt",
+	"QGVsrqXUj8777t1Vg2qKEmsks/ASLKhltS5R5jzbSdkhh8fFvMd7K+bsSvkXN1zf3/CM3YTIuZ/asBve",
+	"Kot0w/Oe//Q9j/H1/rNICbdkvHP8jjnv8AGls/pkDoXbatXWoE4MQgkzuTK1Nyln00UjCpBywSwS00ou",
+	"2GOFKuxH2LXZOT8oQlMDBbowvfMQsV1C7EDIbjLEXw3O+YT/ZbTmllEkllGSVbbx3Nd3e5BhQ+AGIiNm",
+	"LcWnshTOVSA/9qTItJilssGl0loBA8uA3eNi9ACyRVZDwxO2la0Bp+SDTedYN95PMCYUU6C0xUKr0gaI",
+	"1UB84vD19+/W6zi43aEJ3OqJZQDWqmQk6o007qstgfDECaToogHjAtSAuizT6oNEsP3yXUqHQatbU+D5",
+	"MwLQ6Tg+CHaP7XuMdkP/Empg4r1Q5ZY/kxo+wFBU3Dn1RQ3d+TFIUYb+eGjtinD3gbRHzfuJwf4oLA2j",
+	"z5k2AAMpLLkdBJGMC8LavuL3Fb+v+H15/MYXYAws/LPW9z8N5Ls3leAeFSPNPrVoFiuzrUv8Wkgp1pm/",
+	"m+ikCQbqaz/EVFvP0Dh/1EBF5aodrz1jBTQNlgyInY7H44T2QXb6AjP9kR2T1/tiWw7qD9hzxoPofmKN",
+	"MoPMeizPeX0vT3R+mYPhUIH1V47EHv5TIVVoGKjFiqPX+6gcD6l4+wmg6hXFM60lgvI8qHWPSXdpMg53",
+	"rDMo0JFKknEudBsuyAnKWSXKCnB9N+16+2j+Oc7jXnqImoNv09zsxw6j1q3N7buibDLZMBv87FA8eH85",
+	"KkM9IRzsL6EK2ZZbx2iJc2gl8ckcpN05OrvMJc3i7J1SJmaBifyWs3dBo3WTvNJ0NktRC9qw4HQ8Th3d",
+	"NXwWdVv30s/TiFNvkFrjTqwo43WMM14LFR+TafncK2LGrTZ0ZUo0GxvwxvNk/acNMe0mbIeuu6TDamby",
+	"cn40lI5Jje0r72qtNWFmX7gIL31+zXVoaiiC0CtTHmT8qkF1UWmDmk0Ral/bbu1BWHb+8ZLZBgsxF0Xg",
+	"+xLnQqH1G3JaDRTEqAJi4JHpzioooSE0rG4tMVE3EmtUdKN8yhLeGSBkj4KqVYcmWnIVW1j5jcsgKQqM",
+	"x3M0+ryBokJ2lruDrzWST3hF1NjJaPT4+JiDH861uRvFuXb04+XF+w/X70/O8nFeUS17DS++szLMhBS0",
+	"YNO4kfO4kfOPlzzjD2hs8M1pPs7HTpNuUEEj+IS/zcf5W+6qa6o8ikfQiNHDKcimgtNROG9HIQUcw2ib",
+	"oPSfQzURKgnf1HMOSjT2HD35eDiuDdOm3YluAo99r8tFF/rYYIWmkTGOo9+sW7Fr6X4JdAmaXG7mqKvy",
+	"w8XAc453wdl4/JUt2CjbvAVbSRtc59wssGS2LQq0dt5K6SvZ776iQZt944Qtl+oBpCiZ6Rzm1j/9duv/",
+	"u9+W9Yu//XaL/7BqAi8z/rdv6/bQcmah58xC09nJ2bauwcFvA2eOe+HOOpaNELp1wkn4PsX6Zjny5dZh",
+	"cA6V2VybyJB4LLJ9K+UHbaax8GnAQI2Erq799YkLt5SjHZ51PNmVYdsAzXpO3j5wbv/UzLHbjkqkjhd6",
+	"JY9X8jiAPHZQ/RweeQodreUwlfwDiYVPkf5rF4Saf3P5AeqIX0FenECypKbYq/t/YaLE96r/FR1tf50a",
+	"IKRV2F956ZWX9vHSIRSRZKgKQVL1uzPyDhPcc1Fhce/rlSC59dV9+9Y3VMv800/mz4TW1iekVcN7/a8O",
+	"wcjFIR2iBOKC8UxY1unxsX77DCPDd/4NGzufzaC4R1VO3FVaYeFv2HMQ0v8jxZ72/lpTq77WfteaNvMq",
+	"xI0VLgt6KRTDeeuVxpdPqesYM0hG4ANIhqpstFBk1+dDzER3emzO7S+bmhjXX94u/xsAAP//84FXa6Yk",
+	"AAA=",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/observability-tracing-azure-appinsights/internal/appinsights/client.go
+++ b/observability-tracing-azure-appinsights/internal/appinsights/client.go
@@ -122,7 +122,7 @@ func (c *Client) QuerySpans(ctx context.Context, p TracesParams) (*SpansResult, 
 }
 
 // GetSpanDetails looks up one span by trace and span ID.
-func (c *Client) GetSpanDetails(ctx context.Context, traceID, spanID string) (*Span, error) {
+func (c *Client) GetSpanDetails(ctx context.Context, traceID, spanID, namespace, projectUID string) (*Span, error) {
 	ctx, cancel := context.WithTimeout(ctx, c.queryTimeout)
 	defer cancel()
 
@@ -130,7 +130,7 @@ func (c *Client) GetSpanDetails(ctx context.Context, traceID, spanID string) (*S
 	start := end.Add(-spanDetailsLookback)
 
 	resp, err := c.api.QueryWorkspace(ctx, c.workspaceID, azlogs.QueryBody{
-		Query:    to.Ptr(BuildSpanDetailsKQL(traceID, spanID)),
+		Query:    to.Ptr(BuildScopedSpanDetailsKQL(traceID, spanID, namespace, projectUID)),
 		Timespan: to.Ptr(azlogs.NewTimeInterval(start, end)),
 	}, nil)
 	if err != nil {

--- a/observability-tracing-azure-appinsights/internal/appinsights/kql.go
+++ b/observability-tracing-azure-appinsights/internal/appinsights/kql.go
@@ -74,14 +74,20 @@ func BuildSpansKQL(p TracesParams) string {
 	return sb.String()
 }
 
-// BuildSpanDetailsKQL renders the single-span lookup.
-func BuildSpanDetailsKQL(traceID, spanID string) string {
+// BuildScopedSpanDetailsKQL renders the single-span lookup, scoped to the
+// namespace and project UID from the request's searchScope so a span cannot be
+// read from outside the caller's tenancy.
+func BuildScopedSpanDetailsKQL(traceID, spanID, namespace, projectUID string) string {
 	var sb strings.Builder
 	sb.WriteString(unionHead)
 	sb.WriteString("\n| where OperationId == ")
 	sb.WriteString(kqlString(traceID))
 	sb.WriteString("\n| where Id == ")
 	sb.WriteString(kqlString(spanID))
+	writePropertyFilter(&sb, LabelNamespace, namespace)
+	if projectUID != "" {
+		writePropertyFilter(&sb, LabelProjectUID, projectUID)
+	}
 	sb.WriteString(spanProjection(true))
 	sb.WriteString("\n| take 1")
 	return sb.String()

--- a/observability-tracing-azure-appinsights/internal/appinsights/kql_test.go
+++ b/observability-tracing-azure-appinsights/internal/appinsights/kql_test.go
@@ -106,19 +106,32 @@ func TestBuildSpansKQL_IncludeAttributes(t *testing.T) {
 	}
 }
 
-func TestBuildSpanDetailsKQL(t *testing.T) {
-	kql := BuildSpanDetailsKQL("4bf92f3577b34da6", "00f067aa0ba902b7")
+func TestBuildScopedSpanDetailsKQL(t *testing.T) {
+	kql := BuildScopedSpanDetailsKQL("4bf92f3577b34da6", "00f067aa0ba902b7", "spike-ns", "proj-uid-1")
 
 	for _, want := range []string{
 		`| where OperationId == "4bf92f3577b34da6"`,
 		`| where Id == "00f067aa0ba902b7"`,
 		`StatusMessage = tostring(Properties["otel.status_description"])`,
+		`| where tostring(Properties["openchoreo.dev/namespace"]) == "spike-ns"`,
+		`| where tostring(Properties["openchoreo.dev/project-uid"]) == "proj-uid-1"`,
 		`Properties`,
 		`| take 1`,
 	} {
 		if !strings.Contains(kql, want) {
 			t.Errorf("missing %q in:\n%s", want, kql)
 		}
+	}
+}
+
+func TestBuildScopedSpanDetailsKQL_EmptyProject(t *testing.T) {
+	kql := BuildScopedSpanDetailsKQL("4bf92f3577b34da6", "00f067aa0ba902b7", "spike-ns", "")
+
+	if !strings.Contains(kql, `| where tostring(Properties["openchoreo.dev/namespace"]) == "spike-ns"`) {
+		t.Errorf("missing namespace filter in:\n%s", kql)
+	}
+	if strings.Contains(kql, "openchoreo.dev/project-uid") {
+		t.Errorf("unexpected project-uid filter in:\n%s", kql)
 	}
 }
 

--- a/observability-tracing-azure-appinsights/internal/handlers.go
+++ b/observability-tracing-azure-appinsights/internal/handlers.go
@@ -21,7 +21,7 @@ const (
 type tracesClient interface {
 	QueryTraces(ctx context.Context, p appinsights.TracesParams) (*appinsights.TracesResult, error)
 	QuerySpans(ctx context.Context, p appinsights.TracesParams) (*appinsights.SpansResult, error)
-	GetSpanDetails(ctx context.Context, traceID, spanID string) (*appinsights.Span, error)
+	GetSpanDetails(ctx context.Context, traceID, spanID, namespace, projectUID string) (*appinsights.Span, error)
 }
 
 type TracingHandler struct {
@@ -122,32 +122,53 @@ func (h *TracingHandler) QuerySpansForTrace(ctx context.Context, request gen.Que
 	return gen.QuerySpansForTrace200JSONResponse(toSpansListResponse(result, params.IncludeAttributes)), nil
 }
 
-// GetSpanDetailsForTrace implements GET /api/v1alpha1/traces/{traceId}/spans/{spanId}.
-func (h *TracingHandler) GetSpanDetailsForTrace(ctx context.Context, request gen.GetSpanDetailsForTraceRequestObject) (gen.GetSpanDetailsForTraceResponseObject, error) {
+// QuerySpanDetailsForTrace implements POST /api/v1alpha1/traces/{traceId}/spans/{spanId},
+// scoping the lookup to the namespace and project UID from the request body's searchScope.
+func (h *TracingHandler) QuerySpanDetailsForTrace(ctx context.Context, request gen.QuerySpanDetailsForTraceRequestObject) (gen.QuerySpanDetailsForTraceResponseObject, error) {
+	if request.Body == nil {
+		return gen.QuerySpanDetailsForTrace400JSONResponse{
+			Title:  ptr(gen.BadRequest),
+			Detail: ptr("request body is required"),
+		}, nil
+	}
+
+	namespace := strings.TrimSpace(request.Body.SearchScope.Namespace)
+	if namespace == "" {
+		return gen.QuerySpanDetailsForTrace400JSONResponse{
+			Title:  ptr(gen.BadRequest),
+			Detail: ptr("namespace is required"),
+		}, nil
+	}
+
 	if !appinsights.ValidID(request.TraceId) || !appinsights.ValidID(request.SpanId) {
-		return gen.GetSpanDetailsForTrace400JSONResponse{
+		return gen.QuerySpanDetailsForTrace400JSONResponse{
 			Title:  ptr(gen.BadRequest),
 			Detail: ptr("traceId and spanId must be hex strings"),
 		}, nil
 	}
 
-	span, err := h.client.GetSpanDetails(ctx, request.TraceId, request.SpanId)
+	var projectUID string
+	if request.Body.SearchScope.Project != nil {
+		projectUID = strings.TrimSpace(*request.Body.SearchScope.Project)
+	}
+
+	span, err := h.client.GetSpanDetails(ctx, request.TraceId, request.SpanId, namespace, projectUID)
 	if err != nil {
 		h.logger.Error("Failed to query span detail", slog.Any("error", err))
-		return gen.GetSpanDetailsForTrace500JSONResponse{
+		return gen.QuerySpanDetailsForTrace500JSONResponse{
 			Title:  ptr(gen.InternalServerError),
 			Detail: ptr("internal server error"),
 		}, nil
 	}
 	if span == nil {
 		detail := "span not found"
-		return gen.GetSpanDetailsForTrace500JSONResponse{
+		return gen.QuerySpanDetailsForTrace500JSONResponse{
 			Title:  ptr(gen.InternalServerError),
 			Detail: &detail,
 		}, nil
 	}
 
-	return gen.GetSpanDetailsForTrace200JSONResponse(toSpanDetailsResponse(span)), nil
+	return gen.QuerySpanDetailsForTrace200JSONResponse(toSpanDetailsResponse(span)), nil
 }
 
 // toTracesParams converts the generated request body to internal query params.

--- a/observability-tracing-azure-appinsights/internal/handlers_test.go
+++ b/observability-tracing-azure-appinsights/internal/handlers_test.go
@@ -18,7 +18,7 @@ import (
 type mockClient struct {
 	queryTracesFn    func(ctx context.Context, p appinsights.TracesParams) (*appinsights.TracesResult, error)
 	querySpansFn     func(ctx context.Context, p appinsights.TracesParams) (*appinsights.SpansResult, error)
-	getSpanDetailsFn func(ctx context.Context, traceID, spanID string) (*appinsights.Span, error)
+	getSpanDetailsFn func(ctx context.Context, traceID, spanID, namespace, projectUID string) (*appinsights.Span, error)
 }
 
 func (m *mockClient) QueryTraces(ctx context.Context, p appinsights.TracesParams) (*appinsights.TracesResult, error) {
@@ -35,9 +35,9 @@ func (m *mockClient) QuerySpans(ctx context.Context, p appinsights.TracesParams)
 	return &appinsights.SpansResult{}, nil
 }
 
-func (m *mockClient) GetSpanDetails(ctx context.Context, traceID, spanID string) (*appinsights.Span, error) {
+func (m *mockClient) GetSpanDetails(ctx context.Context, traceID, spanID, namespace, projectUID string) (*appinsights.Span, error) {
 	if m.getSpanDetailsFn != nil {
-		return m.getSpanDetailsFn(ctx, traceID, spanID)
+		return m.getSpanDetailsFn(ctx, traceID, spanID, namespace, projectUID)
 	}
 	return nil, nil
 }
@@ -235,37 +235,126 @@ func TestQuerySpansForTrace_Success(t *testing.T) {
 	}
 }
 
-func TestGetSpanDetailsForTrace_RejectsBadIDs(t *testing.T) {
-	h := testHandler(&mockClient{})
-	resp, err := h.GetSpanDetailsForTrace(context.Background(), gen.GetSpanDetailsForTraceRequestObject{
-		TraceId: `" | take 1`,
-		SpanId:  "2419e7552dfbe055",
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if _, ok := resp.(gen.GetSpanDetailsForTrace400JSONResponse); !ok {
-		t.Errorf("got %T, want 400", resp)
+func validSpanDetailsBody() *gen.TraceSpanDetailsRequest {
+	return &gen.TraceSpanDetailsRequest{
+		SearchScope: gen.ComponentSearchScope{
+			Namespace: "spike-ns",
+		},
 	}
 }
 
-func TestGetSpanDetailsForTrace_NotFound(t *testing.T) {
+func TestQuerySpanDetailsForTrace_RequiresBody(t *testing.T) {
 	h := testHandler(&mockClient{})
-	resp, err := h.GetSpanDetailsForTrace(context.Background(), gen.GetSpanDetailsForTraceRequestObject{
+	resp, err := h.QuerySpanDetailsForTrace(context.Background(), gen.QuerySpanDetailsForTraceRequestObject{
 		TraceId: "4372fc01295900a9",
 		SpanId:  "2419e7552dfbe055",
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, ok := resp.(gen.GetSpanDetailsForTrace500JSONResponse); !ok {
+	if _, ok := resp.(gen.QuerySpanDetailsForTrace400JSONResponse); !ok {
+		t.Errorf("got %T, want 400", resp)
+	}
+}
+
+func TestQuerySpanDetailsForTrace_RequiresNamespace(t *testing.T) {
+	h := testHandler(&mockClient{})
+	resp, err := h.QuerySpanDetailsForTrace(context.Background(), gen.QuerySpanDetailsForTraceRequestObject{
+		TraceId: "4372fc01295900a9",
+		SpanId:  "2419e7552dfbe055",
+		Body:    &gen.TraceSpanDetailsRequest{SearchScope: gen.ComponentSearchScope{Namespace: "  "}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := resp.(gen.QuerySpanDetailsForTrace400JSONResponse); !ok {
+		t.Errorf("got %T, want 400", resp)
+	}
+}
+
+func TestQuerySpanDetailsForTrace_RejectsBadIDs(t *testing.T) {
+	h := testHandler(&mockClient{})
+	resp, err := h.QuerySpanDetailsForTrace(context.Background(), gen.QuerySpanDetailsForTraceRequestObject{
+		TraceId: `" | take 1`,
+		SpanId:  "2419e7552dfbe055",
+		Body:    validSpanDetailsBody(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := resp.(gen.QuerySpanDetailsForTrace400JSONResponse); !ok {
+		t.Errorf("got %T, want 400", resp)
+	}
+}
+
+func TestQuerySpanDetailsForTrace_NotFound(t *testing.T) {
+	h := testHandler(&mockClient{})
+	resp, err := h.QuerySpanDetailsForTrace(context.Background(), gen.QuerySpanDetailsForTraceRequestObject{
+		TraceId: "4372fc01295900a9",
+		SpanId:  "2419e7552dfbe055",
+		Body:    validSpanDetailsBody(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := resp.(gen.QuerySpanDetailsForTrace500JSONResponse); !ok {
 		t.Errorf("got %T, want 500 (not found)", resp)
 	}
 }
 
-func TestGetSpanDetailsForTrace_Success(t *testing.T) {
+// The scope from the request body must reach the client, otherwise the span
+// lookup would not be constrained to the caller's tenancy.
+func TestQuerySpanDetailsForTrace_PassesScopeToClient(t *testing.T) {
+	var gotNamespace, gotProjectUID string
 	h := testHandler(&mockClient{
-		getSpanDetailsFn: func(_ context.Context, traceID, spanID string) (*appinsights.Span, error) {
+		getSpanDetailsFn: func(_ context.Context, _, spanID, namespace, projectUID string) (*appinsights.Span, error) {
+			gotNamespace = namespace
+			gotProjectUID = projectUID
+			return &appinsights.Span{SpanID: spanID}, nil
+		},
+	})
+	body := validSpanDetailsBody()
+	body.SearchScope.Project = ptr("proj-uid-1")
+
+	if _, err := h.QuerySpanDetailsForTrace(context.Background(), gen.QuerySpanDetailsForTraceRequestObject{
+		TraceId: "4372fc01295900a9",
+		SpanId:  "2419e7552dfbe055",
+		Body:    body,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if gotNamespace != "spike-ns" {
+		t.Errorf("namespace = %q, want spike-ns", gotNamespace)
+	}
+	if gotProjectUID != "proj-uid-1" {
+		t.Errorf("projectUID = %q, want proj-uid-1", gotProjectUID)
+	}
+}
+
+func TestQuerySpanDetailsForTrace_OmittedProjectIsEmpty(t *testing.T) {
+	gotProjectUID := "sentinel"
+	h := testHandler(&mockClient{
+		getSpanDetailsFn: func(_ context.Context, _, spanID, _, projectUID string) (*appinsights.Span, error) {
+			gotProjectUID = projectUID
+			return &appinsights.Span{SpanID: spanID}, nil
+		},
+	})
+
+	if _, err := h.QuerySpanDetailsForTrace(context.Background(), gen.QuerySpanDetailsForTraceRequestObject{
+		TraceId: "4372fc01295900a9",
+		SpanId:  "2419e7552dfbe055",
+		Body:    validSpanDetailsBody(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if gotProjectUID != "" {
+		t.Errorf("projectUID = %q, want empty", gotProjectUID)
+	}
+}
+
+func TestQuerySpanDetailsForTrace_Success(t *testing.T) {
+	h := testHandler(&mockClient{
+		getSpanDetailsFn: func(_ context.Context, traceID, spanID, namespace, projectUID string) (*appinsights.Span, error) {
 			return &appinsights.Span{
 				SpanID:        spanID,
 				Name:          "lets-go",
@@ -278,14 +367,15 @@ func TestGetSpanDetailsForTrace_Success(t *testing.T) {
 			}, nil
 		},
 	})
-	resp, err := h.GetSpanDetailsForTrace(context.Background(), gen.GetSpanDetailsForTraceRequestObject{
+	resp, err := h.QuerySpanDetailsForTrace(context.Background(), gen.QuerySpanDetailsForTraceRequestObject{
 		TraceId: "4372fc01295900a9",
 		SpanId:  "2419e7552dfbe055",
+		Body:    validSpanDetailsBody(),
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	ok, isOK := resp.(gen.GetSpanDetailsForTrace200JSONResponse)
+	ok, isOK := resp.(gen.QuerySpanDetailsForTrace200JSONResponse)
 	if !isOK {
 		t.Fatalf("got %T, want 200", resp)
 	}


### PR DESCRIPTION
## Purpose

Replace the GET method based REST API used to fetch span details with a POST method based one in the Azure Application Insights tracing module. This is to align with the tracing adapter API spec update in https://github.com/openchoreo/openchoreo/pull/4546, and mirrors the same change made for the OpenSearch adapter in #526 and the GCP Cloud Trace adapter in #535.

The new request body carries `searchScope`, which lets the span details lookup be constrained to the caller's tenancy. Previously the lookup matched on `traceId`/`spanId` alone, so a span could be returned from outside the requested namespace and project.

## Approach

- Regenerated `internal/api/gen` from the updated [tracing adapter API spec](https://github.com/openchoreo/openchoreo/blob/main/openapi/observability-tracing-adapter-api.yaml) via `make openapi-codegen`: `GET` → `POST` on `/api/v1alpha1/traces/{traceId}/spans/{spanId}`, `getSpanDetailsForTrace` → `querySpanDetailsForTrace`, and the new `TraceSpanDetailsRequest` body model.
- **Scoped query**: `BuildSpanDetailsKQL` → `BuildScopedSpanDetailsKQL(traceID, spanID, namespace, projectUID)`, emitting the namespace filter always and the project-uid filter when a project is supplied. Reuses the existing `writePropertyFilter` helper and `openchoreo.dev/*` label constants that the traces/spans queries already filter on, so the scoping is applied server-side by KQL rather than after the fact.
- **Handler**: added 400 responses for a missing request body and a blank namespace, matching the guards the other two endpoints already have. The existing hex validation of `traceId`/`spanId` is retained.
- Unit tests updated and added: the scoped KQL with and without a project UID, the missing-body and blank-namespace guards, and propagation of namespace/project-uid from the request body through to the client.

## Related Issues

N/A

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks

Rebased onto #536 (span status messages), which landed first. That PR anticipated this rebase and it was straightforward: the two changes overlapped only in the span status mapping, where #536's `toSpanStatus(code, message)` is kept as-is. This PR is now limited to the endpoint change with no unrelated regeneration drift, and the span-detail success test asserts the status message propagates through the new POST handler.

The Observer switches to POST for this endpoint, so an adapter still serving GET returns 405 until it is redeployed — worth sequencing the adapter rollout alongside the Observer upgrade.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Span-detail lookups now require a namespace and can be scoped to a specified project.
  * Replaced the span-details GET request with a POST request that accepts namespace details in the request body.
  * Added validation for missing request bodies and namespaces.
  * Standardized span status responses with status codes and optional messages.
* **Bug Fixes**
  * Prevented spans from being retrieved outside the caller’s permitted namespace or project scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->