### PR TITLE
refactor: replace the GET method based span detail fetching API with a POST method based one in GCP Cloud Trace tracing adapter

### DIFF
--- a/observability-tracing-gcp-cloudtrace/internal/api/gen/models.gen.go
+++ b/observability-tracing-gcp-cloudtrace/internal/api/gen/models.gen.go
@@ -63,6 +63,11 @@ type SpanStatus struct {
 // SpanStatusCode The status code of the span. One of "ok", "error", or "unset".
 type SpanStatusCode string
 
+// TraceSpanDetailsRequest defines model for TraceSpanDetailsRequest.
+type TraceSpanDetailsRequest struct {
+	SearchScope ComponentSearchScope `json:"searchScope"`
+}
+
 // TraceSpanDetailsResponse defines model for TraceSpanDetailsResponse.
 type TraceSpanDetailsResponse struct {
 	// Attributes The span attributes as a key/value map
@@ -201,3 +206,6 @@ type QueryTracesJSONRequestBody = TracesQueryRequest
 
 // QuerySpansForTraceJSONRequestBody defines body for QuerySpansForTrace for application/json ContentType.
 type QuerySpansForTraceJSONRequestBody = TracesQueryRequest
+
+// QuerySpanDetailsForTraceJSONRequestBody defines body for QuerySpanDetailsForTrace for application/json ContentType.
+type QuerySpanDetailsForTraceJSONRequestBody = TraceSpanDetailsRequest

--- a/observability-tracing-gcp-cloudtrace/internal/api/gen/server.gen.go
+++ b/observability-tracing-gcp-cloudtrace/internal/api/gen/server.gen.go
@@ -31,8 +31,8 @@ type ServerInterface interface {
 	// (POST /api/v1alpha1/traces/{traceId}/spans/query)
 	QuerySpansForTrace(w http.ResponseWriter, r *http.Request, traceId string)
 	// Get details of a span for a trace
-	// (GET /api/v1alpha1/traces/{traceId}/spans/{spanId})
-	GetSpanDetailsForTrace(w http.ResponseWriter, r *http.Request, traceId string, spanId string)
+	// (POST /api/v1alpha1/traces/{traceId}/spans/{spanId})
+	QuerySpanDetailsForTrace(w http.ResponseWriter, r *http.Request, traceId string, spanId string)
 	// Health check
 	// (GET /healthz)
 	Health(w http.ResponseWriter, r *http.Request)
@@ -86,8 +86,8 @@ func (siw *ServerInterfaceWrapper) QuerySpansForTrace(w http.ResponseWriter, r *
 	handler.ServeHTTP(w, r)
 }
 
-// GetSpanDetailsForTrace operation middleware
-func (siw *ServerInterfaceWrapper) GetSpanDetailsForTrace(w http.ResponseWriter, r *http.Request) {
+// QuerySpanDetailsForTrace operation middleware
+func (siw *ServerInterfaceWrapper) QuerySpanDetailsForTrace(w http.ResponseWriter, r *http.Request) {
 
 	var err error
 
@@ -110,7 +110,7 @@ func (siw *ServerInterfaceWrapper) GetSpanDetailsForTrace(w http.ResponseWriter,
 	}
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.GetSpanDetailsForTrace(w, r, traceId, spanId)
+		siw.Handler.QuerySpanDetailsForTrace(w, r, traceId, spanId)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -256,7 +256,7 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 
 	m.HandleFunc("POST "+options.BaseURL+"/api/v1alpha1/traces/query", wrapper.QueryTraces)
 	m.HandleFunc("POST "+options.BaseURL+"/api/v1alpha1/traces/{traceId}/spans/query", wrapper.QuerySpansForTrace)
-	m.HandleFunc("GET "+options.BaseURL+"/api/v1alpha1/traces/{traceId}/spans/{spanId}", wrapper.GetSpanDetailsForTrace)
+	m.HandleFunc("POST "+options.BaseURL+"/api/v1alpha1/traces/{traceId}/spans/{spanId}", wrapper.QuerySpanDetailsForTrace)
 	m.HandleFunc("GET "+options.BaseURL+"/healthz", wrapper.Health)
 
 	return m
@@ -369,54 +369,55 @@ func (response QuerySpansForTrace500JSONResponse) VisitQuerySpansForTraceRespons
 	return json.NewEncoder(w).Encode(response)
 }
 
-type GetSpanDetailsForTraceRequestObject struct {
+type QuerySpanDetailsForTraceRequestObject struct {
 	TraceId string `json:"traceId"`
 	SpanId  string `json:"spanId"`
+	Body    *QuerySpanDetailsForTraceJSONRequestBody
 }
 
-type GetSpanDetailsForTraceResponseObject interface {
-	VisitGetSpanDetailsForTraceResponse(w http.ResponseWriter) error
+type QuerySpanDetailsForTraceResponseObject interface {
+	VisitQuerySpanDetailsForTraceResponse(w http.ResponseWriter) error
 }
 
-type GetSpanDetailsForTrace200JSONResponse TraceSpanDetailsResponse
+type QuerySpanDetailsForTrace200JSONResponse TraceSpanDetailsResponse
 
-func (response GetSpanDetailsForTrace200JSONResponse) VisitGetSpanDetailsForTraceResponse(w http.ResponseWriter) error {
+func (response QuerySpanDetailsForTrace200JSONResponse) VisitQuerySpanDetailsForTraceResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
 
 	return json.NewEncoder(w).Encode(response)
 }
 
-type GetSpanDetailsForTrace400JSONResponse ErrorResponse
+type QuerySpanDetailsForTrace400JSONResponse ErrorResponse
 
-func (response GetSpanDetailsForTrace400JSONResponse) VisitGetSpanDetailsForTraceResponse(w http.ResponseWriter) error {
+func (response QuerySpanDetailsForTrace400JSONResponse) VisitQuerySpanDetailsForTraceResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(400)
 
 	return json.NewEncoder(w).Encode(response)
 }
 
-type GetSpanDetailsForTrace401JSONResponse ErrorResponse
+type QuerySpanDetailsForTrace401JSONResponse ErrorResponse
 
-func (response GetSpanDetailsForTrace401JSONResponse) VisitGetSpanDetailsForTraceResponse(w http.ResponseWriter) error {
+func (response QuerySpanDetailsForTrace401JSONResponse) VisitQuerySpanDetailsForTraceResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(401)
 
 	return json.NewEncoder(w).Encode(response)
 }
 
-type GetSpanDetailsForTrace403JSONResponse ErrorResponse
+type QuerySpanDetailsForTrace403JSONResponse ErrorResponse
 
-func (response GetSpanDetailsForTrace403JSONResponse) VisitGetSpanDetailsForTraceResponse(w http.ResponseWriter) error {
+func (response QuerySpanDetailsForTrace403JSONResponse) VisitQuerySpanDetailsForTraceResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(403)
 
 	return json.NewEncoder(w).Encode(response)
 }
 
-type GetSpanDetailsForTrace500JSONResponse ErrorResponse
+type QuerySpanDetailsForTrace500JSONResponse ErrorResponse
 
-func (response GetSpanDetailsForTrace500JSONResponse) VisitGetSpanDetailsForTraceResponse(w http.ResponseWriter) error {
+func (response QuerySpanDetailsForTrace500JSONResponse) VisitQuerySpanDetailsForTraceResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(500)
 
@@ -462,8 +463,8 @@ type StrictServerInterface interface {
 	// (POST /api/v1alpha1/traces/{traceId}/spans/query)
 	QuerySpansForTrace(ctx context.Context, request QuerySpansForTraceRequestObject) (QuerySpansForTraceResponseObject, error)
 	// Get details of a span for a trace
-	// (GET /api/v1alpha1/traces/{traceId}/spans/{spanId})
-	GetSpanDetailsForTrace(ctx context.Context, request GetSpanDetailsForTraceRequestObject) (GetSpanDetailsForTraceResponseObject, error)
+	// (POST /api/v1alpha1/traces/{traceId}/spans/{spanId})
+	QuerySpanDetailsForTrace(ctx context.Context, request QuerySpanDetailsForTraceRequestObject) (QuerySpanDetailsForTraceResponseObject, error)
 	// Health check
 	// (GET /healthz)
 	Health(ctx context.Context, request HealthRequestObject) (HealthResponseObject, error)
@@ -562,26 +563,33 @@ func (sh *strictHandler) QuerySpansForTrace(w http.ResponseWriter, r *http.Reque
 	}
 }
 
-// GetSpanDetailsForTrace operation middleware
-func (sh *strictHandler) GetSpanDetailsForTrace(w http.ResponseWriter, r *http.Request, traceId string, spanId string) {
-	var request GetSpanDetailsForTraceRequestObject
+// QuerySpanDetailsForTrace operation middleware
+func (sh *strictHandler) QuerySpanDetailsForTrace(w http.ResponseWriter, r *http.Request, traceId string, spanId string) {
+	var request QuerySpanDetailsForTraceRequestObject
 
 	request.TraceId = traceId
 	request.SpanId = spanId
 
+	var body QuerySpanDetailsForTraceJSONRequestBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		sh.options.RequestErrorHandlerFunc(w, r, fmt.Errorf("can't decode JSON body: %w", err))
+		return
+	}
+	request.Body = &body
+
 	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
-		return sh.ssi.GetSpanDetailsForTrace(ctx, request.(GetSpanDetailsForTraceRequestObject))
+		return sh.ssi.QuerySpanDetailsForTrace(ctx, request.(QuerySpanDetailsForTraceRequestObject))
 	}
 	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "GetSpanDetailsForTrace")
+		handler = middleware(handler, "QuerySpanDetailsForTrace")
 	}
 
 	response, err := handler(r.Context(), w, r, request)
 
 	if err != nil {
 		sh.options.ResponseErrorHandlerFunc(w, r, err)
-	} else if validResponse, ok := response.(GetSpanDetailsForTraceResponseObject); ok {
-		if err := validResponse.VisitGetSpanDetailsForTraceResponse(w); err != nil {
+	} else if validResponse, ok := response.(QuerySpanDetailsForTraceResponseObject); ok {
+		if err := validResponse.VisitQuerySpanDetailsForTraceResponse(w); err != nil {
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
 	} else if response != nil {
@@ -616,36 +624,37 @@ func (sh *strictHandler) Health(w http.ResponseWriter, r *http.Request) {
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+xaUXPbNhL+KxjczeSFlmSndw96c52057k2Tmvd3EPthxW5MlGDAAIs7age/fcbAKRE",
-	"SqAixXEebvxkkVgsFrv7fVgs/cRzXRmtUJHj0yfu8hIrCD8v2oFrBJuX17k26N8bqw1aEhik1tP9Ay29",
-	"CHdkhbrjq4yjehBWq2poXEGFzkCOyVFj9Z+Yp2auMm7xUy0sFnz6R0fNbdaK6nmYu8r4e2u1/R2d0col",
-	"dlAggZDxl8utMCS04lM+K5Ghn8oqdA7ukGccP0NlpFf/q3BOqDvWmsEWAmXh2BtHYGkmKnzDQBXsDaoi",
-	"PPEs4R6v/kIXuG/1XBfIFlZXTM8d2ge0zP8Red+gqx+vT2YnZ2epdUiQxAN3qOrKu3QOxe/4qUZHPOO1",
-	"gppKbcVfWPCML7Sdi6JAxTMuFKFVIK+DZcHVnSB04rUTlmsD6pqAardr2fvPmNf+N3NBgukFoxKZM6Ay",
-	"ttBS6kfvff/uyqCaocQKyS6DBItqWaULlCOe7aTskMObxYLHOyuO2JUKL264vr/hGbuJkfM/tWU3vFYO",
-	"6YaPOv7T97yJb/CfQ0q4JeOt43fMeYcPKL3VJwvI/VbLugJ1YhEKmMu1qZ1JIzZbGpGDlEvmkJhWcske",
-	"S1RxP8JtzB7xgyI0s5CjD9O7ABE3jCEgsmJeU/NUFMJbBPJjR4psjVnK6T5iGwUMHAN2j8vxA8gaWQWG",
-	"J2wragteyQeXDmU73o0jE4opUNphrlXhYiZXQHzq0/ifP2zW8Vl9hzZSWMDvAHpUwUhUvWzpqi2A8MQL",
-	"pFBpwHp2NaAui7T6KBFtv3yX0mHR6drmeP6MALQ6jg+C22P7HqP90L+FGph4L1Sx5c+khg8wFBV/HHxR",
-	"Q0vTg0xg6etD69a89neLCz7lfxtvztlxc8iOOwy4H3/uF+FoGH3etAEYSOHI7yCKZFwQVu4Vv6/4fcXv",
-	"y+O3eQHWwjI8a33/60C+B1MJ7lEx0uxTjXa5Ntv5xK+ElGKT+buJTppgoIwNQ0zV1Ryt90cFlJe+qAja",
-	"M5aDMVgwIHY6mUwS2gfZ6QvM9DU7pqD3xbYc1R+w54xH0f3E2sgMMuuxPBf0vTzRhWUOhkMJLlT2iT38",
-	"t0Qq0TJQyzVHb/ZReh5SzSUjgqpTe861lggq8KDWHSbdpclmuGWdQYGWVJKMc6HreA9NUM46UdaA67pp",
-	"19tH889xHg/SQ9QcfZvm5jB2GLVubW7fTaDPZMNs8JtHcXtv3MHCURkaCOFgfwmVy7rYOkYLXEAtiU8X",
-	"IN3O0dlmLmnWzN4pZZossA2/jdi7qNH5SUFpOpulqAT1LDidTFJHdwWfRVVXnfQLNOLVW6Ta+hOrkQk6",
-	"JhmvhGoek2nZ79XsO72S/R2vQlu6sgXa3gaC8TxZ/2lLTPsJ26Fr78Kwnpm8Ax8NpWNSY6tTtFlrQ5h9",
-	"r+12kFYhvxY69g4UQWxJqQAyfmVQXZTaomYzhCrUtlt7EI6df7xkzmAuFiKPfF/gQih0YUNeq4WcGJVA",
-	"DAIy/VkFBRhCy6raEROVkVihohsVUpbwzgIhexRUrhshjSVXTadodOMzSIocm+O5MfrcQF4iOxv5g6+2",
-	"kk95SWTcdDx+fHwcQRgeaXs3bua68S+XF+8/XL8/ORtNRiVVstNX4jsrw1xIQUs2azZy3mzk/OMlz/gD",
-	"Whd9czqajCZekzaowAg+5W9Hk9Fb7qtrKgOKx2DE+OEUpCnhdBzP23FMAc8w2iUo/bdYTcRKIvTOvIMS",
-	"/TNPTyEenmvjtFl7otvIYz/qYtmGvuljgjGyieP4T+dXbDunXwJdgiZX/Rz1VX68GATOCS44m0y+sQW9",
-	"si1YsJW00XXezQIL5uo8R+cWtZShkv3hGxrUb88mbLlUDyBFwWzrML/+6fdb/z/d7mdY/O33W/ynda91",
-	"lfF/fF+3x84ui61dFnu7Xs7VVQUefj2cee6FO+dZtoHQrRdOwvepqW9W41BuHQbnWJkttG0YEo9Fdmil",
-	"/KTtrCl8DFiokNDXtX88ceGX8rTDs5Yn2zJsG6BZx8nbB87t/zVz7LajEqkThF7J45U8DiCPHVQ/h0ee",
-	"Ykdr5e2/wwST/IzE4ge/8E0JYsnfX73PHD8jdT6BvDh7ZElNTaPuaBp6aSbY/jA0wAVrl79Swisl7KOE",
-	"Q+CZJIcSQVL51yDuL0rM70OpECW3vitvX7iGyoh/hcn8mdDa+nqz7jVvPuZHI5eHNGcSiIvGM+FYqyfE",
-	"+u0zjIxfsns2tj6bQ36Pqpj6W6zCPFxuFyBk+FeBPZ31jaZafav9bjT18yrGjeU+Czop1ITzNihtXj6l",
-	"bkLMIlmBDyAZqsJoocht2LnJRM/d/bndZVMTm/VXt6v/BQAA//+WTBKviCMAAA==",
+	"H4sIAAAAAAAC/+xaX3PjthH/Khi0M/dCU7Iv7YPeHN+l9TQ5X2J1+hD7YUWuTMQgwAOW9ikeffcO/lCi",
+	"JFAnxedrJ+Mni8Risdjd3w+LpZ94oetGK1Rk+eSJ26LCGvzPi27gGsEU1XWhG3TvG6MbNCTQS62muwda",
+	"OBFuyQh1x5cZR/UgjFb10LiCGm0DBSZHG6N/wyI1c5lxg59aYbDkk197am6zTlTP/Nxlxt8bo80vaBut",
+	"bGIHJRIIGX7ZwoiGhFZ8wqcVMnRTWY3Wwh3yjONnqBvp1P8krBXqjnVmsLlAWVr2xhIYmooa3zBQJXuD",
+	"qvRPPEu4x6m/0CXuW73QJbK50TXTM4vmAQ1zf0SxadDV99cn05Ozs9Q6JEjigTtUbe1cOoPyF/zUoiWe",
+	"8VZBS5U24ncsecbn2sxEWaLiGReK0CiQ194y7+peEHrx2gnLdQPqmoBau2vZ+89YtO43s16C6TmjCplt",
+	"QGVsrqXUj8777t1Vg2qKEmsks/ASLKhltS5R5jzbSdkhh8fFvMd7K+bsSvkXN1zf3/CM3YTIuZ/asBve",
+	"Kot0w/Oe//Q9j/H1/rNICbdkvHP8jjnv8AGls/pkDoXbatXWoE4MQgkzuTK1Nyln00UjCpBywSwS00ou",
+	"2GOFKuxH2LXZOT8oQlMDBbowvfMQsV1C7EDIbjLEXw3O+YT/ZbTmllEkllGSVbbx3Nd3e5BhQ+AGIiNm",
+	"LcWnshTOVSA/9qTItJilssGl0loBA8uA3eNi9ACyRVZDwxO2la0Bp+SDTedYN95PMCYUU6C0xUKr0gaI",
+	"1UB84vD19+/W6zi43aEJ3OqJZQDWqmQk6o007qstgfDECaToogHjAtSAuizT6oNEsP3yXUqHQatbU+D5",
+	"MwLQ6Tg+CHaP7XuMdkP/Empg4r1Q5ZY/kxo+wFBU3Dn1RQ3d+TFIUYb+eGjtinD3gbRHzfuJwf4oLA2j",
+	"z5k2AAMpLLkdBJGMC8LavuL3Fb+v+H15/MYXYAws/LPW9z8N5Ls3leAeFSPNPrVoFiuzrUv8Wkgp1pm/",
+	"m+ikCQbqaz/EVFvP0Dh/1EBF5aodrz1jBTQNlgyInY7H44T2QXb6AjP9kR2T1/tiWw7qD9hzxoPofmKN",
+	"MoPMeizPeX0vT3R+mYPhUIH1V47EHv5TIVVoGKjFiqPX+6gcD6l4+wmg6hXFM60lgvI8qHWPSXdpMg53",
+	"rDMo0JFKknEudBsuyAnKWSXKCnB9N+16+2j+Oc7jXnqImoNv09zsxw6j1q3N7buibDLZMBv87FA8eH85",
+	"KkM9IRzsL6EK2ZZbx2iJc2gl8ckcpN05OrvMJc3i7J1SJmaBifyWs3dBo3WTvNJ0NktRC9qw4HQ8Th3d",
+	"NXwWdVv30s/TiFNvkFrjTqwo43WMM14LFR+TafncK2LGrTZ0ZUo0GxvwxvNk/acNMe0mbIeuu6TDamby",
+	"cn40lI5Jje0r72qtNWFmX7gIL31+zXVoaiiC0CtTHmT8qkF1UWmDmk0Ral/bbu1BWHb+8ZLZBgsxF0Xg",
+	"+xLnQqH1G3JaDRTEqAJi4JHpzioooSE0rG4tMVE3EmtUdKN8yhLeGSBkj4KqVYcmWnIVW1j5jcsgKQqM",
+	"x3M0+ryBokJ2lruDrzWST3hF1NjJaPT4+JiDH861uRvFuXb04+XF+w/X70/O8nFeUS17DS++szLMhBS0",
+	"YNO4kfO4kfOPlzzjD2hs8M1pPs7HTpNuUEEj+IS/zcf5W+6qa6o8ikfQiNHDKcimgtNROG9HIQUcw2ib",
+	"oPSfQzURKgnf1HMOSjT2HD35eDiuDdOm3YluAo99r8tFF/rYYIWmkTGOo9+sW7Fr6X4JdAmaXG7mqKvy",
+	"w8XAc453wdl4/JUt2CjbvAVbSRtc59wssGS2LQq0dt5K6SvZ776iQZt944Qtl+oBpCiZ6Rzm1j/9duv/",
+	"u9+W9Yu//XaL/7BqAi8z/rdv6/bQcmah58xC09nJ2bauwcFvA2eOe+HOOpaNELp1wkn4PsX6Zjny5dZh",
+	"cA6V2VybyJB4LLJ9K+UHbaax8GnAQI2Erq799YkLt5SjHZ51PNmVYdsAzXpO3j5wbv/UzLHbjkqkjhd6",
+	"JY9X8jiAPHZQ/RweeQodreUwlfwDiYVPkf5rF4Saf3P5AeqIX0FenECypKbYq/t/YaLE96r/FR1tf50a",
+	"IKRV2F956ZWX9vHSIRSRZKgKQVL1uzPyDhPcc1Fhce/rlSC59dV9+9Y3VMv800/mz4TW1iekVcN7/a8O",
+	"wcjFIR2iBOKC8UxY1unxsX77DCPDd/4NGzufzaC4R1VO3FVaYeFv2HMQ0v8jxZ72/lpTq77WfteaNvMq",
+	"xI0VLgt6KRTDeeuVxpdPqesYM0hG4ANIhqpstFBk1+dDzER3emzO7S+bmhjXX94u/xsAAP//84FXa6Yk",
+	"AAA=",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/observability-tracing-gcp-cloudtrace/internal/cloudtrace/client.go
+++ b/observability-tracing-gcp-cloudtrace/internal/cloudtrace/client.go
@@ -199,9 +199,11 @@ func (c *Client) QuerySpans(ctx context.Context, p TracesParams) (*SpansResult, 
 	return result, nil
 }
 
-// GetSpanDetails looks up one span by trace and span ID. Returns nil when
-// the trace or span does not exist.
-func (c *Client) GetSpanDetails(ctx context.Context, traceID, spanID string) (*Span, error) {
+// GetSpanDetails looks up one span by trace and span ID, scoped to the search
+// scope in p. Returns nil when the trace or span does not exist, or when the
+// trace falls outside the scope. GetTrace carries no filter, so the scope is
+// re-checked against the span labels here, as the spans endpoint does.
+func (c *Client) GetSpanDetails(ctx context.Context, p TracesParams, spanID string) (*Span, error) {
 	ctx, cancel := context.WithTimeout(ctx, c.queryTimeout)
 	defer cancel()
 
@@ -210,11 +212,11 @@ func (c *Client) GetSpanDetails(ctx context.Context, traceID, spanID string) (*S
 		return nil, fmt.Errorf("cloudtrace: invalid span id %q: %w", spanID, err)
 	}
 
-	t, err := c.getTrace(ctx, traceID)
+	t, err := c.getTrace(ctx, p.TraceID)
 	if err != nil {
 		return nil, fmt.Errorf("cloudtrace: GetSpanDetails: %w", err)
 	}
-	if t == nil {
+	if t == nil || !anySpanMatchesScope(t, p) {
 		return nil, nil
 	}
 	for _, s := range t.GetSpans() {

--- a/observability-tracing-gcp-cloudtrace/internal/cloudtrace/client_test.go
+++ b/observability-tracing-gcp-cloudtrace/internal/cloudtrace/client_test.go
@@ -175,13 +175,17 @@ func TestGetSpanDetails(t *testing.T) {
 	c := newClientWithAPI(Config{ProjectID: "p"}, testLogger(), nil,
 		func(ctx context.Context, req *tracepb.GetTraceRequest) (*tracepb.Trace, error) {
 			return &tracepb.Trace{Spans: []*tracepb.TraceSpan{
-				{SpanId: 0xabc, Name: "target", Labels: map[string]string{"http.method": "GET"}},
-				{SpanId: 0xdef, Name: "other"},
+				{SpanId: 0xabc, Name: "target", Labels: map[string]string{
+					LabelNamespace: "default",
+					"http.method":  "GET",
+				}},
+				{SpanId: 0xdef, Name: "other", Labels: scopedLabels()},
 			}}, nil
 		},
 	)
+	params := TracesParams{Namespace: "default", TraceID: "ff"}
 
-	span, err := c.GetSpanDetails(context.Background(), "ff", "0000000000000abc")
+	span, err := c.GetSpanDetails(context.Background(), params, "0000000000000abc")
 	if err != nil {
 		t.Fatalf("GetSpanDetails: %v", err)
 	}
@@ -192,11 +196,52 @@ func TestGetSpanDetails(t *testing.T) {
 		t.Error("details lookup should always include attributes")
 	}
 
-	missing, err := c.GetSpanDetails(context.Background(), "ff", "0000000000000aaa")
+	missing, err := c.GetSpanDetails(context.Background(), params, "0000000000000aaa")
 	if err != nil {
 		t.Fatalf("GetSpanDetails(missing): %v", err)
 	}
 	if missing != nil {
 		t.Errorf("missing span = %+v, want nil", missing)
+	}
+}
+
+func TestGetSpanDetailsEnforcesScope(t *testing.T) {
+	c := newClientWithAPI(Config{ProjectID: "p"}, testLogger(), nil,
+		func(ctx context.Context, req *tracepb.GetTraceRequest) (*tracepb.Trace, error) {
+			return &tracepb.Trace{Spans: []*tracepb.TraceSpan{
+				{SpanId: 0xabc, Name: "target", Labels: map[string]string{LabelNamespace: "other-tenant"}},
+			}}, nil
+		},
+	)
+
+	span, err := c.GetSpanDetails(context.Background(),
+		TracesParams{Namespace: "default", TraceID: "ff"}, "0000000000000abc")
+	if err != nil {
+		t.Fatalf("GetSpanDetails: %v", err)
+	}
+	if span != nil {
+		t.Errorf("out-of-scope span leaked: %+v", span)
+	}
+}
+
+func TestGetSpanDetailsEnforcesProjectScope(t *testing.T) {
+	c := newClientWithAPI(Config{ProjectID: "p"}, testLogger(), nil,
+		func(ctx context.Context, req *tracepb.GetTraceRequest) (*tracepb.Trace, error) {
+			return &tracepb.Trace{Spans: []*tracepb.TraceSpan{
+				{SpanId: 0xabc, Name: "target", Labels: map[string]string{
+					LabelNamespace:  "default",
+					LabelProjectUID: "proj-uid-1",
+				}},
+			}}, nil
+		},
+	)
+
+	span, err := c.GetSpanDetails(context.Background(),
+		TracesParams{Namespace: "default", ProjectUID: "proj-uid-2", TraceID: "ff"}, "0000000000000abc")
+	if err != nil {
+		t.Fatalf("GetSpanDetails: %v", err)
+	}
+	if span != nil {
+		t.Errorf("span from another project leaked: %+v", span)
 	}
 }

--- a/observability-tracing-gcp-cloudtrace/internal/handlers.go
+++ b/observability-tracing-gcp-cloudtrace/internal/handlers.go
@@ -23,7 +23,7 @@ const (
 type tracesClient interface {
 	QueryTraces(ctx context.Context, p cloudtrace.TracesParams) (*cloudtrace.TracesResult, error)
 	QuerySpans(ctx context.Context, p cloudtrace.TracesParams) (*cloudtrace.SpansResult, error)
-	GetSpanDetails(ctx context.Context, traceID, spanID string) (*cloudtrace.Span, error)
+	GetSpanDetails(ctx context.Context, p cloudtrace.TracesParams, spanID string) (*cloudtrace.Span, error)
 }
 
 type TracingHandler struct {
@@ -124,25 +124,41 @@ func (h *TracingHandler) QuerySpansForTrace(ctx context.Context, request gen.Que
 	return gen.QuerySpansForTrace200JSONResponse(toSpansListResponse(result, params.IncludeAttributes)), nil
 }
 
-// GetSpanDetailsForTrace implements GET /api/v1alpha1/traces/{traceId}/spans/{spanId}.
-func (h *TracingHandler) GetSpanDetailsForTrace(ctx context.Context, request gen.GetSpanDetailsForTraceRequestObject) (gen.GetSpanDetailsForTraceResponseObject, error) {
+// QuerySpanDetailsForTrace implements POST /api/v1alpha1/traces/{traceId}/spans/{spanId},
+// scoping the lookup to the search scope in the request body.
+func (h *TracingHandler) QuerySpanDetailsForTrace(ctx context.Context, request gen.QuerySpanDetailsForTraceRequestObject) (gen.QuerySpanDetailsForTraceResponseObject, error) {
+	if request.Body == nil {
+		return gen.QuerySpanDetailsForTrace400JSONResponse{
+			Title:  ptr(gen.BadRequest),
+			Detail: ptr("request body is required"),
+		}, nil
+	}
+	if strings.TrimSpace(request.Body.SearchScope.Namespace) == "" {
+		return gen.QuerySpanDetailsForTrace400JSONResponse{
+			Title:  ptr(gen.BadRequest),
+			Detail: ptr("namespace is required"),
+		}, nil
+	}
 	if !cloudtrace.ValidTraceID(request.TraceId) {
-		return gen.GetSpanDetailsForTrace400JSONResponse{
+		return gen.QuerySpanDetailsForTrace400JSONResponse{
 			Title:  ptr(gen.BadRequest),
 			Detail: ptr("traceId must be a 32-character hex string"),
 		}, nil
 	}
 	if !cloudtrace.ValidSpanID(request.SpanId) {
-		return gen.GetSpanDetailsForTrace400JSONResponse{
+		return gen.QuerySpanDetailsForTrace400JSONResponse{
 			Title:  ptr(gen.BadRequest),
 			Detail: ptr("spanId must be a hex string of at most 16 characters"),
 		}, nil
 	}
 
-	span, err := h.client.GetSpanDetails(ctx, request.TraceId, request.SpanId)
+	params := toSpanDetailsParams(&request.Body.SearchScope)
+	params.TraceID = request.TraceId
+
+	span, err := h.client.GetSpanDetails(ctx, params, request.SpanId)
 	if err != nil {
 		h.logger.Error("Failed to query span detail", slog.Any("error", err))
-		return gen.GetSpanDetailsForTrace500JSONResponse{
+		return gen.QuerySpanDetailsForTrace500JSONResponse{
 			Title:  ptr(gen.InternalServerError),
 			Detail: ptr("internal server error"),
 		}, nil
@@ -155,7 +171,7 @@ func (h *TracingHandler) GetSpanDetailsForTrace(ctx context.Context, request gen
 		return spanNotFoundResponse{}, nil
 	}
 
-	return gen.GetSpanDetailsForTrace200JSONResponse(toSpanDetailsResponse(span)), nil
+	return gen.QuerySpanDetailsForTrace200JSONResponse(toSpanDetailsResponse(span)), nil
 }
 
 // spanNotFoundResponse renders a 404 for a missing span. The generated
@@ -163,7 +179,7 @@ func (h *TracingHandler) GetSpanDetailsForTrace(ctx context.Context, request gen
 // implements the response interface directly.
 type spanNotFoundResponse struct{}
 
-func (spanNotFoundResponse) VisitGetSpanDetailsForTraceResponse(w http.ResponseWriter) error {
+func (spanNotFoundResponse) VisitQuerySpanDetailsForTraceResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusNotFound)
 	return json.NewEncoder(w).Encode(gen.ErrorResponse{
@@ -171,13 +187,36 @@ func (spanNotFoundResponse) VisitGetSpanDetailsForTraceResponse(w http.ResponseW
 	})
 }
 
+// toSpanDetailsParams converts a search scope to internal query params. The
+// span details body carries only the scope, so no time range, limit, or sort
+// order is set: the lookup is by trace and span ID.
+func toSpanDetailsParams(scope *gen.ComponentSearchScope) cloudtrace.TracesParams {
+	var params cloudtrace.TracesParams
+	applySearchScope(&params, scope)
+	return params
+}
+
+// applySearchScope copies the tenancy fields of a search scope onto params.
+func applySearchScope(params *cloudtrace.TracesParams, scope *gen.ComponentSearchScope) {
+	params.Namespace = strings.TrimSpace(scope.Namespace)
+	if scope.Project != nil {
+		params.ProjectUID = strings.TrimSpace(*scope.Project)
+	}
+	if scope.Component != nil {
+		params.ComponentUID = strings.TrimSpace(*scope.Component)
+	}
+	if scope.Environment != nil {
+		params.EnvironmentUID = strings.TrimSpace(*scope.Environment)
+	}
+}
+
 // toTracesParams converts the generated request body to internal query params.
 func toTracesParams(req *gen.TracesQueryRequest) cloudtrace.TracesParams {
 	params := cloudtrace.TracesParams{
 		StartTime: req.StartTime,
 		EndTime:   req.EndTime,
-		Namespace: strings.TrimSpace(req.SearchScope.Namespace),
 	}
+	applySearchScope(&params, &req.SearchScope)
 	if req.Limit != nil {
 		params.Limit = *req.Limit
 	}
@@ -192,15 +231,6 @@ func toTracesParams(req *gen.TracesQueryRequest) cloudtrace.TracesParams {
 	}
 	if params.SortOrder == "" {
 		params.SortOrder = "desc"
-	}
-	if req.SearchScope.Project != nil {
-		params.ProjectUID = strings.TrimSpace(*req.SearchScope.Project)
-	}
-	if req.SearchScope.Component != nil {
-		params.ComponentUID = strings.TrimSpace(*req.SearchScope.Component)
-	}
-	if req.SearchScope.Environment != nil {
-		params.EnvironmentUID = strings.TrimSpace(*req.SearchScope.Environment)
 	}
 	if req.IncludeAttributes != nil {
 		params.IncludeAttributes = *req.IncludeAttributes

--- a/observability-tracing-gcp-cloudtrace/internal/handlers_test.go
+++ b/observability-tracing-gcp-cloudtrace/internal/handlers_test.go
@@ -21,6 +21,7 @@ type fakeClient struct {
 	tracesResult *cloudtrace.TracesResult
 	spansParams  cloudtrace.TracesParams
 	spansResult  *cloudtrace.SpansResult
+	detailParams cloudtrace.TracesParams
 	span         *cloudtrace.Span
 	err          error
 }
@@ -35,7 +36,8 @@ func (f *fakeClient) QuerySpans(_ context.Context, p cloudtrace.TracesParams) (*
 	return f.spansResult, f.err
 }
 
-func (f *fakeClient) GetSpanDetails(_ context.Context, traceID, spanID string) (*cloudtrace.Span, error) {
+func (f *fakeClient) GetSpanDetails(_ context.Context, p cloudtrace.TracesParams, spanID string) (*cloudtrace.Span, error) {
+	f.detailParams = p
 	return f.span, f.err
 }
 
@@ -234,7 +236,15 @@ func TestQuerySpansForTraceRejectsBadTraceID(t *testing.T) {
 	}
 }
 
-func TestGetSpanDetailsForTrace(t *testing.T) {
+func validSpanDetailsBody() *gen.TraceSpanDetailsRequest {
+	return &gen.TraceSpanDetailsRequest{
+		SearchScope: gen.ComponentSearchScope{
+			Namespace: "default",
+		},
+	}
+}
+
+func TestQuerySpanDetailsForTrace(t *testing.T) {
 	client := &fakeClient{
 		span: &cloudtrace.Span{
 			SpanID:        "0000000000000abc",
@@ -246,14 +256,15 @@ func TestGetSpanDetailsForTrace(t *testing.T) {
 	}
 	h := newHandler(client)
 
-	resp, err := h.GetSpanDetailsForTrace(context.Background(), gen.GetSpanDetailsForTraceRequestObject{
+	resp, err := h.QuerySpanDetailsForTrace(context.Background(), gen.QuerySpanDetailsForTraceRequestObject{
 		TraceId: "0123456789abcdef0123456789abcdef",
 		SpanId:  "0000000000000abc",
+		Body:    validSpanDetailsBody(),
 	})
 	if err != nil {
-		t.Fatalf("GetSpanDetailsForTrace: %v", err)
+		t.Fatalf("QuerySpanDetailsForTrace: %v", err)
 	}
-	ok, isOK := resp.(gen.GetSpanDetailsForTrace200JSONResponse)
+	ok, isOK := resp.(gen.QuerySpanDetailsForTrace200JSONResponse)
 	if !isOK {
 		t.Fatalf("resp = %T", resp)
 	}
@@ -268,7 +279,75 @@ func TestGetSpanDetailsForTrace(t *testing.T) {
 	}
 }
 
-func TestGetSpanDetailsForTraceValidation(t *testing.T) {
+// The scope from the request body must reach the client, otherwise the span
+// lookup would not be constrained to the caller's tenancy.
+func TestQuerySpanDetailsForTracePassesScope(t *testing.T) {
+	client := &fakeClient{span: &cloudtrace.Span{SpanID: "0000000000000abc"}}
+	h := newHandler(client)
+
+	body := validSpanDetailsBody()
+	body.SearchScope.Project = ptr("proj-uid-1")
+	body.SearchScope.Component = ptr("comp-uid-1")
+	body.SearchScope.Environment = ptr("env-uid-1")
+
+	if _, err := h.QuerySpanDetailsForTrace(context.Background(), gen.QuerySpanDetailsForTraceRequestObject{
+		TraceId: "0123456789abcdef0123456789abcdef",
+		SpanId:  "0000000000000abc",
+		Body:    body,
+	}); err != nil {
+		t.Fatalf("QuerySpanDetailsForTrace: %v", err)
+	}
+
+	got := client.detailParams
+	if got.Namespace != "default" {
+		t.Errorf("namespace = %q, want default", got.Namespace)
+	}
+	if got.ProjectUID != "proj-uid-1" {
+		t.Errorf("projectUID = %q, want proj-uid-1", got.ProjectUID)
+	}
+	if got.ComponentUID != "comp-uid-1" {
+		t.Errorf("componentUID = %q, want comp-uid-1", got.ComponentUID)
+	}
+	if got.EnvironmentUID != "env-uid-1" {
+		t.Errorf("environmentUID = %q, want env-uid-1", got.EnvironmentUID)
+	}
+	if got.TraceID != "0123456789abcdef0123456789abcdef" {
+		t.Errorf("traceID = %q", got.TraceID)
+	}
+}
+
+func TestQuerySpanDetailsForTraceRequiresBody(t *testing.T) {
+	h := newHandler(&fakeClient{})
+
+	resp, err := h.QuerySpanDetailsForTrace(context.Background(), gen.QuerySpanDetailsForTraceRequestObject{
+		TraceId: "0123456789abcdef0123456789abcdef",
+		SpanId:  "0000000000000abc",
+	})
+	if err != nil {
+		t.Fatalf("QuerySpanDetailsForTrace: %v", err)
+	}
+	if _, ok := resp.(gen.QuerySpanDetailsForTrace400JSONResponse); !ok {
+		t.Errorf("resp = %T, want 400", resp)
+	}
+}
+
+func TestQuerySpanDetailsForTraceRequiresNamespace(t *testing.T) {
+	h := newHandler(&fakeClient{})
+
+	resp, err := h.QuerySpanDetailsForTrace(context.Background(), gen.QuerySpanDetailsForTraceRequestObject{
+		TraceId: "0123456789abcdef0123456789abcdef",
+		SpanId:  "0000000000000abc",
+		Body:    &gen.TraceSpanDetailsRequest{SearchScope: gen.ComponentSearchScope{Namespace: "  "}},
+	})
+	if err != nil {
+		t.Fatalf("QuerySpanDetailsForTrace: %v", err)
+	}
+	if _, ok := resp.(gen.QuerySpanDetailsForTrace400JSONResponse); !ok {
+		t.Errorf("resp = %T, want 400", resp)
+	}
+}
+
+func TestQuerySpanDetailsForTraceValidation(t *testing.T) {
 	h := newHandler(&fakeClient{})
 
 	const validTrace = "0123456789abcdef0123456789abcdef"
@@ -286,34 +365,36 @@ func TestGetSpanDetailsForTraceValidation(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			resp, err := h.GetSpanDetailsForTrace(context.Background(), gen.GetSpanDetailsForTraceRequestObject{
+			resp, err := h.QuerySpanDetailsForTrace(context.Background(), gen.QuerySpanDetailsForTraceRequestObject{
 				TraceId: tt.traceID,
 				SpanId:  tt.spanID,
+				Body:    validSpanDetailsBody(),
 			})
 			if err != nil {
-				t.Fatalf("GetSpanDetailsForTrace: %v", err)
+				t.Fatalf("QuerySpanDetailsForTrace: %v", err)
 			}
-			if _, ok := resp.(gen.GetSpanDetailsForTrace400JSONResponse); !ok {
+			if _, ok := resp.(gen.QuerySpanDetailsForTrace400JSONResponse); !ok {
 				t.Errorf("resp = %T, want 400", resp)
 			}
 		})
 	}
 }
 
-func TestGetSpanDetailsForTraceNotFound(t *testing.T) {
+func TestQuerySpanDetailsForTraceNotFound(t *testing.T) {
 	// fakeClient with no span configured returns (nil, nil): a lookup miss.
 	h := newHandler(&fakeClient{})
 
-	resp, err := h.GetSpanDetailsForTrace(context.Background(), gen.GetSpanDetailsForTraceRequestObject{
+	resp, err := h.QuerySpanDetailsForTrace(context.Background(), gen.QuerySpanDetailsForTraceRequestObject{
 		TraceId: "0123456789abcdef0123456789abcdef",
 		SpanId:  "0000000000000abc",
+		Body:    validSpanDetailsBody(),
 	})
 	if err != nil {
-		t.Fatalf("GetSpanDetailsForTrace: %v", err)
+		t.Fatalf("QuerySpanDetailsForTrace: %v", err)
 	}
 	rec := httptest.NewRecorder()
-	if err := resp.VisitGetSpanDetailsForTraceResponse(rec); err != nil {
-		t.Fatalf("VisitGetSpanDetailsForTraceResponse: %v", err)
+	if err := resp.VisitQuerySpanDetailsForTraceResponse(rec); err != nil {
+		t.Fatalf("VisitQuerySpanDetailsForTraceResponse: %v", err)
 	}
 	if rec.Code != http.StatusNotFound {
 		t.Errorf("status = %d, want %d", rec.Code, http.StatusNotFound)


### PR DESCRIPTION
## Purpose

Replace the GET method based REST API used to fetch span details with a POST method based one in the GCP Cloud Trace tracing module. This is to align with the tracing adapter API spec update in https://github.com/openchoreo/openchoreo/pull/4546, and follows the same change made for the OpenSearch adapter in #526 and the Azure Application Insights adapter in #534.


## Approach

- Regenerated `internal/api/gen` from the updated [tracing adapter API spec](https://github.com/openchoreo/openchoreo/blob/main/openapi/observability-tracing-adapter-api.yaml) via `make openapi-codegen`: `GET` → `POST` on `/api/v1alpha1/traces/{traceId}/spans/{spanId}`, `getSpanDetailsForTrace` → `querySpanDetailsForTrace`, and the new `TraceSpanDetailsRequest` body model.
- **Scoped lookup**: `GetSpanDetails` now takes `TracesParams` instead of a bare trace ID, and gates the result on the existing `anySpanMatchesScope` helper — the same trace-level scope check `QuerySpans` already applies. Cloud Trace v1 `GetTrace` accepts no filter (only a trace ID), so the scope has to be re-checked against span labels in the adapter rather than pushed into the backend query; this reuses the module's established approach for that constraint instead of introducing a second one.
- Unit tests updated and added: scope enforcement in `GetSpanDetails` for both a mismatched namespace and a mismatched project UID, the missing-body and blank-namespace guards, and propagation of all four scope fields from the request body through to the client.

## Related Issues

N/A

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks

Unlike the Azure adapter in #534, this module's generated code was already on the current spec for the structured `SpanStatus` model, so this change is limited to the endpoint itself with no unrelated regeneration drift.

The Observer switches to POST for this endpoint, so an adapter still serving GET returns 405 until it is redeployed — worth sequencing the adapter rollout alongside the Observer upgrade.