### PR TITLE
refactor: replace the GET method based span detail fetching API with a POST method based one in AWS X-Ray tracing adapter

### DIFF
--- a/observability-tracing-aws-xray/internal/api/gen/models.gen.go
+++ b/observability-tracing-aws-xray/internal/api/gen/models.gen.go
@@ -63,6 +63,11 @@ type SpanStatus struct {
 // SpanStatusCode The status code of the span. One of "ok", "error", or "unset".
 type SpanStatusCode string
 
+// TraceSpanDetailsRequest defines model for TraceSpanDetailsRequest.
+type TraceSpanDetailsRequest struct {
+	SearchScope ComponentSearchScope `json:"searchScope"`
+}
+
 // TraceSpanDetailsResponse defines model for TraceSpanDetailsResponse.
 type TraceSpanDetailsResponse struct {
 	// Attributes The span attributes as a key/value map
@@ -201,3 +206,6 @@ type QueryTracesJSONRequestBody = TracesQueryRequest
 
 // QuerySpansForTraceJSONRequestBody defines body for QuerySpansForTrace for application/json ContentType.
 type QuerySpansForTraceJSONRequestBody = TracesQueryRequest
+
+// QuerySpanDetailsForTraceJSONRequestBody defines body for QuerySpanDetailsForTrace for application/json ContentType.
+type QuerySpanDetailsForTraceJSONRequestBody = TraceSpanDetailsRequest

--- a/observability-tracing-aws-xray/internal/api/gen/server.gen.go
+++ b/observability-tracing-aws-xray/internal/api/gen/server.gen.go
@@ -31,8 +31,8 @@ type ServerInterface interface {
 	// (POST /api/v1alpha1/traces/{traceId}/spans/query)
 	QuerySpansForTrace(w http.ResponseWriter, r *http.Request, traceId string)
 	// Get details of a span for a trace
-	// (GET /api/v1alpha1/traces/{traceId}/spans/{spanId})
-	GetSpanDetailsForTrace(w http.ResponseWriter, r *http.Request, traceId string, spanId string)
+	// (POST /api/v1alpha1/traces/{traceId}/spans/{spanId})
+	QuerySpanDetailsForTrace(w http.ResponseWriter, r *http.Request, traceId string, spanId string)
 	// Health check
 	// (GET /healthz)
 	Health(w http.ResponseWriter, r *http.Request)
@@ -86,8 +86,8 @@ func (siw *ServerInterfaceWrapper) QuerySpansForTrace(w http.ResponseWriter, r *
 	handler.ServeHTTP(w, r)
 }
 
-// GetSpanDetailsForTrace operation middleware
-func (siw *ServerInterfaceWrapper) GetSpanDetailsForTrace(w http.ResponseWriter, r *http.Request) {
+// QuerySpanDetailsForTrace operation middleware
+func (siw *ServerInterfaceWrapper) QuerySpanDetailsForTrace(w http.ResponseWriter, r *http.Request) {
 
 	var err error
 
@@ -110,7 +110,7 @@ func (siw *ServerInterfaceWrapper) GetSpanDetailsForTrace(w http.ResponseWriter,
 	}
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.GetSpanDetailsForTrace(w, r, traceId, spanId)
+		siw.Handler.QuerySpanDetailsForTrace(w, r, traceId, spanId)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -256,7 +256,7 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 
 	m.HandleFunc("POST "+options.BaseURL+"/api/v1alpha1/traces/query", wrapper.QueryTraces)
 	m.HandleFunc("POST "+options.BaseURL+"/api/v1alpha1/traces/{traceId}/spans/query", wrapper.QuerySpansForTrace)
-	m.HandleFunc("GET "+options.BaseURL+"/api/v1alpha1/traces/{traceId}/spans/{spanId}", wrapper.GetSpanDetailsForTrace)
+	m.HandleFunc("POST "+options.BaseURL+"/api/v1alpha1/traces/{traceId}/spans/{spanId}", wrapper.QuerySpanDetailsForTrace)
 	m.HandleFunc("GET "+options.BaseURL+"/healthz", wrapper.Health)
 
 	return m
@@ -369,54 +369,55 @@ func (response QuerySpansForTrace500JSONResponse) VisitQuerySpansForTraceRespons
 	return json.NewEncoder(w).Encode(response)
 }
 
-type GetSpanDetailsForTraceRequestObject struct {
+type QuerySpanDetailsForTraceRequestObject struct {
 	TraceId string `json:"traceId"`
 	SpanId  string `json:"spanId"`
+	Body    *QuerySpanDetailsForTraceJSONRequestBody
 }
 
-type GetSpanDetailsForTraceResponseObject interface {
-	VisitGetSpanDetailsForTraceResponse(w http.ResponseWriter) error
+type QuerySpanDetailsForTraceResponseObject interface {
+	VisitQuerySpanDetailsForTraceResponse(w http.ResponseWriter) error
 }
 
-type GetSpanDetailsForTrace200JSONResponse TraceSpanDetailsResponse
+type QuerySpanDetailsForTrace200JSONResponse TraceSpanDetailsResponse
 
-func (response GetSpanDetailsForTrace200JSONResponse) VisitGetSpanDetailsForTraceResponse(w http.ResponseWriter) error {
+func (response QuerySpanDetailsForTrace200JSONResponse) VisitQuerySpanDetailsForTraceResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
 
 	return json.NewEncoder(w).Encode(response)
 }
 
-type GetSpanDetailsForTrace400JSONResponse ErrorResponse
+type QuerySpanDetailsForTrace400JSONResponse ErrorResponse
 
-func (response GetSpanDetailsForTrace400JSONResponse) VisitGetSpanDetailsForTraceResponse(w http.ResponseWriter) error {
+func (response QuerySpanDetailsForTrace400JSONResponse) VisitQuerySpanDetailsForTraceResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(400)
 
 	return json.NewEncoder(w).Encode(response)
 }
 
-type GetSpanDetailsForTrace401JSONResponse ErrorResponse
+type QuerySpanDetailsForTrace401JSONResponse ErrorResponse
 
-func (response GetSpanDetailsForTrace401JSONResponse) VisitGetSpanDetailsForTraceResponse(w http.ResponseWriter) error {
+func (response QuerySpanDetailsForTrace401JSONResponse) VisitQuerySpanDetailsForTraceResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(401)
 
 	return json.NewEncoder(w).Encode(response)
 }
 
-type GetSpanDetailsForTrace403JSONResponse ErrorResponse
+type QuerySpanDetailsForTrace403JSONResponse ErrorResponse
 
-func (response GetSpanDetailsForTrace403JSONResponse) VisitGetSpanDetailsForTraceResponse(w http.ResponseWriter) error {
+func (response QuerySpanDetailsForTrace403JSONResponse) VisitQuerySpanDetailsForTraceResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(403)
 
 	return json.NewEncoder(w).Encode(response)
 }
 
-type GetSpanDetailsForTrace500JSONResponse ErrorResponse
+type QuerySpanDetailsForTrace500JSONResponse ErrorResponse
 
-func (response GetSpanDetailsForTrace500JSONResponse) VisitGetSpanDetailsForTraceResponse(w http.ResponseWriter) error {
+func (response QuerySpanDetailsForTrace500JSONResponse) VisitQuerySpanDetailsForTraceResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(500)
 
@@ -462,8 +463,8 @@ type StrictServerInterface interface {
 	// (POST /api/v1alpha1/traces/{traceId}/spans/query)
 	QuerySpansForTrace(ctx context.Context, request QuerySpansForTraceRequestObject) (QuerySpansForTraceResponseObject, error)
 	// Get details of a span for a trace
-	// (GET /api/v1alpha1/traces/{traceId}/spans/{spanId})
-	GetSpanDetailsForTrace(ctx context.Context, request GetSpanDetailsForTraceRequestObject) (GetSpanDetailsForTraceResponseObject, error)
+	// (POST /api/v1alpha1/traces/{traceId}/spans/{spanId})
+	QuerySpanDetailsForTrace(ctx context.Context, request QuerySpanDetailsForTraceRequestObject) (QuerySpanDetailsForTraceResponseObject, error)
 	// Health check
 	// (GET /healthz)
 	Health(ctx context.Context, request HealthRequestObject) (HealthResponseObject, error)
@@ -562,26 +563,33 @@ func (sh *strictHandler) QuerySpansForTrace(w http.ResponseWriter, r *http.Reque
 	}
 }
 
-// GetSpanDetailsForTrace operation middleware
-func (sh *strictHandler) GetSpanDetailsForTrace(w http.ResponseWriter, r *http.Request, traceId string, spanId string) {
-	var request GetSpanDetailsForTraceRequestObject
+// QuerySpanDetailsForTrace operation middleware
+func (sh *strictHandler) QuerySpanDetailsForTrace(w http.ResponseWriter, r *http.Request, traceId string, spanId string) {
+	var request QuerySpanDetailsForTraceRequestObject
 
 	request.TraceId = traceId
 	request.SpanId = spanId
 
+	var body QuerySpanDetailsForTraceJSONRequestBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		sh.options.RequestErrorHandlerFunc(w, r, fmt.Errorf("can't decode JSON body: %w", err))
+		return
+	}
+	request.Body = &body
+
 	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
-		return sh.ssi.GetSpanDetailsForTrace(ctx, request.(GetSpanDetailsForTraceRequestObject))
+		return sh.ssi.QuerySpanDetailsForTrace(ctx, request.(QuerySpanDetailsForTraceRequestObject))
 	}
 	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "GetSpanDetailsForTrace")
+		handler = middleware(handler, "QuerySpanDetailsForTrace")
 	}
 
 	response, err := handler(r.Context(), w, r, request)
 
 	if err != nil {
 		sh.options.ResponseErrorHandlerFunc(w, r, err)
-	} else if validResponse, ok := response.(GetSpanDetailsForTraceResponseObject); ok {
-		if err := validResponse.VisitGetSpanDetailsForTraceResponse(w); err != nil {
+	} else if validResponse, ok := response.(QuerySpanDetailsForTraceResponseObject); ok {
+		if err := validResponse.VisitQuerySpanDetailsForTraceResponse(w); err != nil {
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
 	} else if response != nil {
@@ -616,36 +624,37 @@ func (sh *strictHandler) Health(w http.ResponseWriter, r *http.Request) {
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+xaUXPbNhL+KxjczeSFlmSndw96c52057k2Tmvd3EPthxW5MlGDAAIs7age/fcbAKRE",
-	"SqAixXEebvxkkVgsFrv7fVgs/cRzXRmtUJHj0yfu8hIrCD8v2oFrBJuX17k26N8bqw1aEhik1tP9Ay29",
-	"CHdkhbrjq4yjehBWq2poXEGFzkCOyVFj9Z+Yp2auMm7xUy0sFnz6R0fNbdaK6nmYu8r4e2u1/R2d0col",
-	"dlAggZDxl8utMCS04lM+K5Ghn8oqdA7ukGccP0NlpFf/q3BOqDvWmsEWAmXh2BtHYGkmKnzDQBXsDaoi",
-	"PPEs4R6v/kIXuG/1XBfIFlZXTM8d2ge0zP8Red+gqx+vT2YnZ2epdUiQxAN3qOrKu3QOxe/4qUZHPOO1",
-	"gppKbcVfWPCML7Sdi6JAxTMuFKFVIK+DZcHVnSB04rUTlmsD6pqAardr2fvPmNf+N3NBgukFoxKZM6Ay",
-	"ttBS6kfvff/uyqCaocQKyS6DBItqWaULlCOe7aTskMObxYLHOyuO2JUKL264vr/hGbuJkfM/tWU3vFYO",
-	"6YaPOv7T97yJb/CfQ0q4JeOt43fMeYcPKL3VJwvI/VbLugJ1YhEKmMu1qZ1JIzZbGpGDlEvmkJhWcske",
-	"S1RxP8JtzB7xgyI0s5CjD9O7ABE3jCEgsmJeU/NUFMJbBPJjR4psjVnK6T5iGwUMHAN2j8vxA8gaWQWG",
-	"J2wragteyQeXDmU73o0jE4opUNphrlXhYiZXQHzq0/ifP2zW8Vl9hzZSWMDvAHpUwUhUvWzpqi2A8MQL",
-	"pFBpwHp2NaAui7T6KBFtv3yX0mHR6drmeP6MALQ6jg+C22P7HqP90L+FGph4L1Sx5c+khg8wFBV/HHxR",
-	"Q0vTg0xg6etD69a89neLCz7lfxtvztlxc8iOOwy4H3/uF+FoGH3etAEYSOHI7yCKZFwQVu4Vv6/4fcXv",
-	"y+O3eQHWwjI8a33/60C+B1MJ7lEx0uxTjXa5Ntv5xK+ElGKT+buJTppgoIwNQ0zV1Ryt90cFlJe+qAja",
-	"M5aDMVgwIHY6mUwS2gfZ6QvM9DU7pqD3xbYc1R+w54xH0f3E2sgMMuuxPBf0vTzRhWUOhkMJLlT2iT38",
-	"t0Qq0TJQyzVHb/ZReh5SzSUjgqpTe861lggq8KDWHSbdpclmuGWdQYGWVJKMc6HreA9NUM46UdaA67pp",
-	"19tH889xHg/SQ9QcfZvm5jB2GLVubW7fTaDPZMNs8JtHcXtv3MHCURkaCOFgfwmVy7rYOkYLXEAtiU8X",
-	"IN3O0dlmLmnWzN4pZZossA2/jdi7qNH5SUFpOpulqAT1LDidTFJHdwWfRVVXnfQLNOLVW6Ta+hOrkQk6",
-	"JhmvhGoek2nZ79XsO72S/R2vQlu6sgXa3gaC8TxZ/2lLTPsJ26Fr78Kwnpm8Ax8NpWNSY6tTtFlrQ5h9",
-	"r+12kFYhvxY69g4UQWxJqQAyfmVQXZTaomYzhCrUtlt7EI6df7xkzmAuFiKPfF/gQih0YUNeq4WcGJVA",
-	"DAIy/VkFBRhCy6raEROVkVihohsVUpbwzgIhexRUrhshjSVXTadodOMzSIocm+O5MfrcQF4iOxv5g6+2",
-	"kk95SWTcdDx+fHwcQRgeaXs3bua68S+XF+8/XL8/ORtNRiVVstNX4jsrw1xIQUs2azZy3mzk/OMlz/gD",
-	"Whd9czqajCZekzaowAg+5W9Hk9Fb7qtrKgOKx2DE+OEUpCnhdBzP23FMAc8w2iUo/bdYTcRKIvTOvIMS",
-	"/TNPTyEenmvjtFl7otvIYz/qYtmGvuljgjGyieP4T+dXbDunXwJdgiZX/Rz1VX68GATOCS44m0y+sQW9",
-	"si1YsJW00XXezQIL5uo8R+cWtZShkv3hGxrUb88mbLlUDyBFwWzrML/+6fdb/z/d7mdY/O33W/ynda91",
-	"lfF/fF+3x84ui61dFnu7Xs7VVQUefj2cee6FO+dZtoHQrRdOwvepqW9W41BuHQbnWJkttG0YEo9Fdmil",
-	"/KTtrCl8DFiokNDXtX88ceGX8rTDs5Yn2zJsG6BZx8nbB87t/zVz7LajEqkThF7J45U8DiCPHVQ/h0ee",
-	"Ykdr5e2/wwST/IzE4ge/8E0JYsnfX73PHD8jdT6BvDh7ZElNTaPuaBp6aSbY/jA0wAVrl79Swisl7KOE",
-	"Q+CZJIcSQVL51yDuL0rM70OpECW3vitvX7iGyoh/hcn8mdDa+nqz7jVvPuZHI5eHNGcSiIvGM+FYqyfE",
-	"+u0zjIxfsns2tj6bQ36Pqpj6W6zCPFxuFyBk+FeBPZ31jaZafav9bjT18yrGjeU+Czop1ITzNihtXj6l",
-	"bkLMIlmBDyAZqsJoocht2LnJRM/d/bndZVMTm/VXt6v/BQAA//+WTBKviCMAAA==",
+	"H4sIAAAAAAAC/+xaX3PjthH/Khi0M/dCU7Iv7YPeHN+l9TQ5X2J1+hD7YUWuTMQgwAOW9ikeffcO/lCi",
+	"JFAnxedrJ+Mni8Risdjd3w+LpZ94oetGK1Rk+eSJ26LCGvzPi27gGsEU1XWhG3TvG6MbNCTQS62muwda",
+	"OBFuyQh1x5cZR/UgjFb10LiCGm0DBSZHG6N/wyI1c5lxg59aYbDkk197am6zTlTP/Nxlxt8bo80vaBut",
+	"bGIHJRIIGX7ZwoiGhFZ8wqcVMnRTWY3Wwh3yjONnqBvp1P8krBXqjnVmsLlAWVr2xhIYmooa3zBQJXuD",
+	"qvRPPEu4x6m/0CXuW73QJbK50TXTM4vmAQ1zf0SxadDV99cn05Ozs9Q6JEjigTtUbe1cOoPyF/zUoiWe",
+	"8VZBS5U24ncsecbn2sxEWaLiGReK0CiQ194y7+peEHrx2gnLdQPqmoBau2vZ+89YtO43s16C6TmjCplt",
+	"QGVsrqXUj8777t1Vg2qKEmsks/ASLKhltS5R5jzbSdkhh8fFvMd7K+bsSvkXN1zf3/CM3YTIuZ/asBve",
+	"Kot0w/Oe//Q9j/H1/rNICbdkvHP8jjnv8AGls/pkDoXbatXWoE4MQgkzuTK1Nyln00UjCpBywSwS00ou",
+	"2GOFKuxH2LXZOT8oQlMDBbowvfMQsV1C7EDIbjLEXw3O+YT/ZbTmllEkllGSVbbx3Nd3e5BhQ+AGIiNm",
+	"LcWnshTOVSA/9qTItJilssGl0loBA8uA3eNi9ACyRVZDwxO2la0Bp+SDTedYN95PMCYUU6C0xUKr0gaI",
+	"1UB84vD19+/W6zi43aEJ3OqJZQDWqmQk6o007qstgfDECaToogHjAtSAuizT6oNEsP3yXUqHQatbU+D5",
+	"MwLQ6Tg+CHaP7XuMdkP/Empg4r1Q5ZY/kxo+wFBU3Dn1RQ3d+TFIUYb+eGjtinD3gbRHzfuJwf4oLA2j",
+	"z5k2AAMpLLkdBJGMC8LavuL3Fb+v+H15/MYXYAws/LPW9z8N5Ls3leAeFSPNPrVoFiuzrUv8Wkgp1pm/",
+	"m+ikCQbqaz/EVFvP0Dh/1EBF5aodrz1jBTQNlgyInY7H44T2QXb6AjP9kR2T1/tiWw7qD9hzxoPofmKN",
+	"MoPMeizPeX0vT3R+mYPhUIH1V47EHv5TIVVoGKjFiqPX+6gcD6l4+wmg6hXFM60lgvI8qHWPSXdpMg53",
+	"rDMo0JFKknEudBsuyAnKWSXKCnB9N+16+2j+Oc7jXnqImoNv09zsxw6j1q3N7buibDLZMBv87FA8eH85",
+	"KkM9IRzsL6EK2ZZbx2iJc2gl8ckcpN05OrvMJc3i7J1SJmaBifyWs3dBo3WTvNJ0NktRC9qw4HQ8Th3d",
+	"NXwWdVv30s/TiFNvkFrjTqwo43WMM14LFR+TafncK2LGrTZ0ZUo0GxvwxvNk/acNMe0mbIeuu6TDamby",
+	"cn40lI5Jje0r72qtNWFmX7gIL31+zXVoaiiC0CtTHmT8qkF1UWmDmk0Ral/bbu1BWHb+8ZLZBgsxF0Xg",
+	"+xLnQqH1G3JaDRTEqAJi4JHpzioooSE0rG4tMVE3EmtUdKN8yhLeGSBkj4KqVYcmWnIVW1j5jcsgKQqM",
+	"x3M0+ryBokJ2lruDrzWST3hF1NjJaPT4+JiDH861uRvFuXb04+XF+w/X70/O8nFeUS17DS++szLMhBS0",
+	"YNO4kfO4kfOPlzzjD2hs8M1pPs7HTpNuUEEj+IS/zcf5W+6qa6o8ikfQiNHDKcimgtNROG9HIQUcw2ib",
+	"oPSfQzURKgnf1HMOSjT2HD35eDiuDdOm3YluAo99r8tFF/rYYIWmkTGOo9+sW7Fr6X4JdAmaXG7mqKvy",
+	"w8XAc453wdl4/JUt2CjbvAVbSRtc59wssGS2LQq0dt5K6SvZ776iQZt944Qtl+oBpCiZ6Rzm1j/9duv/",
+	"u9+W9Yu//XaL/7BqAi8z/rdv6/bQcmah58xC09nJ2bauwcFvA2eOe+HOOpaNELp1wkn4PsX6Zjny5dZh",
+	"cA6V2VybyJB4LLJ9K+UHbaax8GnAQI2Erq799YkLt5SjHZ51PNmVYdsAzXpO3j5wbv/UzLHbjkqkjhd6",
+	"JY9X8jiAPHZQ/RweeQodreUwlfwDiYVPkf5rF4Saf3P5AeqIX0FenECypKbYq/t/YaLE96r/FR1tf50a",
+	"IKRV2F956ZWX9vHSIRSRZKgKQVL1uzPyDhPcc1Fhce/rlSC59dV9+9Y3VMv800/mz4TW1iekVcN7/a8O",
+	"wcjFIR2iBOKC8UxY1unxsX77DCPDd/4NGzufzaC4R1VO3FVaYeFv2HMQ0v8jxZ72/lpTq77WfteaNvMq",
+	"xI0VLgt6KRTDeeuVxpdPqesYM0hG4ANIhqpstFBk1+dDzER3emzO7S+bmhjXX94u/xsAAP//84FXa6Yk",
+	"AAA=",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/observability-tracing-aws-xray/internal/handlers.go
+++ b/observability-tracing-aws-xray/internal/handlers.go
@@ -5,7 +5,9 @@ package app
 
 import (
 	"context"
+	"encoding/json"
 	"log/slog"
+	"net/http"
 	"strings"
 	"time"
 
@@ -103,47 +105,85 @@ func (h *TracingHandler) QuerySpansForTrace(ctx context.Context, request gen.Que
 	return gen.QuerySpansForTrace200JSONResponse(toSpansListResponse(result)), nil
 }
 
-func (h *TracingHandler) GetSpanDetailsForTrace(ctx context.Context, request gen.GetSpanDetailsForTraceRequestObject) (gen.GetSpanDetailsForTraceResponseObject, error) {
+// QuerySpanDetailsForTrace implements POST /api/v1alpha1/traces/{traceId}/spans/{spanId},
+// scoping the lookup to the search scope in the request body.
+func (h *TracingHandler) QuerySpanDetailsForTrace(ctx context.Context, request gen.QuerySpanDetailsForTraceRequestObject) (gen.QuerySpanDetailsForTraceResponseObject, error) {
+	if request.Body == nil {
+		return gen.QuerySpanDetailsForTrace400JSONResponse{
+			Title:  ptr(gen.BadRequest),
+			Detail: ptr("request body is required"),
+		}, nil
+	}
+	if strings.TrimSpace(request.Body.SearchScope.Namespace) == "" {
+		return gen.QuerySpanDetailsForTrace400JSONResponse{
+			Title:  ptr(gen.BadRequest),
+			Detail: ptr("namespace is required"),
+		}, nil
+	}
+
 	params := xray.TracesQueryParams{
 		TraceID: request.TraceId,
 		SpanID:  request.SpanId,
+		Scope:   toScope(&request.Body.SearchScope),
 	}
 
 	result, err := h.client.GetSpanDetail(ctx, params)
 	if err != nil {
 		h.logger.Error("Failed to query span detail", slog.Any("error", err))
-		detail := err.Error()
-		return gen.GetSpanDetailsForTrace500JSONResponse{
+		return gen.QuerySpanDetailsForTrace500JSONResponse{
 			Title:  ptr(gen.InternalServerError),
-			Detail: &detail,
+			Detail: ptr("internal server error"),
 		}, nil
 	}
+	if result == nil {
+		// A missing (or scope-filtered) span is an expected lookup miss, and
+		// reporting it identically either way keeps the response from
+		// revealing traces outside the caller's scope.
+		return spanNotFoundResponse{}, nil
+	}
 
-	return gen.GetSpanDetailsForTrace200JSONResponse(toSpanDetailsResponse(&result.Span)), nil
+	return gen.QuerySpanDetailsForTrace200JSONResponse(toSpanDetailsResponse(&result.Span)), nil
+}
+
+// spanNotFoundResponse renders a 404 for a missing span. The generated server
+// has no 404 type for this endpoint (the spec omits it), so this implements
+// the response interface directly.
+type spanNotFoundResponse struct{}
+
+func (spanNotFoundResponse) VisitQuerySpanDetailsForTraceResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusNotFound)
+	return json.NewEncoder(w).Encode(gen.ErrorResponse{
+		Detail: ptr("span not found"),
+	})
+}
+
+// toScope converts a generated search scope to the internal scope.
+func toScope(scope *gen.ComponentSearchScope) xray.Scope {
+	out := xray.Scope{Namespace: scope.Namespace}
+	if scope.Project != nil {
+		out.ProjectID = *scope.Project
+	}
+	if scope.Component != nil {
+		out.ComponentID = *scope.Component
+	}
+	if scope.Environment != nil {
+		out.EnvironmentID = *scope.Environment
+	}
+	return out
 }
 
 func toTracesQueryParams(req *gen.TracesQueryRequest) xray.TracesQueryParams {
 	params := xray.TracesQueryParams{
 		StartTime: req.StartTime,
 		EndTime:   req.EndTime,
-		Scope: xray.Scope{
-			Namespace: req.SearchScope.Namespace,
-		},
+		Scope:     toScope(&req.SearchScope),
 	}
 	if req.Limit != nil {
 		params.Limit = *req.Limit
 	}
 	if req.SortOrder != nil {
 		params.SortOrder = string(*req.SortOrder)
-	}
-	if req.SearchScope.Project != nil {
-		params.Scope.ProjectID = *req.SearchScope.Project
-	}
-	if req.SearchScope.Component != nil {
-		params.Scope.ComponentID = *req.SearchScope.Component
-	}
-	if req.SearchScope.Environment != nil {
-		params.Scope.EnvironmentID = *req.SearchScope.Environment
 	}
 	if req.IncludeAttributes != nil {
 		params.IncludeAttributes = *req.IncludeAttributes

--- a/observability-tracing-aws-xray/internal/xray/client_test.go
+++ b/observability-tracing-aws-xray/internal/xray/client_test.go
@@ -440,7 +440,11 @@ func TestGetSpanDetail_Found(t *testing.T) {
 		"trace_id": "1-5759e988-bd862e3fe1be46a994272793",
 		"start_time": 1465510988.0,
 		"end_time": 1465510988.5,
-		"annotations": {"key1": "value1"},
+		"annotations": {
+			"key1": "value1",
+			"openchoreo.dev_namespace": "default",
+			"openchoreo.dev_project_uid": "proj-uid-1"
+		},
 		"http": {"request": {"method": "GET"}},
 		"subsegments": [
 			{
@@ -472,9 +476,13 @@ func TestGetSpanDetail_Found(t *testing.T) {
 	result, err := client.GetSpanDetail(context.Background(), TracesQueryParams{
 		TraceID: "5759e988bd862e3fe1be46a994272793",
 		SpanID:  "sub1",
+		Scope:   Scope{Namespace: "default", ProjectID: "proj-uid-1"},
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected a span, got nil")
 	}
 	if result.Span.SpanID != "sub1" {
 		t.Errorf("expected spanID sub1, got %s", result.Span.SpanID)
@@ -506,12 +514,144 @@ func TestGetSpanDetail_NotFound(t *testing.T) {
 	}
 
 	client := NewClientWithAWS(mock, &mockSTSClient{}, testLogger())
-	_, err := client.GetSpanDetail(context.Background(), TracesQueryParams{
+	result, err := client.GetSpanDetail(context.Background(), TracesQueryParams{
 		TraceID: "5759e988bd862e3fe1be46a994272793",
 		SpanID:  "nonexistent",
 	})
-	if err == nil {
-		t.Fatal("expected error for non-existent span")
+	if err != nil {
+		t.Fatalf("a lookup miss should not be an error, got %v", err)
+	}
+	if result != nil {
+		t.Errorf("expected nil for non-existent span, got %+v", result)
+	}
+}
+
+// BatchGetTraces takes no filter expression, so the scope must be enforced
+// against the annotations after the trace is fetched.
+func TestGetSpanDetail_EnforcesScope(t *testing.T) {
+	segDoc := `{
+		"id": "seg1",
+		"name": "GET /api",
+		"start_time": 1465510988.0,
+		"end_time": 1465510988.5,
+		"annotations": {"openchoreo.dev_namespace": "other-tenant"}
+	}`
+
+	mock := &mockXRayClient{
+		batchGetTracesFn: func(ctx context.Context, input *xray.BatchGetTracesInput, opts ...func(*xray.Options)) (*xray.BatchGetTracesOutput, error) {
+			return &xray.BatchGetTracesOutput{
+				Traces: []xraytypes.Trace{
+					{
+						Id: aws.String("1-5759e988-bd862e3fe1be46a994272793"),
+						Segments: []xraytypes.Segment{
+							{Document: aws.String(segDoc)},
+						},
+					},
+				},
+			}, nil
+		},
+	}
+
+	client := NewClientWithAWS(mock, &mockSTSClient{}, testLogger())
+	result, err := client.GetSpanDetail(context.Background(), TracesQueryParams{
+		TraceID: "5759e988bd862e3fe1be46a994272793",
+		SpanID:  "seg1",
+		Scope:   Scope{Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != nil {
+		t.Errorf("out-of-scope span leaked: %+v", result)
+	}
+}
+
+func TestGetSpanDetail_EnforcesProjectScope(t *testing.T) {
+	segDoc := `{
+		"id": "seg1",
+		"name": "GET /api",
+		"start_time": 1465510988.0,
+		"end_time": 1465510988.5,
+		"annotations": {
+			"openchoreo.dev_namespace": "default",
+			"openchoreo.dev_project_uid": "proj-uid-1"
+		}
+	}`
+
+	mock := &mockXRayClient{
+		batchGetTracesFn: func(ctx context.Context, input *xray.BatchGetTracesInput, opts ...func(*xray.Options)) (*xray.BatchGetTracesOutput, error) {
+			return &xray.BatchGetTracesOutput{
+				Traces: []xraytypes.Trace{
+					{
+						Id: aws.String("1-5759e988-bd862e3fe1be46a994272793"),
+						Segments: []xraytypes.Segment{
+							{Document: aws.String(segDoc)},
+						},
+					},
+				},
+			}, nil
+		},
+	}
+
+	client := NewClientWithAWS(mock, &mockSTSClient{}, testLogger())
+	result, err := client.GetSpanDetail(context.Background(), TracesQueryParams{
+		TraceID: "5759e988bd862e3fe1be46a994272793",
+		SpanID:  "seg1",
+		Scope:   Scope{Namespace: "default", ProjectID: "proj-uid-2"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != nil {
+		t.Errorf("span from another project leaked: %+v", result)
+	}
+}
+
+// The collector promotes the annotations onto subsegments too, so a scope
+// match on a subsegment alone must admit the trace.
+func TestGetSpanDetail_MatchesScopeOnSubsegment(t *testing.T) {
+	segDoc := `{
+		"id": "seg1",
+		"name": "GET /api",
+		"start_time": 1465510988.0,
+		"end_time": 1465510988.5,
+		"subsegments": [
+			{
+				"id": "sub1",
+				"name": "DynamoDB",
+				"start_time": 1465510988.1,
+				"end_time": 1465510988.3,
+				"annotations": {"openchoreo.dev_namespace": "default"}
+			}
+		]
+	}`
+
+	mock := &mockXRayClient{
+		batchGetTracesFn: func(ctx context.Context, input *xray.BatchGetTracesInput, opts ...func(*xray.Options)) (*xray.BatchGetTracesOutput, error) {
+			return &xray.BatchGetTracesOutput{
+				Traces: []xraytypes.Trace{
+					{
+						Id: aws.String("1-5759e988-bd862e3fe1be46a994272793"),
+						Segments: []xraytypes.Segment{
+							{Document: aws.String(segDoc)},
+						},
+					},
+				},
+			}, nil
+		},
+	}
+
+	client := NewClientWithAWS(mock, &mockSTSClient{}, testLogger())
+	result, err := client.GetSpanDetail(context.Background(), TracesQueryParams{
+		TraceID: "5759e988bd862e3fe1be46a994272793",
+		SpanID:  "sub1",
+		Scope:   Scope{Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil || result.Span.SpanID != "sub1" {
+		t.Errorf("subsegment-scoped span not returned: %+v", result)
 	}
 }
 

--- a/observability-tracing-aws-xray/internal/xray/queries.go
+++ b/observability-tracing-aws-xray/internal/xray/queries.go
@@ -193,7 +193,10 @@ func (c *Client) GetSpans(ctx context.Context, params TracesQueryParams) (*Spans
 	}, nil
 }
 
-// GetSpanDetail queries X-Ray for a specific span within a trace.
+// GetSpanDetail queries X-Ray for a specific span within a trace, scoped to
+// the search scope in params. Returns nil when the trace or span does not
+// exist, or when the trace falls outside the scope: BatchGetTraces carries no
+// filter expression, so the scope is enforced here against the span annotations.
 func (c *Client) GetSpanDetail(ctx context.Context, params TracesQueryParams) (*SpanDetailResult, error) {
 	xrayTraceID := toXRayTraceID(params.TraceID)
 
@@ -205,13 +208,13 @@ func (c *Client) GetSpanDetail(ctx context.Context, params TracesQueryParams) (*
 		return nil, fmt.Errorf("failed to batch get traces: %w", err)
 	}
 
-	if len(output.Traces) == 0 {
-		return nil, fmt.Errorf("trace not found: traceId=%s", params.TraceID)
+	if len(output.Traces) == 0 || !anySegmentMatchesScope(output.Traces[0], params.Scope) {
+		return nil, nil
 	}
 
-	detail, err := findSpanDetail(output.Traces[0], params.SpanID)
-	if err != nil {
-		return nil, err
+	detail := findSpanDetail(output.Traces[0], params.SpanID)
+	if detail == nil {
+		return nil, nil
 	}
 
 	return &SpanDetailResult{Span: *detail}, nil
@@ -340,26 +343,94 @@ func segmentHasErrors(seg *xraySegment) bool {
 	return false
 }
 
+// OpenChoreo span attributes indexed as X-Ray annotations by the awsxray
+// exporter's indexed_attributes. X-Ray annotation keys preserve dots and
+// convert slashes/hyphens to underscores, so these are the keys that appear
+// both in filter expressions and on a segment document's "annotations" object.
+const (
+	annotationNamespace      = "openchoreo.dev_namespace"
+	annotationComponentUID   = "openchoreo.dev_component_uid"
+	annotationProjectUID     = "openchoreo.dev_project_uid"
+	annotationEnvironmentUID = "openchoreo.dev_environment_uid"
+)
+
 // buildFilterExpression constructs an X-Ray filter expression from the search scope.
-// X-Ray annotation keys preserve dots and convert slashes/hyphens to underscores.
 // Keys containing dots must use annotation[key] filter syntax.
 func buildFilterExpression(scope Scope) string {
 	var parts []string
 
 	if scope.Namespace != "" {
-		parts = append(parts, fmt.Sprintf("annotation[openchoreo.dev_namespace] = %q", scope.Namespace))
+		parts = append(parts, fmt.Sprintf("annotation[%s] = %q", annotationNamespace, scope.Namespace))
 	}
 	if scope.ProjectID != "" {
-		parts = append(parts, fmt.Sprintf("annotation[openchoreo.dev_project_uid] = %q", scope.ProjectID))
+		parts = append(parts, fmt.Sprintf("annotation[%s] = %q", annotationProjectUID, scope.ProjectID))
 	}
 	if scope.ComponentID != "" {
-		parts = append(parts, fmt.Sprintf("annotation[openchoreo.dev_component_uid] = %q", scope.ComponentID))
+		parts = append(parts, fmt.Sprintf("annotation[%s] = %q", annotationComponentUID, scope.ComponentID))
 	}
 	if scope.EnvironmentID != "" {
-		parts = append(parts, fmt.Sprintf("annotation[openchoreo.dev_environment_uid] = %q", scope.EnvironmentID))
+		parts = append(parts, fmt.Sprintf("annotation[%s] = %q", annotationEnvironmentUID, scope.EnvironmentID))
 	}
 
 	return strings.Join(parts, " AND ")
+}
+
+// anySegmentMatchesScope reports whether any segment or subsegment of a trace
+// satisfies the scope. BatchGetTraces accepts only trace IDs and no filter
+// expression, so a scoped lookup has to be re-checked here against the
+// annotations the collector indexed onto each span.
+func anySegmentMatchesScope(trace xraytypes.Trace, scope Scope) bool {
+	for _, segment := range trace.Segments {
+		if segment.Document == nil {
+			continue
+		}
+
+		var seg xraySegment
+		if err := json.Unmarshal([]byte(*segment.Document), &seg); err != nil {
+			continue
+		}
+
+		if segmentTreeMatchesScope(&seg, scope) {
+			return true
+		}
+	}
+	return false
+}
+
+// segmentTreeMatchesScope reports whether a segment or any of its subsegments
+// satisfies the scope. Subsegments carry the annotations too, so a match on any
+// of them proves the trace belongs to the scope.
+func segmentTreeMatchesScope(seg *xraySegment, scope Scope) bool {
+	if matchesScope(seg.Annotations, scope) {
+		return true
+	}
+	for i := range seg.Subsegments {
+		if segmentTreeMatchesScope(&seg.Subsegments[i], scope) {
+			return true
+		}
+	}
+	return false
+}
+
+// matchesScope reports whether a segment's annotations satisfy the search
+// scope. Only the fields set on the scope are compared, so an unset project or
+// component UID does not constrain the match.
+func matchesScope(annotations map[string]interface{}, scope Scope) bool {
+	return annotationEquals(annotations, annotationNamespace, scope.Namespace) &&
+		annotationEquals(annotations, annotationProjectUID, scope.ProjectID) &&
+		annotationEquals(annotations, annotationComponentUID, scope.ComponentID) &&
+		annotationEquals(annotations, annotationEnvironmentUID, scope.EnvironmentID)
+}
+
+// annotationEquals reports whether the annotation matches want. An empty want
+// is treated as "not scoped" and always matches. A non-string annotation value
+// never matches, so a scoped lookup cannot be satisfied by unexpected types.
+func annotationEquals(annotations map[string]interface{}, key, want string) bool {
+	if want == "" {
+		return true
+	}
+	got, ok := annotations[key].(string)
+	return ok && got == want
 }
 
 // toXRayTraceID converts a plain OTLP trace ID (32 hex chars) to the X-Ray format
@@ -662,8 +733,9 @@ func flattenMap(prefix string, m map[string]interface{}) map[string]interface{} 
 	return result
 }
 
-// findSpanDetail locates a specific span by ID in a trace and returns its full detail.
-func findSpanDetail(trace xraytypes.Trace, spanID string) (*SpanDetail, error) {
+// findSpanDetail locates a specific span by ID in a trace and returns its full
+// detail, or nil when the trace holds no span with that ID.
+func findSpanDetail(trace xraytypes.Trace, spanID string) *SpanDetail {
 	traceID := ""
 	if trace.Id != nil {
 		traceID = fromXRayTraceID(*trace.Id)
@@ -680,11 +752,11 @@ func findSpanDetail(trace xraytypes.Trace, spanID string) (*SpanDetail, error) {
 		}
 
 		if detail := findInSegment(&seg, "", traceID, spanID, false); detail != nil {
-			return detail, nil
+			return detail
 		}
 	}
 
-	return nil, fmt.Errorf("span not found: traceId=%s, spanId=%s", traceID, spanID)
+	return nil
 }
 
 // findInSegment recursively searches for a span by ID in a segment tree.

--- a/observability-tracing-aws-xray/internal/xray/queries_test.go
+++ b/observability-tracing-aws-xray/internal/xray/queries_test.go
@@ -44,6 +44,90 @@ func TestBuildFilterExpression_NamespaceOnly(t *testing.T) {
 	}
 }
 
+func TestMatchesScope(t *testing.T) {
+	full := map[string]interface{}{
+		annotationNamespace:      "default",
+		annotationProjectUID:     "proj-1",
+		annotationComponentUID:   "comp-1",
+		annotationEnvironmentUID: "env-1",
+	}
+
+	tests := []struct {
+		name        string
+		annotations map[string]interface{}
+		scope       Scope
+		want        bool
+	}{
+		{
+			name:        "all fields match",
+			annotations: full,
+			scope: Scope{
+				Namespace:     "default",
+				ProjectID:     "proj-1",
+				ComponentID:   "comp-1",
+				EnvironmentID: "env-1",
+			},
+			want: true,
+		},
+		{
+			name:        "namespace only is not over-constrained",
+			annotations: full,
+			scope:       Scope{Namespace: "default"},
+			want:        true,
+		},
+		{
+			name:        "wrong namespace",
+			annotations: full,
+			scope:       Scope{Namespace: "other-tenant"},
+			want:        false,
+		},
+		{
+			name:        "wrong project",
+			annotations: full,
+			scope:       Scope{Namespace: "default", ProjectID: "proj-2"},
+			want:        false,
+		},
+		{
+			name:        "wrong environment",
+			annotations: full,
+			scope:       Scope{Namespace: "default", EnvironmentID: "env-2"},
+			want:        false,
+		},
+		{
+			name:        "missing annotation cannot satisfy a scoped field",
+			annotations: map[string]interface{}{annotationNamespace: "default"},
+			scope:       Scope{Namespace: "default", ProjectID: "proj-1"},
+			want:        false,
+		},
+		{
+			name:        "no annotations at all",
+			annotations: nil,
+			scope:       Scope{Namespace: "default"},
+			want:        false,
+		},
+		{
+			name:        "empty scope matches anything",
+			annotations: nil,
+			scope:       Scope{},
+			want:        true,
+		},
+		{
+			name:        "non-string annotation never matches",
+			annotations: map[string]interface{}{annotationNamespace: 42},
+			scope:       Scope{Namespace: "42"},
+			want:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := matchesScope(tt.annotations, tt.scope); got != tt.want {
+				t.Errorf("matchesScope() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestBuildFilterExpression_Empty(t *testing.T) {
 	scope := Scope{}
 	expr := buildFilterExpression(scope)


### PR DESCRIPTION
## Purpose

Replace the GET method based REST API used to fetch span details with a POST method based one in the AWS X-Ray tracing module. This is to align with the tracing adapter API spec update in https://github.com/openchoreo/openchoreo/pull/4546, and completes the migration across the tracing adapters after OpenSearch (#526), Azure Application Insights (#534), and GCP Cloud Trace (#535).

## Approach

- Regenerated `internal/api/gen` from the updated [tracing adapter API spec](https://github.com/openchoreo/openchoreo/blob/main/openapi/observability-tracing-adapter-api.yaml) via `make openapi-codegen`: `GET` → `POST` on `/api/v1alpha1/traces/{traceId}/spans/{spanId}`, `getSpanDetailsForTrace` → `querySpanDetailsForTrace`, and the new `TraceSpanDetailsRequest` body model.
- **Scoped lookup**: `BatchGetTraces` accepts only trace IDs and no filter expression (unlike `GetTraceSummaries`, which the traces query uses), so the scope cannot be pushed into the backend call. It is enforced in the adapter instead: `GetSpanDetail` now gates on `anySegmentMatchesScope` before returning a span, checking the `openchoreo.dev_*` annotations the collector indexes onto each span. The check walks subsegments as well as top-level segments, since the collector's transform processor promotes the labels onto every span.
- The annotation-key constants and the `matchesScope` matcher live in `queries.go` alongside `buildFilterExpression`, which is their only other consumer. X-Ray converts slashes and hyphens in annotation keys to underscores, so the stored keys are `openchoreo.dev_namespace` and friends; `buildFilterExpression` previously hardcoded these strings inline and now shares the constants, so the filter expression and the post-fetch check cannot drift apart.
- **Lookup misses are no longer errors**: `findSpanDetail` and `GetSpanDetail` return nil instead of a synthesized error, and the handler maps that to a 404 the way the GCP adapter does. An out-of-scope trace and a genuinely missing span are reported identically, so the response does not reveal whether a trace exists in another tenant.
- **Handler**: added 400 responses for a missing request body and a blank namespace, matching the guards the traces and spans endpoints already have. The 500 path no longer echoes the raw backend error string into the response body.
- Factored the search-scope mapping shared by `toTracesQueryParams` and the new span-details path into `toScope`.
- Unit tests added: a table-driven `matchesScope` suite in `queries_test.go` (per-field mismatches, missing annotations, empty scope, non-string annotation values), plus client-level coverage for namespace and project scope enforcement, a scope match found only on a subsegment, and the lookup-miss-is-not-an-error contract.

## Related Issues

N/A

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved trace span lookups to enforce namespace and project scope.
  * Added request validation and clearer handling for missing spans.
  * Missing or out-of-scope spans now return a not-found response.
  * Replaced exposed internal error details with a generic server error message.
* **API Changes**
  * Updated the span-detail query operation name to match the current API definition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->