### PR TITLE
fix: reconcile opensearch ISM policies on setup

### DIFF
--- a/observability-logs-opensearch/init/setup-opensearch.sh
+++ b/observability-logs-opensearch/init/setup-opensearch.sh
@@ -440,6 +440,78 @@ normalize_json() {
     echo "$1" | jq -c -S '.'
 }
 
+reconcile_ism_policy_indices() {
+    local policyName="$1"
+    local indexPattern="$policyName-*"
+    local response
+    local indicesWithPolicies
+    local indexName
+    local currentPolicyName
+    local operation
+    local requestBody
+    local -a curlArgs=(
+        --location
+        --header "Authorization: Basic $authnToken"
+        --insecure
+        --silent
+        --show-error
+        --fail-with-body
+    )
+
+    requestBody=$(jq --null-input --compact-output --arg policyId "$policyName" '{policy_id: $policyId}')
+    if ! response=$(curl "${curlArgs[@]}" "$openSearchHost/_cat/indices/$indexPattern?format=json&h=index"); then
+        echo "Failed to list indices matching $indexPattern: $response"
+        exit 1
+    fi
+
+    if [ "$(echo "$response" | jq 'length')" -eq 0 ]; then
+        return
+    fi
+
+    if ! response=$(curl "${curlArgs[@]}" "$openSearchHost/_plugins/_ism/explain/$indexPattern"); then
+        echo "Failed to inspect ISM policies for indices matching $indexPattern: $response"
+        exit 1
+    fi
+
+    indicesWithPolicies=$(echo "$response" | jq --raw-output '
+        to_entries[] |
+        select(.key != "total_managed_indices") |
+        [.key, (.value["index.plugins.index_state_management.policy_id"] // .value.policy_id // "")] |
+        @tsv
+    ')
+
+    while IFS=$'\t' read -r indexName currentPolicyName; do
+        if [ -z "$indexName" ]; then
+            continue
+        fi
+
+        if [ -z "$currentPolicyName" ]; then
+            operation="add"
+        elif [ "$currentPolicyName" = "$policyName" ]; then
+            operation="change_policy"
+        else
+            echo "Index $indexName uses ISM policy $currentPolicyName. Leaving it unchanged."
+            continue
+        fi
+
+        if ! response=$(curl "${curlArgs[@]}" \
+                             --request POST \
+                             --header "Content-Type: application/json" \
+                             --data "$requestBody" \
+                             "$openSearchHost/_plugins/_ism/$operation/$indexName"); then
+            echo "ISM $operation failed for index $indexName: $response"
+            exit 1
+        fi
+
+        if ! echo "$response" | jq --exit-status '.failures == false' >/dev/null; then
+            echo "ISM $operation failed for index $indexName: $response"
+            exit 1
+        fi
+
+        echo "ISM $operation succeeded for index $indexName."
+    done <<< "$indicesWithPolicies"
+}
+
 # Create or update ISM policies through a loop
 for ((i=0; i<${#ismPolicies[@]}; i+=2)); do
     ismPolicyName="${ismPolicies[i]}"
@@ -536,6 +608,8 @@ for ((i=0; i<${#ismPolicies[@]}; i+=2)); do
         echo "Response: $responseBody"
         exit 1
     fi
+
+    reconcile_ism_policy_indices "$ismPolicyName"
 
     echo ""
 done


### PR DESCRIPTION
## Purpose

Updating an ISM policy does not update the policy already attached to existing indices. Matching indices can also remain unmanaged if they predate the policy, so retention changes may not take effect for existing logs.

## Approach

After creating or updating each policy, reconcile its matching indices:

- Attach the policy to unmanaged indices.
- Update indices already using the module's policy.
- Leave indices with a different policy unchanged.

## Related Issues

Fixes openchoreo/openchoreo#3273

## Checklist

- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks

No automated test was added. I verified the setup hook against OpenSearch 3.3.0 on k3d. It completed without retries and queued the current policies for the existing container log and Kubernetes event indices.

Existing matching indices older than the configured retention may be deleted after upgrade once ISM runs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved index lifecycle policy alignment after policies are created or updated.
  - Matching indices without an assigned policy are now assigned the appropriate policy automatically.
  - Indices already assigned to a different policy remain unchanged.
  - Setup now checks policy assignments and reports failures encountered while applying changes.
  - Setup stops with an error when policy checks or operations fail, helping prevent incomplete configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->